### PR TITLE
Add backward edge of Ref in compiler

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -528,7 +528,7 @@ class AbsTransfer(sem: AbsSemantics) {
   def transfer(ref: Ref)(using cp: ControlPoint): Result[AbsRefValue] =
     ref match
       case id: Id => AbsRefId(id)
-      case Prop(ref, expr) =>
+      case Prop(ref, expr, _) =>
         for {
           rv <- transfer(ref)
           b <- transfer(rv)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -491,7 +491,7 @@ class Compiler(
       case InvokeMethodExpression(ref, args) =>
         val (x, xExpr) = fb.newTIdWithExpr
         // NOTE: there is no method call via dynamic property access
-        val Prop(base, EStr(method)) = compile(fb, ref)
+        val Prop(base, EStr(method), _) = compile(fb, ref)
         fb.addInst(IMethodCall(x, base, method, args.map(compile(fb, _))))
         xExpr
       case InvokeSyntaxDirectedOperationExpression(base, name, args) =>

--- a/src/main/scala/esmeta/compiler/FuncBuilder.scala
+++ b/src/main/scala/esmeta/compiler/FuncBuilder.scala
@@ -59,14 +59,20 @@ case class FuncBuilder(
   /** add return to resume instruction */
   def addReturnToResume(context: Ref, value: Expr): Unit =
     addInst(
-      ICall(newTId, EPop(toStrERef(context, "ReturnCont"), true), List(value)),
+      ICall(
+        newTId(),
+        EPop(toStrERef(context, "ReturnCont"), true),
+        List(value),
+      ),
     )
 
   /** get next temporal identifier */
-  def newTId: Temp = Temp(nextTId)
+  def newTId(langOpt: Option[Syntax] = None): Temp = Temp(nextTId, langOpt)
 
   /** get next temporal identifier with expressions */
-  def newTIdWithExpr: (Temp, Expr) = { val x = newTId; (x, ERef(x)) }
+  def newTIdWithExpr(langOpt: Option[Syntax] = None): (Temp, Expr) = {
+    val x = newTId(langOpt); (x, ERef(x))
+  }
 
   /** get closure name */
   def nextCloName: String = s"$name:clo${nextCId}"

--- a/src/main/scala/esmeta/compiler/package.scala
+++ b/src/main/scala/esmeta/compiler/package.scala
@@ -19,13 +19,18 @@ inline def toRef(fb: FuncBuilder, base: Expr, props: Expr*): Ref =
   toRef(getRef(fb, base), props*)
 inline def getRef(fb: FuncBuilder, expr: Expr): Ref = expr match {
   case ERef(ref) => ref
-  case _         => val x = fb.newTId; fb.addInst(IAssign(x, expr)); x
+  case _ =>
+    val x = fb.newTId(); fb.addInst(IAssign(x, expr)); x
 }
 
 // conversion to intrinsics
-inline def toIntrinsic(base: Ref, intr: Intrinsic): Prop =
+inline def toIntrinsic(
+  base: Ref,
+  intr: Intrinsic,
+  langOpt: Option[Syntax] = None,
+): Prop =
   // convert intr to string for exceptional case in GetPrototypeFromConstructor
-  Prop(base, EStr(intr.toString))
+  Prop(base, EStr(intr.toString), langOpt)
 inline def toEIntrinsic(base: Ref, intr: Intrinsic): ERef =
   toERef(toIntrinsic(base, intr))
 

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -491,7 +491,7 @@ class Interpreter(
   /** transition for references */
   def eval(ref: Ref): RefValue = ref match
     case x: Id => IdValue(x)
-    case Prop(ref, expr) =>
+    case Prop(ref, expr, _) =>
       var base = st(eval(ref))
       val p = eval(expr)
       PropValue(base, p.toPureValue)

--- a/src/main/scala/esmeta/ir/Ref.scala
+++ b/src/main/scala/esmeta/ir/Ref.scala
@@ -1,22 +1,22 @@
 package esmeta.ir
 
 import esmeta.ir.util.Parser
-import esmeta.lang.{Reference => LangRef}
+import esmeta.lang.Syntax
 
 // IR references
 sealed trait Ref extends IRElem:
-  val langRef: Option[LangRef]
+  val langOpt: Option[Syntax]
 object Ref extends Parser.From(Parser.ref)
 
-case class Prop(ref: Ref, expr: Expr, langRef: Option[LangRef] = None)
+case class Prop(ref: Ref, expr: Expr, langOpt: Option[Syntax] = None)
   extends Ref
 
 sealed trait Id extends Ref
-case class Global(name: String, langRef: Option[LangRef] = None) extends Id
+case class Global(name: String, langOpt: Option[Syntax] = None) extends Id
 
 sealed trait Local extends Id
-case class Name(name: String, langRef: Option[LangRef] = None) extends Local
-case class Temp(idx: Int, langRef: Option[LangRef] = None) extends Local
+case class Name(name: String, langOpt: Option[Syntax] = None) extends Local
+case class Temp(idx: Int, langOpt: Option[Syntax] = None) extends Local
 
 /** ordering of global identifiers */
 given Ordering[Global] = Ordering.by(_.name)

--- a/src/main/scala/esmeta/ir/Ref.scala
+++ b/src/main/scala/esmeta/ir/Ref.scala
@@ -1,25 +1,29 @@
 package esmeta.ir
 
 import esmeta.ir.util.Parser
+import esmeta.lang.{Reference => LangRef}
 
 // IR references
-sealed trait Ref extends IRElem
+sealed trait Ref extends IRElem:
+  val langRef: Option[LangRef]
 object Ref extends Parser.From(Parser.ref)
 
-case class Prop(ref: Ref, expr: Expr) extends Ref
+case class Prop(ref: Ref, expr: Expr, langRef: Option[LangRef] = None)
+  extends Ref
 
 sealed trait Id extends Ref
-case class Global(name: String) extends Id
+case class Global(name: String, langRef: Option[LangRef] = None) extends Id
 
 sealed trait Local extends Id
-case class Name(name: String) extends Local
-case class Temp(idx: Int) extends Local
+case class Name(name: String, langRef: Option[LangRef] = None) extends Local
+case class Temp(idx: Int, langRef: Option[LangRef] = None) extends Local
 
 /** ordering of global identifiers */
 given Ordering[Global] = Ordering.by(_.name)
 
 /** ordering of local identifiers */
-given Ordering[Local] = Ordering.by(_ match
-  case Name(name) => (-1, name)
-  case Temp(idx)  => (idx, ""),
+given Ordering[Local] = Ordering.by(local =>
+  local match
+    case Name(name, _) => (-1, name)
+    case Temp(idx, _)  => (idx, ""),
 )

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -338,17 +338,17 @@ class Stringifier(detail: Boolean, location: Boolean) {
   lazy val inlineProp = "([_a-zA-Z][_a-zA-Z0-9]*)".r
   given refRule: Rule[Ref] = (app, ref) =>
     ref match {
-      case Prop(ref, EStr(inlineProp(str))) => app >> ref >> "." >> str
-      case Prop(ref, expr)                  => app >> ref >> "[" >> expr >> "]"
-      case id: Id                           => idRule(app, id)
+      case Prop(ref, EStr(inlineProp(str)), _) => app >> ref >> "." >> str
+      case Prop(ref, expr, _) => app >> ref >> "[" >> expr >> "]"
+      case id: Id             => idRule(app, id)
     }
 
   // identifiers
   given idRule: Rule[Id] = (app, id) =>
     id match {
-      case Global(name) => app >> "@" >> name
-      case Name(name)   => app >> name
-      case Temp(id)     => app >> "%" >> id
+      case Global(name, _) => app >> "@" >> name
+      case Name(name, _)   => app >> name
+      case Temp(id, _)     => app >> "%" >> id
     }
 
   // types

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -166,15 +166,15 @@ trait UnitWalker extends BasicUnitWalker {
 
   // references
   def walk(ref: Ref): Unit = ref match {
-    case Prop(ref, expr) => walk(ref); walk(expr)
-    case x: Id           => walk(x)
+    case Prop(ref, expr, _) => walk(ref); walk(expr)
+    case x: Id              => walk(x)
   }
 
   // identifiers
   def walk(x: Id): Unit = x match {
-    case Global(x) => walk(x)
-    case x: Name   => walk(x)
-    case Temp(k)   => walk(k)
+    case Global(x, _) => walk(x)
+    case x: Name      => walk(x)
+    case Temp(k, _)   => walk(k)
   }
 
   // named local identifiers

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -178,19 +178,19 @@ trait Walker extends BasicWalker {
 
   // references
   def walk(ref: Ref): Ref = ref match
-    case Prop(ref, expr) => Prop(walk(ref), walk(expr))
-    case x: Id           => walk(x)
+    case Prop(ref, expr, langRef) => Prop(walk(ref), walk(expr), langRef)
+    case x: Id                    => walk(x)
 
   // identifiers
   def walk(x: Id): Id = x match
-    case Global(x)    => Global(walk(x))
-    case local: Local => walk(local)
+    case Global(x, langRef) => Global(walk(x), langRef)
+    case local: Local       => walk(local)
   def walk(x: Local): Local = x match
-    case x: Name => walk(x)
-    case Temp(k) => Temp(walk(k))
+    case x: Name          => walk(x)
+    case Temp(k, langRef) => Temp(walk(k), langRef)
 
   // named local identifiers
-  def walk(x: Name): Name = Name(walk(x.name))
+  def walk(x: Name): Name = Name(walk(x.name), x.langRef)
 
   // types
   def walk(ty: Type): Type = Type(ty.ty)

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -178,19 +178,19 @@ trait Walker extends BasicWalker {
 
   // references
   def walk(ref: Ref): Ref = ref match
-    case Prop(ref, expr, langRef) => Prop(walk(ref), walk(expr), langRef)
+    case Prop(ref, expr, langOpt) => Prop(walk(ref), walk(expr), langOpt)
     case x: Id                    => walk(x)
 
   // identifiers
   def walk(x: Id): Id = x match
-    case Global(x, langRef) => Global(walk(x), langRef)
+    case Global(x, langOpt) => Global(walk(x), langOpt)
     case local: Local       => walk(local)
   def walk(x: Local): Local = x match
     case x: Name          => walk(x)
-    case Temp(k, langRef) => Temp(walk(k), langRef)
+    case Temp(k, langOpt) => Temp(walk(k), langOpt)
 
   // named local identifiers
-  def walk(x: Name): Name = Name(walk(x.name), x.langRef)
+  def walk(x: Name): Name = Name(walk(x.name), x.langOpt)
 
   // types
   def walk(ty: Type): Type = Type(ty.ty)

--- a/src/main/scala/esmeta/web/Debugger.scala
+++ b/src/main/scala/esmeta/web/Debugger.scala
@@ -288,7 +288,7 @@ class Debugger(st: State) extends Interpreter(st, log = true) {
       c.name,
       c.cursor.stepsOpt.getOrElse(List()),
       c.locals.collect {
-        case (Name(name), v) => (name, v.toString)
+        case (Name(name, _), v) => (name, v.toString)
       }.toList,
     )
     (st.context :: st.callStack.map(_.context)).map(getInfo(_))

--- a/src/test/scala/esmeta/state/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/state/StringifyTinyTest.scala
@@ -41,6 +41,7 @@ class StringifyTinyTest extends StateTest {
     lazy val ctxtSingle = Context(func, MMap(Name("x") -> Math(42)))
     lazy val ctxtMulti =
       Context(func, MMap(Name("x") -> Math(42), Name("y") -> Str("abc")))
+
     checkStringify("Context")(
       ctxt -> """{
       |  cursor: Block[0] @ f
@@ -123,7 +124,7 @@ class StringifyTinyTest extends StateTest {
     lazy val ast = AstValue(Syntactic("Identifier", Nil, 1, Nil))
     lazy val astArgs =
       AstValue(Syntactic("Identifier", List(true, false), 1, Nil))
-    lazy val nt = Nt("Identifier", List(true, false))
+    lazy val grammar = Grammar("Identifier", List(true, false))
     lazy val lex = AstValue(Lexical("Identifier", "x"))
     checkStringify("Value")(
       comp -> "comp[~throw~/to](42)",
@@ -137,7 +138,7 @@ class StringifyTinyTest extends StateTest {
       ast -> "|Identifier|<1>",
       astArgs -> "|Identifier|[TF]<1>",
       lex -> "|Identifier|(x)",
-      nt -> "|Identifier|[TF]",
+      grammar -> "|Identifier|[TF]",
       Math(3.2) -> "3.2",
       Number(3.2) -> "3.2f",
       BigInt(324) -> "324n",

--- a/src/test/scala/esmeta/state/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/state/StringifyTinyTest.scala
@@ -41,7 +41,6 @@ class StringifyTinyTest extends StateTest {
     lazy val ctxtSingle = Context(func, MMap(Name("x") -> Math(42)))
     lazy val ctxtMulti =
       Context(func, MMap(Name("x") -> Math(42), Name("y") -> Str("abc")))
-
     checkStringify("Context")(
       ctxt -> """{
       |  cursor: Block[0] @ f
@@ -124,7 +123,7 @@ class StringifyTinyTest extends StateTest {
     lazy val ast = AstValue(Syntactic("Identifier", Nil, 1, Nil))
     lazy val astArgs =
       AstValue(Syntactic("Identifier", List(true, false), 1, Nil))
-    lazy val grammar = Grammar("Identifier", List(true, false))
+    lazy val nt = Nt("Identifier", List(true, false))
     lazy val lex = AstValue(Lexical("Identifier", "x"))
     checkStringify("Value")(
       comp -> "comp[~throw~/to](42)",
@@ -138,7 +137,7 @@ class StringifyTinyTest extends StateTest {
       ast -> "|Identifier|<1>",
       astArgs -> "|Identifier|[TF]<1>",
       lex -> "|Identifier|(x)",
-      grammar -> "|Identifier|[TF]",
+      nt -> "|Identifier|[TF]",
       Math(3.2) -> "3.2",
       Number(3.2) -> "3.2f",
       BigInt(324) -> "324n",

--- a/tests/result/state/StringifyTinyTest
+++ b/tests/result/state/StringifyTinyTest
@@ -1,1 +1,1 @@
-state.StringifyTinyTest: 8 / 8
+state.StringifyTinyTest: 7 / 8

--- a/tests/result/state/StringifyTinyTest.json
+++ b/tests/result/state/StringifyTinyTest.json
@@ -1,6 +1,6 @@
 {
   "CallContext" : true,
-  "Context" : true,
+  "Context" : false,
   "Cursor" : true,
   "Heap" : true,
   "Object" : true,


### PR DESCRIPTION
Added backward edge of `Ref` to `Syntax` in compiler.
The backward edge has type `Option[Syntax]`, since `Ref` can come from `Step`, `Expression`, `Condition`, or `Reference`.
However, it doesn't add a backward edge for `Param` types for now.

There are some issues though.

First, I think there is some ambiguity in resolving the backward edge regarding temporary references made with `newTId`.

Second, regarding the `compileWithExpr` function in `Compiler.scala`, adding a backward edge in `Name` leads to `UnknownId` error in `State.scala`. So the current implementation doesn't add a backward edge in `compileWithExpr`.

I think it would be great to discuss in off-line. :)