### PR TITLE
Fixed bug in extractorValidityTest

### DIFF
--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -5,11 +5,14 @@
     - numeric string: 16
     - syntactic: 195
   - extended productions for web: 28
-- algorithms: 2623 (86.08%)
-  - complete: 2258
-  - incomplete: 365
-- algorithm steps: 19061 (96.04%)
-  - complete: 18307
-  - incomplete: 754
+- algorithms: 2623 (86.20%)
+  - complete: 2261
+  - incomplete: 362
+- algorithm steps: 19063 (96.13%)
+  - complete: 18325
+  - incomplete: 738
+- types: 7451 (73.49%)
+  - known: 5476
+  - unknown: 1975
 - tables: 89
 - type model: 58

--- a/src/test/scala/esmeta/extractor/ValiditySmallTest.scala
+++ b/src/test/scala/esmeta/extractor/ValiditySmallTest.scala
@@ -22,7 +22,7 @@ class ValiditySmallTest extends ExtractorTest {
     check("types") { assert(prev.types.known <= cur.types.known) }
     check("tables") { assert(prev.tables == cur.tables) }
     check("type model") { assert(prev.tyModel == cur.tyModel) }
-    if (cur != prev) dumpFile(cur, path)
+    dumpFile(cur, path)
   }
 
   init


### PR DESCRIPTION
In `ValiditySmallTest`, the `prev` variable stores the same `Spec` object as the current one (`cur`) when the spec parser fails to parse the `$RESULT_DIR/spec-summary` file. So, we need to always dump the current `Spec` object into `$RESULT_DIR/spec-summary` even if `prev == cur`.