### PR TITLE
Add backward edge of Param in compiler

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsSemantics.scala
+++ b/src/main/scala/esmeta/analyzer/AbsSemantics.scala
@@ -169,7 +169,7 @@ class AbsSemantics(
     @tailrec
     def aux(ps: List[Param], as: List[AbsValue]): Unit = (ps, as) match {
       case (Nil, Nil) =>
-      case (Param(lhs, _, optional) :: pl, Nil) =>
+      case (Param(lhs, _, optional, _) :: pl, Nil) =>
         if (optional) {
           map += lhs -> AbsValue(Absent)
           aux(pl, Nil)

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -109,7 +109,7 @@ class TypeAnalyzer(cfg: CFG, targets: List[Func]) {
 
   // get return point
   def getState(func: Func): AbsState = func.params.foldLeft(AbsState.Empty) {
-    case (st, Param(x, ty, opt)) =>
+    case (st, Param(x, ty, opt, _)) =>
       var v = AbsValue(ty.ty)
       if (opt) v ⊔= AbsValue.absentTop
       st.update(x, v)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -762,7 +762,7 @@ class Compiler(
   def compile(param: Param): IRParam = {
     val Param(name, ty, skind) = param
     val optional = skind == ParamKind.Optional
-    IRParam(Name(name), compile(ty), optional)
+    IRParam(Name(name), compile(ty), optional, Some(param))
   }
 
   /** compile types */

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -458,8 +458,8 @@ class Interpreter(
     val map = MMap[Local, Value]()
     @tailrec
     def aux(ps: List[Param], as: List[Value]): Unit = (ps, as) match {
-      case (Nil, Nil)                           =>
-      case (Param(lhs, _, optional) :: pl, Nil) =>
+      case (Nil, Nil)                              =>
+      case (Param(lhs, _, optional, _) :: pl, Nil) =>
         // TODO parameter type check
         if (optional) {
           map += lhs -> Absent

--- a/src/main/scala/esmeta/ir/Param.scala
+++ b/src/main/scala/esmeta/ir/Param.scala
@@ -1,11 +1,13 @@
 package esmeta.ir
 
 import esmeta.ir.util.Parser
+import esmeta.spec.{Param => SpecParam}
 
 /** IR function parameters */
 case class Param(
   lhs: Name,
   ty: Type = UnknownType,
   optional: Boolean = false,
+  specParam: Option[SpecParam] = None,
 ) extends IRElem
 object Param extends Parser.From(Parser.param)

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -67,7 +67,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
 
   // function parameters
   given paramRule: Rule[Param] = (app, param) =>
-    val Param(name, ty, optional) = param
+    val Param(name, ty, optional, _) = param
     app >> name >> (if (optional) "?" else "") >> ": " >> ty
 
   // instructions

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -33,7 +33,7 @@ trait UnitWalker extends BasicUnitWalker {
 
   // function parameters
   def walk(param: Param): Unit =
-    val Param(name, opt, ty) = param
+    val Param(name, opt, ty, _) = param
     walk(name); walk(opt); walk(ty)
 
   // instructions

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -40,8 +40,8 @@ trait Walker extends BasicWalker {
 
   // function parameters
   def walk(param: Param): Param =
-    val Param(name, opt, ty) = param
-    Param(walk(name), walk(opt), walk(ty))
+    val Param(name, opt, ty, specParam) = param
+    Param(walk(name), walk(opt), walk(ty), specParam)
 
   // instructions
   def walk(inst: Inst): Inst =


### PR DESCRIPTION
Add backward edge of `ir/Param` to `spec/Param` in `compiler/Compiler.scala`.