### PR TITLE
Support optional "to" suffix in substring phrase

### DIFF
--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -1332,6 +1332,8 @@ INTRINSICS.String.prototype.match
 INTRINSICS.String.prototype.matchAll
 INTRINSICS.String.prototype.padEnd
 INTRINSICS.String.prototype.padStart
+INTRINSICS.String.prototype.replace
+INTRINSICS.String.prototype.replaceAll
 INTRINSICS.String.prototype.search
 INTRINSICS.String.prototype.slice
 INTRINSICS.String.prototype.startsWith

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -5,11 +5,11 @@
     - numeric string: 16
     - syntactic: 195
   - extended productions for web: 28
-- algorithms: 2623 (85.63%)
-  - complete: 2246
-  - incomplete: 377
-- algorithm steps: 19061 (95.96%)
-  - complete: 18290
-  - incomplete: 771
+- algorithms: 2623 (85.70%)
+  - complete: 2248
+  - incomplete: 375
+- algorithm steps: 19061 (95.99%)
+  - complete: 18296
+  - incomplete: 765
 - tables: 89
 - type model: 58

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -427,14 +427,19 @@ case class AbsTransfer(sem: AbsSemantics) {
           v <- transfer(elem)
           st <- get
         } yield st.contains(l, v, field)
-      case ESubstring(expr, from, to) => to match {
-        case Some(to) => for {
-          v <- transfer(expr)
-          f <- transfer(from)
-          t <- transfer(to)
-        } yield v.substring(f, t)
-        case None => throw NotSupported("ESubstring with no to is not supported expression") // TODO
-      }
+      case ESubstring(expr, from, to) =>
+        to match {
+          case Some(to) =>
+            for {
+              v <- transfer(expr)
+              f <- transfer(from)
+              t <- transfer(to)
+            } yield v.substring(f, t)
+          case None =>
+            throw NotSupported(
+              "ESubstring with no to is not supported expression",
+            ) // TODO
+        }
       case ERef(ref) =>
         for {
           rv <- transfer(ref)

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -427,12 +427,14 @@ case class AbsTransfer(sem: AbsSemantics) {
           v <- transfer(elem)
           st <- get
         } yield st.contains(l, v, field)
-      case ESubstring(expr, from, to) =>
-        for {
+      case ESubstring(expr, from, to) => to match {
+        case Some(to) => for {
           v <- transfer(expr)
           f <- transfer(from)
           t <- transfer(to)
         } yield v.substring(f, t)
+        case None => throw NotSupported("ESubstring with no to is not supported expression") // TODO
+      }
       case ERef(ref) =>
         for {
           rv <- transfer(ref)

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -435,7 +435,7 @@ case class AbsTransfer(sem: AbsSemantics) {
             throw NotSupported(
               "ESubstring with no to is not supported expression", // TODO
             ),
-          )(transfer(_))
+          )(transfer)
         } yield v.substring(f, t)
       case ERef(ref) =>
         for {

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -428,18 +428,15 @@ case class AbsTransfer(sem: AbsSemantics) {
           st <- get
         } yield st.contains(l, v, field)
       case ESubstring(expr, from, to) =>
-        to match {
-          case Some(to) =>
-            for {
-              v <- transfer(expr)
-              f <- transfer(from)
-              t <- transfer(to)
-            } yield v.substring(f, t)
-          case None =>
+        for {
+          v <- transfer(expr)
+          f <- transfer(from)
+          t <- to.fold(
             throw NotSupported(
-              "ESubstring with no to is not supported expression",
-            ) // TODO
-        }
+              "ESubstring with no to is not supported expression", // TODO
+            ),
+          )(transfer(_))
+        } yield v.substring(f, t)
       case ERef(ref) =>
         for {
           rv <- transfer(ref)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -445,7 +445,7 @@ class Compiler(
           compile(fb, from),
           to match {
             case Some(to) => Some(compile(fb, to))
-            case None => None
+            case None     => None
           },
         )
       case NumberOfExpression(ReferenceExpression(ref)) =>

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -443,7 +443,10 @@ class Compiler(
         ESubstring(
           compile(fb, expr),
           compile(fb, from),
-          compile(fb, to),
+          to match {
+            case Some(to) => Some(compile(fb, to))
+            case None => None
+          },
         )
       case NumberOfExpression(ReferenceExpression(ref)) =>
         toStrERef(compile(fb, ref), "length")

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -443,10 +443,7 @@ class Compiler(
         ESubstring(
           compile(fb, expr),
           compile(fb, from),
-          to match {
-            case Some(to) => Some(compile(fb, to))
-            case None     => None
-          },
+          to.map(compile(fb, _)),
         )
       case NumberOfExpression(ReferenceExpression(ref)) =>
         toStrERef(compile(fb, ref), "length")

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -240,9 +240,13 @@ class Interpreter(
     case ESubstring(expr, from, to) =>
       val s = eval(expr).asStr
       val f = eval(from).asInt
-      eval(to) match
-        case Math(n) if s.length < n => Str(s.substring(f))
-        case v                       => Str(s.substring(f, v.asInt))
+      to match {
+        case None => Str(s.substring(f))
+        case Some(to) => eval(to) match {
+          case Math(n) if s.length < n => Str(s.substring(f))
+          case v                       => Str(s.substring(f, v.asInt))
+        }
+      }
     case ERef(ref) =>
       st(eval(ref))
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -242,10 +242,11 @@ class Interpreter(
       val f = eval(from).asInt
       to match {
         case None => Str(s.substring(f))
-        case Some(to) => eval(to) match {
-          case Math(n) if s.length < n => Str(s.substring(f))
-          case v                       => Str(s.substring(f, v.asInt))
-        }
+        case Some(to) =>
+          eval(to) match {
+            case Math(n) if s.length < n => Str(s.substring(f))
+            case v                       => Str(s.substring(f, v.asInt))
+          }
       }
     case ERef(ref) =>
       st(eval(ref))

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -240,10 +240,10 @@ class Interpreter(
     case ESubstring(expr, from, to) =>
       val s = eval(expr).asStr
       val f = eval(from).asInt
-      to.fold(Str(s.substring(f)))(eval(_) match {
-        case Math(n) if s.length < n => Str(s.substring(f))
-        case v                       => Str(s.substring(f, v.asInt))
-      })
+      Str(to.fold(s.substring(f))(eval(_) match
+        case Math(n) if s.length < n => s.substring(f)
+        case v                       => s.substring(f, v.asInt),
+      ))
     case ERef(ref) =>
       st(eval(ref))
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -240,14 +240,10 @@ class Interpreter(
     case ESubstring(expr, from, to) =>
       val s = eval(expr).asStr
       val f = eval(from).asInt
-      to match {
-        case None => Str(s.substring(f))
-        case Some(to) =>
-          eval(to) match {
-            case Math(n) if s.length < n => Str(s.substring(f))
-            case v                       => Str(s.substring(f, v.asInt))
-          }
-      }
+      to.fold(Str(s.substring(f)))(eval(_) match {
+        case Math(n) if s.length < n => Str(s.substring(f))
+        case v                       => Str(s.substring(f, v.asInt))
+      })
     case ERef(ref) =>
       st(eval(ref))
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/ir/Expr.scala
+++ b/src/main/scala/esmeta/ir/Expr.scala
@@ -16,7 +16,7 @@ case class ESourceText(expr: Expr) extends Expr
 case class EYet(msg: String) extends Expr
 case class EContains(list: Expr, expr: Expr, field: Option[(Type, String)])
   extends Expr
-case class ESubstring(expr: Expr, from: Expr, to: Expr) extends Expr
+case class ESubstring(expr: Expr, from: Expr, to: Option[Expr]) extends Expr
 case class ERef(ref: Ref) extends Expr
 case class EUnary(uop: UOp, expr: Expr) extends Expr
 case class EBinary(bop: BOp, left: Expr, right: Expr) extends Expr

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -120,7 +120,7 @@ trait Parsers extends BasicParsers {
       ":" ~> pair(ty ~ word),
     ) <~ ")" ^^ {
       case l ~ e ~ f => EContains(l, e, f)
-    } | "(" ~ "substring" ~> expr ~ expr ~ expr <~ ")" ^^ {
+    } | "(" ~ "substring" ~> expr ~ expr ~ opt(expr) <~ ")" ^^ {
       case e ~ f ~ t => ESubstring(e, f, t)
     } | "(" ~> uop ~ expr <~ ")" ^^ {
       case u ~ e => EUnary(u, e)

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -131,8 +131,10 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "(contains " >> list >> " " >> elem
         field.map { case (t, f) => app >> ": " >> t >> " " >> f }
         app >> ")"
-      case ESubstring(expr, from, to) =>
-        app >> "(substring " >> expr >> " " >> from >> " " >> to >> ")"
+      case ESubstring(expr, from, to) => to match {
+        case Some(to) => app >> "(substring " >> expr >> " " >> from >> " " >> to >> ")"
+        case None => app >> "(substring " >> expr >> " " >> from >> ")"
+      }
       case ERef(ref) =>
         app >> ref
       case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -131,10 +131,13 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "(contains " >> list >> " " >> elem
         field.map { case (t, f) => app >> ": " >> t >> " " >> f }
         app >> ")"
-      case ESubstring(expr, from, to) => to match {
-        case Some(to) => app >> "(substring " >> expr >> " " >> from >> " " >> to >> ")"
-        case None => app >> "(substring " >> expr >> " " >> from >> ")"
-      }
+      case ESubstring(expr, from, to) =>
+        app >> "(substring " >> expr >> " " >> from
+        to match {
+          case Some(to) => app >> " " >> to
+          case None     => app
+        }
+        app >> ")"
       case ERef(ref) =>
         app >> ref
       case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -133,10 +133,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> ")"
       case ESubstring(expr, from, to) =>
         app >> "(substring " >> expr >> " " >> from
-        to match {
-          case Some(to) => app >> " " >> to
-          case None     => app
-        }
+        to.map(app >> " " >> _)
         app >> ")"
       case ERef(ref) =>
         app >> ref

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -79,7 +79,8 @@ trait UnitWalker extends BasicUnitWalker {
       walk(list); walk(elem)
       walkOpt(field, { case (t, f) => walk(t) })
     case ESubstring(expr, from, to) =>
-      walk(expr); walk(from); walk(to)
+      walk(expr); walk(from)
+      walkOpt(to, walk)
     case ERef(ref) =>
       walk(ref)
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -79,8 +79,7 @@ trait UnitWalker extends BasicUnitWalker {
       walk(list); walk(elem)
       walkOpt(field, { case (t, f) => walk(t) })
     case ESubstring(expr, from, to) =>
-      walk(expr); walk(from)
-      walkOpt(to, walk)
+      walk(expr); walk(from); walkOpt(to, walk)
     case ERef(ref) =>
       walk(ref)
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -91,7 +91,7 @@ trait Walker extends BasicWalker {
         walkOpt(field, { case (t, f) => (walk(t), f) }),
       )
     case ESubstring(expr, from, to) =>
-      ESubstring(walk(expr), walk(from), walk(to))
+      ESubstring(walk(expr), walk(from), walkOpt(to, walk))
     case ERef(ref) =>
       ERef(walk(ref))
     case EUnary(uop, expr) =>

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -26,7 +26,7 @@ case class LengthExpression(expr: Expression) extends Expression with Diverged
 case class SubstringExpression(
   expr: Expression,
   from: Expression,
-  to: Expression,
+  to: Option[Expression],
 ) extends Expression
 
 // `the number of elements in <list>` expressions

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -334,7 +334,7 @@ trait Parsers extends IndentParsers {
   lazy val substrExpr: PL[SubstringExpression] =
     ("the substring of" ~> expr) ~
     ("from" ~> expr) ~
-    ("to" ~> expr) ^^ { case e ~ f ~ t => SubstringExpression(e, f, t) }
+    opt("to" ~> expr) ^^ { case e ~ f ~ t => SubstringExpression(e, f, t) }
 
   // `the number of elements in` expressions
   lazy val numberOfExpr: PL[NumberOfExpression] =

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -198,8 +198,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "the length of " >> expr
       case SubstringExpression(expr, from, to) =>
         app >> "the substring of " >> expr >> " from " >> from
-        to.map(app >> " to " >> _)
-        app
+        to.fold(app)(app >> " to " >> _)
       case NumberOfExpression(expr) =>
         app >> "the number of elements in " >> expr
       case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -196,10 +196,11 @@ class Stringifier(detail: Boolean, location: Boolean) {
         else app >> fields
       case LengthExpression(expr) =>
         app >> "the length of " >> expr
-      case SubstringExpression(expr, from, to) => to match {
-        case Some(to) => app >> "the substring of " >> expr >> " from " >> from >> " to " >> to
-        case None => app >> "the substring of " >> expr >> " from " >> from
-      }
+      case SubstringExpression(expr, from, to) =>
+        app >> "the substring of " >> expr >> " from " >> from
+        to match
+          case Some(to) => app >> " to " >> to
+          case None     => app
       case NumberOfExpression(expr) =>
         app >> "the number of elements in " >> expr
       case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -198,9 +198,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "the length of " >> expr
       case SubstringExpression(expr, from, to) =>
         app >> "the substring of " >> expr >> " from " >> from
-        to match
-          case Some(to) => app >> " to " >> to
-          case None     => app
+        to.map(app >> " to " >> _)
+        app
       case NumberOfExpression(expr) =>
         app >> "the number of elements in " >> expr
       case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -196,8 +196,10 @@ class Stringifier(detail: Boolean, location: Boolean) {
         else app >> fields
       case LengthExpression(expr) =>
         app >> "the length of " >> expr
-      case SubstringExpression(expr, from, to) =>
-        app >> "the substring of " >> expr >> " from " >> from >> " to " >> to
+      case SubstringExpression(expr, from, to) => to match {
+        case Some(to) => app >> "the substring of " >> expr >> " from " >> from >> " to " >> to
+        case None => app >> "the substring of " >> expr >> " from " >> from
+      }
       case NumberOfExpression(expr) =>
         app >> "the number of elements in " >> expr
       case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -89,8 +89,7 @@ trait UnitWalker extends BasicUnitWalker {
     case LengthExpression(expr) =>
       walk(expr)
     case SubstringExpression(expr, from, to) =>
-      walk(expr); walk(from)
-      walkOpt(to, walk)
+      walk(expr); walk(from); walkOpt(to, walk)
     case NumberOfExpression(expr) =>
       walk(expr)
     case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -89,7 +89,8 @@ trait UnitWalker extends BasicUnitWalker {
     case LengthExpression(expr) =>
       walk(expr)
     case SubstringExpression(expr, from, to) =>
-      walk(expr); walk(from); walk(to)
+      walk(expr); walk(from)
+      walkOpt(to, walk)
     case NumberOfExpression(expr) =>
       walk(expr)
     case SourceTextExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -118,7 +118,7 @@ trait Walker extends BasicWalker {
     case LengthExpression(expr) =>
       LengthExpression(walk(expr))
     case SubstringExpression(expr, from, to) =>
-      SubstringExpression(walk(expr), walk(from), walk(to))
+      SubstringExpression(walk(expr), walk(from), walkOpt(to, walk))
     case NumberOfExpression(expr) =>
       NumberOfExpression(walk(expr))
     case SourceTextExpression(expr) =>

--- a/src/test/scala/esmeta/ir/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/ir/StringifyTinyTest.scala
@@ -145,6 +145,8 @@ class StringifyTinyTest extends IRTest {
     lazy val yet = EYet("NOT YET")
     lazy val contains = EContains(xExpr, xExpr, None)
     lazy val containsField = EContains(xExpr, xExpr, Some(Type("T"), "Value"))
+    lazy val substring = ESubstring(xExpr, xExpr, None)
+    lazy val substringTo = ESubstring(xExpr, xExpr, Some(xExpr))
     lazy val xExpr = ERef(x)
     lazy val yExpr = ERef(y)
     lazy val unary = EUnary(UOp.Neg, xExpr)
@@ -206,6 +208,8 @@ class StringifyTinyTest extends IRTest {
       yet -> "(yet \"NOT YET\")",
       contains -> "(contains x x)",
       containsField -> "(contains x x: T Value)",
+      substring -> "(substring x x)",
+      substringTo -> "(substring x x x)",
       xExpr -> "x",
       unary -> "(- x)",
       binary -> "(+ x x)",

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -193,7 +193,8 @@ class StringifyTinyTest extends LangTest {
     lazy val recordExpr =
       RecordExpression(ty, List(fieldLit -> refExpr))
     lazy val lengthExpr = LengthExpression(refExpr)
-    lazy val substrExpr = SubstringExpression(refExpr, refExpr, refExpr)
+    lazy val substrExpr = SubstringExpression(refExpr, refExpr, None)
+    lazy val substrExprTo = SubstringExpression(refExpr, refExpr, Some(refExpr))
     lazy val numberOfExpr = NumberOfExpression(refExpr)
     lazy val sourceTextExpr = SourceTextExpression(nt)
     lazy val coveredByExpr = CoveredByExpression(nt, nt)
@@ -261,7 +262,8 @@ class StringifyTinyTest extends LangTest {
       recordEmptyExpr -> "Object { }",
       recordExpr -> "Object { [[Value]]: _x_ }",
       lengthExpr -> "the length of _x_",
-      substrExpr -> "the substring of _x_ from _x_ to _x_",
+      substrExpr -> "the substring of _x_ from _x_",
+      substrExprTo -> "the substring of _x_ from _x_ to _x_",
       numberOfExpr -> "the number of elements in _x_",
       sourceTextExpr -> "the source text matched by |Identifier|",
       coveredByExpr -> "the |Identifier| that is covered by |Identifier|",


### PR DESCRIPTION
Add additional substring rule to `SubstringExpression`and `ESubstring`.

According to the spec rule of substring,

`If the "to" suffix is omitted, the length of S is used as the value of exclusiveEnd.`