### PR TITLE
Fix font option of CFG

### DIFF
--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -51,7 +51,8 @@ case class Graph(
             val entry = func.entry
             val eid = ViewDotPrinter(returnView).getId(entry)
             for (callNp @ NodePoint(_, call, callView) <- calls)
-              ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
+              ViewDotPrinter(sem.getEntryView(callView))
+                .drawCall(call, eid, app),
     }
     app.toString
 

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -13,42 +13,46 @@ case class Graph(
   // conversion to DOT
   lazy val toDot: String =
     val app = new Appender
-    (app >> "digraph").wrap((curOpt, depthOpt, pathOpt) match
-      case (Some(cp), _, Some(path)) =>
-        val func = cp.func
-        val view = sem.getEntryView(cp.view)
-        val dot = ViewDotPrinter(view)
-        val entry = func.entry
-        var eid = dot.getId(entry)
-        dot.addFunc(func, app)
-        for (np <- path)
-          val func = np.func
-          val view = sem.getEntryView(np.view)
+    (app >> "digraph").wrap {
+      app :> """graph [fontname = "Consolas"]"""
+      app :> """node [fontname = "Consolas"]"""
+      app :> """edge [fontname = "Consolas"]"""
+      (curOpt, depthOpt, pathOpt) match
+        case (Some(cp), _, Some(path)) =>
+          val func = cp.func
+          val view = sem.getEntryView(cp.view)
           val dot = ViewDotPrinter(view)
-          dot.addFunc(func, app)
-          dot.drawCall(np.node, eid, app)
           val entry = func.entry
-          eid = dot.getId(entry)
-      case (Some(cp), Some(depth), _) =>
-        val func = cp.func
-        val view = sem.getEntryView(cp.view)
-        val dot = ViewDotPrinter(view)
-        val rp = ReturnPoint(func, view)
-        dot.addFunc(func, app)
-        showPrev(rp, dot, depth, app)
-      case _ =>
-        val funcs: Set[(Func, View)] =
-          sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
-        for ((func, view) <- funcs)
+          var eid = dot.getId(entry)
+          dot.addFunc(func, app)
+          for (np <- path)
+            val func = np.func
+            val view = sem.getEntryView(np.view)
+            val dot = ViewDotPrinter(view)
+            dot.addFunc(func, app)
+            dot.drawCall(np.node, eid, app)
+            val entry = func.entry
+            eid = dot.getId(entry)
+        case (Some(cp), Some(depth), _) =>
+          val func = cp.func
+          val view = sem.getEntryView(cp.view)
           val dot = ViewDotPrinter(view)
+          val rp = ReturnPoint(func, view)
           dot.addFunc(func, app)
-        // print call edges
-        for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
-          val entry = func.entry
-          val eid = ViewDotPrinter(returnView).getId(entry)
-          for (callNp @ NodePoint(_, call, callView) <- calls)
-            ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
-    )
+          showPrev(rp, dot, depth, app)
+        case _ =>
+          val funcs: Set[(Func, View)] =
+            sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
+          for ((func, view) <- funcs)
+            val dot = ViewDotPrinter(view)
+            dot.addFunc(func, app)
+          // print call edges
+          for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
+            val entry = func.entry
+            val eid = ViewDotPrinter(returnView).getId(entry)
+            for (callNp @ NodePoint(_, call, callView) <- calls)
+              ViewDotPrinter(sem.getEntryView(callView)).drawCall(call, eid, app),
+    }
     app.toString
 
   // show previous traces with depth

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -29,9 +29,9 @@ trait DotPrinter {
   override def toString: String = {
     val app = Appender()
     (app >> "digraph ").wrap {
-      app :> """graph [fontname = "helvetica"]"""
-      app :> """node [fontname = "helvetica"]"""
-      app :> """edge [fontname = "helvetica"]"""
+      app :> """graph [fontname = "Consolas"]"""
+      app :> """node [fontname = "Consolas"]"""
+      app :> """edge [fontname = "Consolas"]"""
       this(app)
     }
     app.toString


### PR DESCRIPTION
Originally, the font option is only applied to spec CFG.
Because we add font option at override toString function at DotPrinter object.
But when dumping analyzer CFG, we use Graph case class.
Thus, I added a font option to the toDot function in the Graph case class.
Also, I fixed the font option Helvetica to Consolas