### PR TITLE
Fix left alignment problem in CFG

### DIFF
--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -194,12 +194,8 @@ trait DotPrinter {
         .escapeHtml(node.toString(detail = false, location = false)),
     )
   }
-  def norm(nodes: Iterable[IRElem]): String = {
-    nodes
-      .map(norm(_))
-      .zipWithIndex
-      .map((ele, idx) => s"""[${idx}] ${ele}""")
-      .mkString("""<BR ALIGN="LEFT"/>""")
-      .concat("""<BR ALIGN="LEFT"/>""")
-  }
+  def norm(insts: Iterable[Inst]): String = (for {
+    (inst, idx) <- insts.zipWithIndex
+    str = norm(inst)
+  } yield s"""[$idx] $str<BR ALIGN="LEFT"/>""").mkString
 }

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -197,6 +197,8 @@ trait DotPrinter {
   def norm(nodes: Iterable[IRElem]): String = {
     nodes
       .map(norm(_))
+      .zipWithIndex
+      .map((ele, idx) => s"""[${idx}] ${ele}""")
       .mkString("""<BR ALIGN="LEFT"/>""")
       .concat("""<BR ALIGN="LEFT"/>""")
   }

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -195,6 +195,9 @@ trait DotPrinter {
     )
   }
   def norm(nodes: Iterable[IRElem]): String = {
-    nodes.map(norm(_)).mkString("""<BR ALIGN="LEFT"/>""")
+    nodes
+      .map(norm(_))
+      .mkString("""<BR ALIGN="LEFT"/>""")
+      .concat("""<BR ALIGN="LEFT"/>""")
   }
 }


### PR DESCRIPTION
Originally, if the upper string is longer than the lower one, they become center-aligned.
Fix this problem by adding \<BR ALIGN="LEFT"/\> tag at the end of the label.