### PR TITLE
Add backward edge of Ref in compiler

### DIFF
--- a/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
+++ b/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
@@ -1,6 +1,6 @@
 package esmeta.compiler
 
-import esmeta.ir.{Inst, Expr}
+import esmeta.ir.{Inst, Expr, Ref}
 import esmeta.ir.util.Walker
 
 /** walker for adjusting backward edge from ir to lang */
@@ -15,4 +15,8 @@ case class BackEdgeWalker(
   override def walk(e: Expr) =
     if (force || e.langOpt.isEmpty) e.setLangOpt(fb.langs.headOption)
     super.walk(e)
+
+  override def walk(r: Ref) =
+    if (force || r.langOpt.isEmpty) r.setLangOpt(fb.langs.headOption)
+    super.walk(r)
 }

--- a/src/main/scala/esmeta/ir/Ref.scala
+++ b/src/main/scala/esmeta/ir/Ref.scala
@@ -3,7 +3,7 @@ package esmeta.ir
 import esmeta.ir.util.Parser
 
 // IR references
-sealed trait Ref extends IRElem
+sealed trait Ref extends IRElem with LangEdge
 object Ref extends Parser.From(Parser.ref)
 
 case class Prop(ref: Ref, expr: Expr) extends Ref


### PR DESCRIPTION
Added backward edge of `Ref` to `Syntax` in compiler. It extends the `trait LangEdge`.
However, it doesn't add a backward edge for `Param` types for now.

I believe there are mainly two issues left to be solved.

1. Mutable data structure
<br/> The backward edge is implemented as` var langOpt: Option[Syntax] = None` in `trait LangEdge`. 
To implement it as immutable (i.e., `val langOpt`), `langOpt: Option[Syntax] = None` should be appended to all of the case class parameters extending the `trait LangEdge`. This, on the other hand can bring performance issues regarding the implicit definitions of `apply`, `unapply`, ... provided by the `case class`.

3. How the backward edges are inserted
<br/> In `Compiler.scala`, the backward edges are actually inserted by the `fb.addInst` function, where `fb` is a `FunctionBuilder` object. I think it would be better to insert backward edges right away at each compilation step rather than collecting and inserting backward edges with `fb.withLang` and `fb.addInst`.

