### PR TITLE
Fix font option of CFG

### DIFF
--- a/.completion
+++ b/.completion
@@ -15,7 +15,7 @@ _esmeta_completions() {
   globalOpt="-silent -error -status -time"
   helpOpt=""
   extractOpt="-extract:target -extract:log -extract:repl"
-  compileOpt="-compile:log"
+  compileOpt="-compile:log -compile:log-with-loc"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:log"
   parseOpt="-parse:debug"

--- a/src/main/resources/manuals/default/algos/ToString.algo
+++ b/src/main/resources/manuals/default/algos/ToString.algo
@@ -2,7 +2,7 @@
   <h1>
     ToString (
       _argument_: an ECMAScript language value,
-    ): either a normal completion containing an ECMAScript language value or an abrupt completion
+    ): either a normal completion containing a String or an abrupt completion
   </h1>
   <dl class="header"></dl>
   <emu-alg>

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -11,9 +11,9 @@
 - algorithm steps: 19063 (96.33%)
   - complete: 18363
   - incomplete: 700
-- types: 5908 (92.69%)
-  - known: 5476
+- types: 5908 (92.03%)
+  - known: 5437
+  - yet: 471
   - unknown: 1543
-  - notyet: 432
 - tables: 89
 - type model: 58

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -11,8 +11,9 @@
 - algorithm steps: 19063 (96.33%)
   - complete: 18363
   - incomplete: 700
-- types: 7451 (73.49%)
+- types: 5908 (92.69%)
   - known: 5476
-  - unknown: 1975
+  - unknown: 1543
+  - notyet: 432
 - tables: 89
 - type model: 58

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -554,9 +554,7 @@ class AbsTransfer(sem: AbsSemantics) {
 
   /** transfer function for reference values */
   def transfer(rv: AbsRefValue)(using cp: ControlPoint): Result[AbsValue] =
-    for {
-      v <- get(_.get(rv, cp))
-    } yield v
+    for { v <- get(_.get(rv, cp)) } yield v
 
   /** transfer function for unary operators */
   def transfer(

--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -308,7 +308,6 @@ object TypeDomain extends state.Domain {
               if (propIdx >= nts.size)
                 () // TODO warning(s"invalid access: $propIdx of $ast")
               else res ||= nts(propIdx).fold(AbsentT)(AstT(_))
-              res ||= nts(propIdx).fold(AbsentT)(AstT(_))
             }
           case Inf => res ||= AstTopT
         prop.str match
@@ -328,7 +327,7 @@ object TypeDomain extends state.Domain {
   private def lookupStr(str: BSet[String], prop: ValueTy): ValueTy =
     var res = ValueTy()
     if (prop.str contains "length") res ||= MathTopT
-    if (!prop.math.isBottom) res ||= CodeUnitT
+    if (!str.isBottom && !prop.math.isBottom) res ||= CodeUnitT
     // TODO if (!str.isBottom)
     //   boundCheck(
     //     prop,

--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -270,11 +270,13 @@ object TypeDomain extends state.Domain {
     CONSTT_BREAK || CONSTT_CONTINUE || CONSTT_RETURN || CONSTT_THROW
   private def lookupComp(comp: CompTy, prop: ValueTy): ValueTy =
     val str = prop.str
-    val normal = !comp.normal.isBottom
+    val normal = !comp.normal.fold(false)(_.isBottom)
     val abrupt = comp.abrupt
     var res = ValueTy()
     if (str contains "Value")
-      if (normal) res ||= ValueTy(pureValue = comp.normal)
+      if (normal)
+        // remove impossible top normal completion
+        res ||= ValueTy(pureValue = comp.normal.getOrElse(PureValueTy.Bot))
       if (comp.abrupt) res ||= ESValueT || CONSTT_EMPTY
     if (str contains "Target")
       if (normal) res ||= CONSTT_EMPTY

--- a/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
@@ -47,7 +47,7 @@ object TypeDomain extends value.Domain {
       if (consts contains "normal") value.ty.pureValue
       else PureValueTy()
     val abrupt = !(consts - "normal").isEmpty
-    Elem(ValueTy(normal = normal, abrupt = abrupt))
+    Elem(ValueTy(normal = Some(normal), abrupt = abrupt))
 
   /** predefined top values */
   lazy val compTop: Elem = notSupported("value.TypeDomain.compTop")
@@ -259,10 +259,19 @@ object TypeDomain extends value.Domain {
     /** completion helpers */
     def wrapCompletion: Elem =
       val ty = elem.ty
-      Elem(ValueTy(normal = ty.normal || ty.pureValue, abrupt = ty.abrupt))
+      Elem(
+        ValueTy(
+          normal = ty.normal.map(_ || ty.pureValue),
+          abrupt = ty.abrupt,
+        ),
+      )
     def unwrapCompletion: Elem =
       val ty = elem.ty
-      Elem(ValueTy(pureValue = ty.normal || ty.pureValue))
+      Elem(
+        ValueTy(
+          normal = ty.normal.map(_ || ty.pureValue),
+        ),
+      )
     def isCompletion: Elem =
       val ty = elem.ty
       var bs: Set[Boolean] = Set()

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -51,7 +51,8 @@ case class Graph(
             val entry = func.entry
             val eid = ViewDotPrinter(returnView).getId(entry)
             for (callNp @ NodePoint(_, call, callView) <- calls)
-              ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
+              ViewDotPrinter(sem.getEntryView(callView))
+                .drawCall(call, eid, app),
     }
     app.toString
 

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -13,42 +13,46 @@ case class Graph(
   // conversion to DOT
   lazy val toDot: String =
     val app = new Appender
-    (app >> "digraph").wrap((curOpt, depthOpt, pathOpt) match
-      case (Some(cp), _, Some(path)) =>
-        val func = cp.func
-        val view = sem.getEntryView(cp.view)
-        val dot = ViewDotPrinter(view)
-        val entry = func.entry
-        var eid = dot.getId(entry)
-        dot.addFunc(func, app)
-        for (np <- path)
-          val func = np.func
-          val view = sem.getEntryView(np.view)
+    (app >> "digraph").wrap {
+      app :> """graph [fontname = "Consolas"]"""
+      app :> """node [fontname = "Consolas"]"""
+      app :> """edge [fontname = "Consolas"]"""
+      (curOpt, depthOpt, pathOpt) match
+        case (Some(cp), _, Some(path)) =>
+          val func = cp.func
+          val view = sem.getEntryView(cp.view)
           val dot = ViewDotPrinter(view)
-          dot.addFunc(func, app)
-          dot.drawCall(np.node, eid, app)
           val entry = func.entry
-          eid = dot.getId(entry)
-      case (Some(cp), Some(depth), _) =>
-        val func = cp.func
-        val view = sem.getEntryView(cp.view)
-        val dot = ViewDotPrinter(view)
-        val rp = ReturnPoint(func, view)
-        dot.addFunc(func, app)
-        showPrev(rp, dot, depth, app)
-      case _ =>
-        val funcs: Set[(Func, View)] =
-          sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
-        for ((func, view) <- funcs)
+          var eid = dot.getId(entry)
+          dot.addFunc(func, app)
+          for (np <- path)
+            val func = np.func
+            val view = sem.getEntryView(np.view)
+            val dot = ViewDotPrinter(view)
+            dot.addFunc(func, app)
+            dot.drawCall(np.node, eid, app)
+            val entry = func.entry
+            eid = dot.getId(entry)
+        case (Some(cp), Some(depth), _) =>
+          val func = cp.func
+          val view = sem.getEntryView(cp.view)
           val dot = ViewDotPrinter(view)
+          val rp = ReturnPoint(func, view)
           dot.addFunc(func, app)
-        // print call edges
-        for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
-          val entry = func.entry
-          val eid = ViewDotPrinter(returnView).getId(entry)
-          for (callNp @ NodePoint(_, call, callView) <- calls)
-            ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
-    )
+          showPrev(rp, dot, depth, app)
+        case _ =>
+          val funcs: Set[(Func, View)] =
+            sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
+          for ((func, view) <- funcs)
+            val dot = ViewDotPrinter(view)
+            dot.addFunc(func, app)
+          // print call edges
+          for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
+            val entry = func.entry
+            val eid = ViewDotPrinter(returnView).getId(entry)
+            for (callNp @ NodePoint(_, call, callView) <- calls)
+              ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
+    }
     app.toString
 
   // show previous traces with depth

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -105,7 +105,7 @@ class Stringifier(
       case m @ ParamTypeMismatch(callerNp, calleeRp, param, argTy) =>
         app >> "[ParamTypeMismatch] parameter _" >> param.lhs.name >> "_"
         app >> " of " >> calleeRp.func.name
-        app >> " from " >> callerNp.func.name >> callerNp.node.callInst
+        app >> " @ " >> callerNp.func.name >> callerNp.node.callInst
         app :> "- expected: " >> param.ty
         app :> "- actual  : " >> argTy
       case m @ ReturnTypeMismatch(ret, calleeRp, actual) =>
@@ -127,7 +127,7 @@ class Stringifier(
     for {
       lang <- elem.langOpt
       loc <- lang.loc
-    } app >> " @ " >> loc.toString
+    } app >> " " >> loc.toString
     app
   }
 

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -103,8 +103,9 @@ class Stringifier(
     given Rule[IRElem with LangEdge] = addLoc
     m match
       case m @ ParamTypeMismatch(callerNp, calleeRp, param, argTy) =>
-        app >> "[ParamTypeMismatch] parameter _" >> param.lhs >> "_"
-        app >> " of " >> callerNp.func.name >> callerNp.node.callInst
+        app >> "[ParamTypeMismatch] parameter _" >> param.lhs.name >> "_"
+        app >> " of " >> calleeRp.func.name
+        app >> " from " >> callerNp.func.name >> callerNp.node.callInst
         app :> "- expected: " >> param.ty
         app :> "- actual  : " >> argTy
       case m @ ReturnTypeMismatch(ret, calleeRp, actual) =>

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -29,9 +29,9 @@ trait DotPrinter {
   override def toString: String = {
     val app = Appender()
     (app >> "digraph ").wrap {
-      app :> """graph [fontname = "helvetica"]"""
-      app :> """node [fontname = "helvetica"]"""
-      app :> """edge [fontname = "helvetica"]"""
+      app :> """graph [fontname = "Consolas"]"""
+      app :> """node [fontname = "Consolas"]"""
+      app :> """edge [fontname = "Consolas"]"""
       this(app)
     }
     app.toString

--- a/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
+++ b/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
@@ -1,6 +1,6 @@
 package esmeta.compiler
 
-import esmeta.ir.{Inst, Expr}
+import esmeta.ir.{Inst, Expr, Ref}
 import esmeta.ir.util.Walker
 
 /** walker for adjusting backward edge from ir to lang */
@@ -15,4 +15,8 @@ case class BackEdgeWalker(
   override def walk(e: Expr) =
     if (force || e.langOpt.isEmpty) e.setLangOpt(fb.langs.headOption)
     super.walk(e)
+
+  override def walk(r: Ref) =
+    if (force || r.langOpt.isEmpty) r.setLangOpt(fb.langs.headOption)
+    super.walk(r)
 }

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -22,7 +22,7 @@ object Compiler:
   def apply(
     spec: Spec,
     log: Boolean = false,
-  ): Program = new Compiler(spec).result
+  ): Program = new Compiler(spec, log).result
 
 /** extensible helper of compiler from metalangauge to IR */
 class Compiler(

--- a/src/main/scala/esmeta/ir/Program.scala
+++ b/src/main/scala/esmeta/ir/Program.scala
@@ -40,13 +40,14 @@ case class Program(
   def tyModel: TyModel = spec.tyModel
 
   /** dump IR program */
-  def dumpTo(baseDir: String): Unit =
+  def dumpTo(baseDir: String, loc: Boolean = false): Unit =
     val dirname = s"$baseDir/func"
     dumpDir(
       name = "IR functions",
       iterable = ProgressBar("Dump IR functions", funcs),
       dirname = dirname,
       getName = func => s"${func.normalizedName}.ir",
+      getData = func => func.toString(detail = true, location = loc),
     )
 }
 object Program extends Parser.From(Parser.program) {

--- a/src/main/scala/esmeta/ir/Ref.scala
+++ b/src/main/scala/esmeta/ir/Ref.scala
@@ -3,7 +3,7 @@ package esmeta.ir
 import esmeta.ir.util.Parser
 
 // IR references
-sealed trait Ref extends IRElem
+sealed trait Ref extends IRElem with LangEdge
 object Ref extends Parser.From(Parser.ref)
 
 case class Prop(ref: Ref, expr: Expr) extends Ref

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -327,7 +327,7 @@ trait Parsers extends IndentParsers {
         val fields = fs.map { case f ~ e => f -> e }
         RecordExpression(t, fields)
     } |||
-    opt("an" | "a") ~ ("newly created" | "new") ~
+    opt("an " | "a ") ~ ("newly created" | "new") ~
     guard(not("Realm")) ~> tname <~ opt(
       "containing no bindings" |
       "with no fields" |
@@ -440,7 +440,7 @@ trait Parsers extends IndentParsers {
       "𝔽" ^^^ ToNumber ||| "ℤ" ^^^ ToBigInt ||| "ℝ" ^^^ ToMath
     ) ~ ("(" ~> expr <~ ")")
     val textFormat =
-      ("the" | "an" | "a") ~> (
+      ("the " | "an " | "a ") ~> (
         "implementation-approximated Number" ^^^ ToApproxNumber |
         "Number" ^^^ ToNumber |
         "BigInt" ^^^ ToBigInt |
@@ -819,7 +819,7 @@ trait Parsers extends IndentParsers {
 
   // instance check conditions
   lazy val instanceOfCond: PL[InstanceOfCondition] =
-    expr ~ isEither((("an" | "a") ~> langType)) ^^ {
+    expr ~ isEither((("an " | "a ") ~> langType)) ^^ {
       case e ~ (n ~ t) => InstanceOfCondition(e, n, t)
     }
 
@@ -829,7 +829,7 @@ trait Parsers extends IndentParsers {
     // GeneratorValidate
     (ref <~ opt("also")) ~
     ("has" ^^^ false ||| "does not have" ^^^ true) ~
-    (("an" | "a") ~> expr <~ fieldStr) ^^ {
+    (("an " | "a ") ~> expr <~ fieldStr) ^^ {
       case r ~ n ~ f => HasFieldCondition(r, n, f)
     }
 
@@ -914,7 +914,7 @@ trait Parsers extends IndentParsers {
   // contains-whose conditions
   lazy val containsWhoseCond: PL[ContainsWhoseCondition] =
     expr ~
-    ("contains" ~ opt("an" | "a") ~> langType) ~
+    ("contains" ~ opt("an " | "a ") ~> langType) ~
     ("whose" ~ "[[" ~> word <~ "]]") ~
     ("is" ~> expr) ^^ {
       case l ~ t ~ f ~ e => ContainsWhoseCondition(l, t, f, e)
@@ -1110,6 +1110,7 @@ trait Parsers extends IndentParsers {
 
   // completion record types
   lazy val compTy: P[ValueTy] = multi(
+    "a Completion Record" ^^^ CompT |
     "a normal completion containing" ~> multi(pureValueTy) ^^ { NormalT(_) } |
     "an abrupt completion" ^^^ AbruptT,
   )
@@ -1119,24 +1120,23 @@ trait Parsers extends IndentParsers {
 
   // named record types
   lazy val nameTy: P[ValueTy] =
-    opt("an " | "a ") ~> rep1("[-a-zA-Z]+".r.filter(_ != "or"))
-      .flatMap {
-        case ss =>
-          val name = ss.mkString(" ")
-          val normalizedName = Type.normalizeName(name)
-          if (TyModel.es.infos.contains(normalizedName)) success(NameT(name))
-          else failure("unknown type name")
-      }
+    opt("an " | "a ") ~> rep1("[-a-zA-Z]+".r.filter(_ != "or")).flatMap {
+      case ss =>
+        val name = ss.mkString(" ")
+        val normalizedName = Type.normalizeName(name)
+        if (TyModel.es.infos.contains(normalizedName)) success(NameT(name))
+        else failure("unknown type name")
+    }
 
   // record types TODO
-  lazy val recordTy: P[ValueTy] = opt("an" | "a") ~> failure("TODO")
+  lazy val recordTy: P[ValueTy] = opt("an " | "a ") ~> failure("TODO")
 
   // list types
   lazy val listTy: P[ValueTy] =
-    opt("an" | "a") ~ "List of" ~> multi(pureValueTy) ^^ { ListT(_) }
+    opt("an " | "a ") ~ "List of" ~> multi(pureValueTy) ^^ { ListT(_) }
 
   // simple types
-  lazy val simpleTy: P[ValueTy] = opt("an" | "a") ~> {
+  lazy val simpleTy: P[ValueTy] = opt("an " | "a ") ~> {
     "Number" ^^^ NumberTopT |
     "BigInt" ^^^ BigIntT |
     "Boolean" ^^^ BoolT |
@@ -1151,8 +1151,7 @@ trait Parsers extends IndentParsers {
     "property key" ^^^ (StrTopT || SymbolT) |
     "Parse Node" ^^^ AstTopT |
     nt <~ "Parse Node" ^^ { AstT(_) } |
-    "~" ~> "[-+a-zA-Z0-9]+".r <~ "~" ^^ { ConstT(_) } |
-    "[a-zA-Z ]+Record".r ^^ { NameT(_) }
+    "~" ~> "[-+a-zA-Z0-9]+".r <~ "~" ^^ { ConstT(_) }
   } <~ opt("s")
 
   private def multi(
@@ -1166,7 +1165,7 @@ trait Parsers extends IndentParsers {
     else multiParser
 
   // rarely used expressions
-  lazy val specialTy: P[Ty] = opt("an" | "a") ~> {
+  lazy val specialTy: P[Ty] = opt("an " | "a ") ~> {
     "List of" ~> word ^^ {
       case s => UnknownTy(s"List of $s")
     } | "Record" ~ "{" ~> repsep(fieldLiteral, ",") <~ "}" ^^ {

--- a/src/main/scala/esmeta/phase/Compile.scala
+++ b/src/main/scala/esmeta/phase/Compile.scala
@@ -22,7 +22,7 @@ case object Compile extends Phase[Spec, Program] {
     // logging mode
     if (config.log)
       // results
-      program.dumpTo(COMPILE_LOG_DIR)
+      program.dumpTo(COMPILE_LOG_DIR, config.loc)
 
       // yet expressions
       dumpFile(
@@ -52,8 +52,14 @@ case object Compile extends Phase[Spec, Program] {
       BoolOption(c => c.log = true),
       "turn on logging mode.",
     ),
+    (
+      "log-with-loc",
+      BoolOption(c => { c.log = true; c.loc = true }),
+      "turn on logging mode with location info.",
+    ),
   )
   case class Config(
     var log: Boolean = false,
+    var loc: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -40,14 +40,14 @@ case object Extract extends Phase[Unit, Spec] {
       filename = s"$EXTRACT_LOG_DIR/yet-steps",
     )
 
-    val unknownTypes = spec.unknownTypes
+    val notyetTypes = spec.notyetTypes
     dumpFile(
-      name = "unknown types",
-      data = unknownTypes
+      name = "not yet parsed types",
+      data = notyetTypes
         .map(_.toString)
         .sorted
         .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/unknown-types",
+      filename = s"$EXTRACT_LOG_DIR/notyet-types",
     )
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -40,14 +40,14 @@ case object Extract extends Phase[Unit, Spec] {
       filename = s"$EXTRACT_LOG_DIR/yet-steps",
     )
 
-    val notyetTypes = spec.notyetTypes
+    val yetTypes = spec.yetTypes
     dumpFile(
       name = "not yet parsed types",
-      data = notyetTypes
+      data = yetTypes
         .map(_.toString)
         .sorted
         .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/notyet-types",
+      filename = s"$EXTRACT_LOG_DIR/yet-types",
     )
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -58,7 +58,7 @@ case class Spec(
     types.collect { case ty @ Type(_: ValueTy) => ty }
 
   /** get known types */
-  lazy val notyetTypes: List[Type] =
+  lazy val yetTypes: List[Type] =
     types.collect { case ty @ Type(UnknownTy(Some(_))) => ty }
 
   /** mapping from algorithms names to algorithms */

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -55,11 +55,11 @@ case class Spec(
 
   /** get known types */
   lazy val knownTypes: List[Type] =
-    types.filter(_.ty.isInstanceOf[ValueTy])
+    types.collect { case ty @ Type(_: ValueTy) => ty }
 
   /** get known types */
-  lazy val unknownTypes: List[Type] =
-    types.filter(_.ty.isInstanceOf[UnknownTy])
+  lazy val notyetTypes: List[Type] =
+    types.collect { case ty @ Type(UnknownTy(Some(_))) => ty }
 
   /** mapping from algorithms names to algorithms */
   lazy val fnameMap: Map[String, Algorithm] =

--- a/src/main/scala/esmeta/spec/Summary.scala
+++ b/src/main/scala/esmeta/spec/Summary.scala
@@ -24,7 +24,7 @@ object Summary extends Parser.From[Summary](Parser.summary) {
     val completeAlgos = spec.completeAlgorithms.length
     val completeSteps = spec.completeSteps.length
     val knownTypes = spec.knownTypes.length
-    val notyetTypes = spec.notyetTypes.length
+    val yetTypes = spec.yetTypes.length
     Summary(
       version = version,
       grammar = GrammarSummary(
@@ -43,8 +43,8 @@ object Summary extends Parser.From[Summary](Parser.summary) {
       ),
       types = TypeSummary(
         known = knownTypes,
-        unknown = spec.types.length - knownTypes - notyetTypes,
-        notyet = notyetTypes,
+        unknown = spec.types.length - knownTypes - yetTypes,
+        yet = yetTypes,
       ),
       tables = tables.size,
       tyModel = tyModel.infos.size,
@@ -84,9 +84,9 @@ case class StepSummary(
 /** type element */
 case class TypeSummary(
   known: Int = 0,
+  yet: Int = 0,
   unknown: Int = 0,
-  notyet: Int = 0,
 ) {
-  def total: Int = known + notyet
+  def total: Int = known + yet
   def ratioString: String = ratioSimpleString(known, total)
 }

--- a/src/main/scala/esmeta/spec/Summary.scala
+++ b/src/main/scala/esmeta/spec/Summary.scala
@@ -24,6 +24,7 @@ object Summary extends Parser.From[Summary](Parser.summary) {
     val completeAlgos = spec.completeAlgorithms.length
     val completeSteps = spec.completeSteps.length
     val knownTypes = spec.knownTypes.length
+    val notyetTypes = spec.notyetTypes.length
     Summary(
       version = version,
       grammar = GrammarSummary(
@@ -42,7 +43,8 @@ object Summary extends Parser.From[Summary](Parser.summary) {
       ),
       types = TypeSummary(
         known = knownTypes,
-        unknown = spec.types.length - knownTypes,
+        unknown = spec.types.length - knownTypes - notyetTypes,
+        notyet = notyetTypes,
       ),
       tables = tables.size,
       tyModel = tyModel.infos.size,
@@ -83,7 +85,8 @@ case class StepSummary(
 case class TypeSummary(
   known: Int = 0,
   unknown: Int = 0,
+  notyet: Int = 0,
 ) {
-  def total: Int = known + unknown
+  def total: Int = known + notyet
   def ratioString: String = ratioSimpleString(known, total)
 }

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -306,8 +306,8 @@ trait Parsers extends LangParsers {
     val types = {
       (empty ~ "- types:" ~ ".*".r) ~>
       (empty ~ "- known:" ~> int) ~
-      (empty ~ "- unknown:" ~> int) ~
-      (empty ~ "- notyet:" ~> int)
+      (empty ~ "- yet:" ~> int) ~
+      (empty ~ "- unknown:" ~> int)
     } ^^ { case c ~ u ~ n => TypeSummary(c, u, n) }
     val tables = empty ~ "- tables:" ~> int
     val tyModel = empty ~ "- type model:" ~> int <~ empty

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -306,8 +306,9 @@ trait Parsers extends LangParsers {
     val types = {
       (empty ~ "- types:" ~ ".*".r) ~>
       (empty ~ "- known:" ~> int) ~
-      (empty ~ "- unknown:" ~> int)
-    } ^^ { case c ~ i => TypeSummary(c, i) }
+      (empty ~ "- unknown:" ~> int) ~
+      (empty ~ "- notyet:" ~> int)
+    } ^^ { case c ~ u ~ n => TypeSummary(c, u, n) }
     val tables = empty ~ "- tables:" ~> int
     val tyModel = empty ~ "- type model:" ~> int <~ empty
     version ~ grammar ~ algos ~ steps ~ types ~ tables ~ tyModel ^^ {

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -61,8 +61,8 @@ object Stringifier {
     app :> "  - incomplete: " >> steps.incomplete
     app :> "- types: " >> types.total >> " " >> types.ratioString
     app :> "  - known: " >> types.known
+    app :> "  - yet: " >> types.yet
     app :> "  - unknown: " >> types.unknown
-    app :> "  - notyet: " >> types.notyet
     app :> "- tables: " >> tables
     app :> "- type model: " >> tyModel
 

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -62,6 +62,7 @@ object Stringifier {
     app :> "- types: " >> types.total >> " " >> types.ratioString
     app :> "  - known: " >> types.known
     app :> "  - unknown: " >> types.unknown
+    app :> "  - notyet: " >> types.notyet
     app :> "- tables: " >> tables
     app :> "- type model: " >> tyModel
 

--- a/src/main/scala/esmeta/ty/CompTy.scala
+++ b/src/main/scala/esmeta/ty/CompTy.scala
@@ -7,7 +7,7 @@ import esmeta.ty.util.Parser
 
 /** completion record types */
 case class CompTy(
-  normal: PureValueTy = PureValueTy.Bot,
+  normal: Option[PureValueTy] = Some(PureValueTy.Bot),
   abrupt: Boolean = false,
 ) extends TyElem
   with Lattice[CompTy] {
@@ -15,14 +15,17 @@ case class CompTy(
 
   /** bottom check */
   def isBottom: Boolean = (this eq Bot) || (
-    this.normal.isBottom &&
+    this.normal.fold(false)(_.isBottom) &&
     !this.abrupt
   )
 
   /** partial order/subset operator */
   def <=(that: => CompTy): Boolean = (this eq that) || (
-    this.normal <= that.normal &&
-    this.abrupt <= that.abrupt
+    ((this.normal, that.normal) match
+      case (_, None)          => true
+      case (None, _)          => false
+      case (Some(l), Some(r)) => l <= r
+    ) && this.abrupt <= that.abrupt
   )
 
   /** union type */
@@ -30,7 +33,10 @@ case class CompTy(
     if (this eq that) this
     else
       CompTy(
-        this.normal || that.normal,
+        (this.normal, that.normal) match
+          case (None, _) | (_, None) => None
+          case (Some(l), Some(r))    => Some(l || r)
+        ,
         this.abrupt || that.abrupt,
       )
 
@@ -39,7 +45,11 @@ case class CompTy(
     if (this eq that) this
     else
       CompTy(
-        this.normal && that.normal,
+        (this.normal, that.normal) match
+          case (None, r)          => r
+          case (l, None)          => l
+          case (Some(l), Some(r)) => Some(l && r)
+        ,
         this.abrupt && that.abrupt,
       )
 
@@ -48,15 +58,20 @@ case class CompTy(
     if (that.isBottom) this
     else
       CompTy(
-        this.normal -- that.normal,
+        (this.normal, that.normal) match
+          case (None, _)          => None
+          case (_, None)          => Some(PureValueTy.Bot)
+          case (Some(l), Some(r)) => Some(l -- r)
+        ,
         this.abrupt -- that.abrupt,
       )
 
   /** get single value */
   def getSingle: Flat[AValue] =
     if (abrupt) Many
-    else normal.getSingle.map(AComp(Const("normal"), _, None))
+    else normal.fold(Many)(_.getSingle.map(AComp(Const("normal"), _, None)))
 }
 object CompTy extends Parser.From(Parser.compTy) {
   val Bot: CompTy = CompTy()
+  val Top = CompTy(None, true)
 }

--- a/src/main/scala/esmeta/ty/NameTy.scala
+++ b/src/main/scala/esmeta/ty/NameTy.scala
@@ -10,6 +10,10 @@ case class NameTy(set: Set[String] = Set())
   import NameTy.*
   import TyModel.es.isSubTy
 
+  if (set contains "any value except a Completion Record")
+    println("???")
+    throw Error("!!!")
+
   /** bottom check */
   def isBottom: Boolean = (this eq Bot) || set.isEmpty
 

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -71,7 +71,7 @@ case class ValueTy(
     subMap.isBottom
 
   /** getters */
-  def normal: PureValueTy = comp.normal
+  def normal: Option[PureValueTy] = comp.normal
   def abrupt: Boolean = comp.abrupt
   def clo: BSet[String] = pureValue.clo
   def cont: BSet[Int] = pureValue.cont
@@ -95,7 +95,7 @@ case class ValueTy(
 object ValueTy {
   def apply(
     comp: CompTy = CompTy.Bot,
-    normal: PureValueTy = PureValueTy.Bot,
+    normal: Option[PureValueTy] = Some(PureValueTy.Bot),
     abrupt: Boolean = false,
     pureValue: PureValueTy = PureValueTy.Bot,
     clo: BSet[String] = Fin(),

--- a/src/main/scala/esmeta/ty/package.scala
+++ b/src/main/scala/esmeta/ty/package.scala
@@ -16,13 +16,14 @@ trait TyElem {
 // -----------------------------------------------------------------------------
 // helpers
 // -----------------------------------------------------------------------------
+val CompT: ValueTy = ValueTy(normal = None, abrupt = true)
 def CompT(normal: ValueTy, abrupt: Boolean): ValueTy =
   if (normal.pureValue.isBottom && !abrupt) ValueTy.Bot
-  else ValueTy(normal = normal.pureValue, abrupt = abrupt)
+  else ValueTy(normal = Some(normal.pureValue), abrupt = abrupt)
 val AbruptT: ValueTy = ValueTy(abrupt = true)
 def NormalT(value: ValueTy): ValueTy =
   if (value.pureValue.isBottom) ValueTy.Bot
-  else ValueTy(normal = value.pureValue)
+  else ValueTy(normal = Some(value.pureValue))
 def SubMapT(key: ValueTy, value: ValueTy): ValueTy =
   if (key.isBottom || value.isBottom) ValueTy.Bot
   else ValueTy(subMap = SubMapTy(key.pureValue, value.pureValue))

--- a/src/main/scala/esmeta/ty/util/Parser.scala
+++ b/src/main/scala/esmeta/ty/util/Parser.scala
@@ -37,8 +37,9 @@ trait Parsers extends BasicParsers {
   }.named("ty.CompTy")
 
   private lazy val singleCompTy: Parser[CompTy] = {
-    "Normal[" ~> pureValueTy <~ "]" ^^ { case v => CompTy(normal = v) } |
-    "Abrupt" ^^^ CompTy(abrupt = true)
+    "Normal" ~> opt("[" ~> pureValueTy <~ "]") ^^ {
+      case v => CompTy(normal = v)
+    } | "Abrupt" ^^^ CompTy(abrupt = true)
   }.named("ty.CompTy (single)")
 
   /** pure value types (non-completion record types) */

--- a/src/main/scala/esmeta/ty/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ty/util/UnitWalker.scala
@@ -33,7 +33,7 @@ trait UnitWalker extends BasicUnitWalker {
 
   /** completion record types */
   def walk(ty: CompTy): Unit =
-    walk(ty.normal)
+    walkOpt(ty.normal, walk)
     walk(ty.abrupt)
 
   /** pure value types */

--- a/src/main/scala/esmeta/ty/util/Walker.scala
+++ b/src/main/scala/esmeta/ty/util/Walker.scala
@@ -35,7 +35,7 @@ trait Walker extends BasicWalker {
 
   /** completion record types */
   def walk(ty: CompTy): CompTy = CompTy(
-    walk(ty.normal),
+    walkOpt(ty.normal, walk),
     walk(ty.abrupt),
   )
 

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -29,7 +29,7 @@ case class Loc(
 
   // TODO short string for the same line (e.g. 3:2-4)
   override def toString: String =
-    s"${start.simpleString}-${end.simpleString} (step $stepString)"
+    s"(step $stepString, ${start.simpleString}-${end.simpleString})"
 
   def stepString: String =
     (for ((step, idx) <- steps.zipWithIndex) yield idx % 3 match

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -59,9 +59,10 @@ object SystemUtils {
     iterable: Iterable[T],
     dirname: String,
     getName: T => String,
+    getData: T => Any = (x: T) => x,
   ): Unit =
     mkdir(dirname)
-    for (data <- iterable) dumpFile(data, s"$dirname/${getName(data)}")
+    for (x <- iterable) dumpFile(getData(x), s"$dirname/${getName(x)}")
     println(s"- Dumped $name into $dirname.")
 
   /** dump given data into a file and show message */

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -752,7 +752,9 @@ class StringifyTinyTest extends LangTest {
       "~end~, ~start~, or ~start+end~",
       Type(ListT(NumberTopT)) -> "a List of Numbers",
       Type(ListT(AstTopT)) -> "a List of Parse Nodes",
-      Type(ListT(StrTopT || UndefT)) -> "a List of Strings or *undefined*",
+      Type(
+        ListT(StrTopT || UndefT),
+      ) -> "a List of either Strings or *undefined*",
       Type(NameT("Environment Record")) -> "an Environment Record",
       Type(NormalT(NumberTopT)) -> "a normal completion containing a Number",
       Type(NormalT(NumberTopT || BigIntT)) ->
@@ -767,6 +769,9 @@ class StringifyTinyTest extends LangTest {
       Type(NullT || ESValueT) -> "an ECMAScript language value",
       Type(ESValueT || AstTopT) ->
       "an ECMAScript language value or a Parse Node",
+      Type(
+        CompT(ListT(StrTopT || NullT), true),
+      ) -> "either a normal completion containing a List of either Strings or *null*, or an abrupt completion",
     )
   }
 

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -21,7 +21,7 @@ class StringifyTinyTest extends SpecTest {
         GrammarSummary(145, 16, 195, 28),
         AlgorithmSummary(2258, 365),
         StepSummary(18307, 754),
-        TypeSummary(0, 7451),
+        TypeSummary(5469, 1543, 439),
         89,
         58,
       ) ->
@@ -38,9 +38,10 @@ class StringifyTinyTest extends SpecTest {
          |- algorithm steps: 19061 (96.04%)
          |  - complete: 18307
          |  - incomplete: 754
-         |- types: 7451 (0.00%)
-         |  - known: 0
-         |  - unknown: 7451
+         |- types: 5908 (92.57%)
+         |  - known: 5469
+         |  - unknown: 1543
+         |  - notyet: 439
          |- tables: 89
          |- type model: 58""".stripMargin,
     )

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -21,7 +21,7 @@ class StringifyTinyTest extends SpecTest {
         GrammarSummary(145, 16, 195, 28),
         AlgorithmSummary(2258, 365),
         StepSummary(18307, 754),
-        TypeSummary(5469, 1543, 439),
+        TypeSummary(5469, 439, 1543),
         89,
         58,
       ) ->
@@ -40,8 +40,8 @@ class StringifyTinyTest extends SpecTest {
          |  - incomplete: 754
          |- types: 5908 (92.57%)
          |  - known: 5469
+         |  - yet: 439
          |  - unknown: 1543
-         |  - notyet: 439
          |- tables: 89
          |- type model: 58""".stripMargin,
     )


### PR DESCRIPTION
Originally, the font option is only applied to spec CFG.
Because we add font option at override toString function at DotPrinter object.
But when dumping analyzer CFG, we use Graph case class.
Thus, I added a font option to the toDot function in the Graph case class.
Also, I fixed the font option Helvetica to Consolas