### PR TITLE
Supported -compile:log-with-loc option

### DIFF
--- a/.completion
+++ b/.completion
@@ -15,7 +15,7 @@ _esmeta_completions() {
   globalOpt="-silent -error -status -time"
   helpOpt=""
   extractOpt="-extract:target -extract:log -extract:repl"
-  compileOpt="-compile:log"
+  compileOpt="-compile:log -compile:log-with-loc"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:log"
   parseOpt="-parse:debug"

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -22,7 +22,7 @@ object Compiler:
   def apply(
     spec: Spec,
     log: Boolean = false,
-  ): Program = new Compiler(spec).result
+  ): Program = new Compiler(spec, log).result
 
 /** extensible helper of compiler from metalangauge to IR */
 class Compiler(

--- a/src/main/scala/esmeta/ir/Program.scala
+++ b/src/main/scala/esmeta/ir/Program.scala
@@ -40,13 +40,14 @@ case class Program(
   def tyModel: TyModel = spec.tyModel
 
   /** dump IR program */
-  def dumpTo(baseDir: String): Unit =
+  def dumpTo(baseDir: String, loc: Boolean = false): Unit =
     val dirname = s"$baseDir/func"
     dumpDir(
       name = "IR functions",
       iterable = ProgressBar("Dump IR functions", funcs),
       dirname = dirname,
       getName = func => s"${func.normalizedName}.ir",
+      getData = func => func.toString(detail = true, location = loc),
     )
 }
 object Program extends Parser.From(Parser.program) {

--- a/src/main/scala/esmeta/phase/Compile.scala
+++ b/src/main/scala/esmeta/phase/Compile.scala
@@ -22,7 +22,7 @@ case object Compile extends Phase[Spec, Program] {
     // logging mode
     if (config.log)
       // results
-      program.dumpTo(COMPILE_LOG_DIR)
+      program.dumpTo(COMPILE_LOG_DIR, config.loc)
 
       // yet expressions
       dumpFile(
@@ -52,8 +52,14 @@ case object Compile extends Phase[Spec, Program] {
       BoolOption(c => c.log = true),
       "turn on logging mode.",
     ),
+    (
+      "log-with-loc",
+      BoolOption(c => { c.log = true; c.loc = true }),
+      "turn on logging mode with location info.",
+    ),
   )
   case class Config(
     var log: Boolean = false,
+    var loc: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -59,9 +59,10 @@ object SystemUtils {
     iterable: Iterable[T],
     dirname: String,
     getName: T => String,
+    getData: T => Any = (x: T) => x,
   ): Unit =
     mkdir(dirname)
-    for (data <- iterable) dumpFile(data, s"$dirname/${getName(data)}")
+    for (x <- iterable) dumpFile(getData(x), s"$dirname/${getName(x)}")
     println(s"- Dumped $name into $dirname.")
 
   /** dump given data into a file and show message */


### PR DESCRIPTION
Supported `-compile:log-with-loc` option in compile phase.
It prints out the locations in `spec.html` from which the `ir` instruction or expressions are compiled.