### PR TITLE
Add backward edge of Expression in compiler

### DIFF
--- a/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
+++ b/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
@@ -1,6 +1,6 @@
 package esmeta.compiler
 
-import esmeta.ir.Inst
+import esmeta.ir.{Inst, Expr}
 import esmeta.ir.util.Walker
 
 /** walker for adjusting backward edge from ir to lang */
@@ -11,4 +11,8 @@ case class BackEdgeWalker(
   override def walk(i: Inst) =
     if (force || i.langOpt.isEmpty) i.setLangOpt(fb.langs.headOption)
     super.walk(i)
+
+  override def walk(e: Expr) =
+    if (force || e.langOpt.isEmpty) e.setLangOpt(fb.langs.headOption)
+    super.walk(e)
 }

--- a/src/main/scala/esmeta/ir/Expr.scala
+++ b/src/main/scala/esmeta/ir/Expr.scala
@@ -1,10 +1,17 @@
 package esmeta.ir
 
 import esmeta.ir.util.Parser
+import esmeta.lang.Syntax
 import esmeta.util.DoubleEquals
 
 // IR expressions
-sealed trait Expr extends IRElem
+sealed trait Expr extends IRElem:
+  // backward edge to metalangauge
+  var langOpt: Option[Syntax] = None
+  def setLang(lang: Syntax): this.type = setLangOpt(Some(lang))
+  def setLangOpt(langOpt: Option[Syntax]): this.type =
+    this.langOpt = langOpt; this
+
 object Expr extends Parser.From(Parser.expr)
 case class EComp(tyExpr: Expr, valExpr: Expr, tgtExpr: Expr) extends Expr
 case class EIsCompletion(expr: Expr) extends Expr


### PR DESCRIPTION
Add backward edge of `ir/Expr` to `Syntax` in compiler.
The backward edge has type `Option[Syntax]`, since `ir/Expr` can come from both `lang/Expression` or `lang/Cond` during compilation.
It follows the implementation strategy of the backward edge in `ir/Inst`. (i.e., it utilizes mutable `var` for now.)