### PR TITLE
Add colored exit node and Fix call edge to point out the entry node

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsSemantics.scala
+++ b/src/main/scala/esmeta/analyzer/AbsSemantics.scala
@@ -278,17 +278,9 @@ class AbsSemantics(
         val st = this(rp).getString(detail = detail)
         s"""$k -> $st"""
 
-  /** check reachability based on call contexts */
-  def reachable(np: NodePoint[Node]): Boolean =
-    !getNps(np).forall(this(_).isBottom)
-
-  /** get node points */
-  def getNps(givenNp: NodePoint[Node]): Set[NodePoint[Node]] =
-    val entryView = getEntryView(givenNp.view)
-    for {
-      np <- npMap.keySet
-      if givenNp.node == np.node && entryView == getEntryView(np.view)
-    } yield np
+  /** check reachability */
+  def reachable(np: NodePoint[Node]): Boolean = !apply(np).isBottom
+  def reachable(rp: ReturnPoint): Boolean = !apply(rp).isBottom
 
   /** conversion to string */
   override def toString: String = shortString

--- a/src/main/scala/esmeta/analyzer/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/analyzer/util/DotPrinter.scala
@@ -1,6 +1,6 @@
 package esmeta.analyzer.util
 
-import esmeta.*
+import esmeta.ANALYZE_LOG_DIR
 import esmeta.analyzer.*
 import esmeta.cfg.*
 import esmeta.cfg.util.{DotPrinter => CFGDotPrinter}
@@ -9,17 +9,56 @@ import esmeta.util.SystemUtils.*
 import esmeta.util.Appender
 import scala.Console.*
 
-trait DotPrinter extends CFGDotPrinter {
-  val SELECTED = """"gray""""
+class DotPrinter(
+  cp: ControlPoint,
+  cur: Option[ControlPoint] = None,
+) extends CFGDotPrinter(cp.func) {
+  val WORKLIST = """"gray""""
+
+  // helpers for views
+  lazy val view = sem.getEntryView(cp.view)
+  lazy val viewStr: String = norm(view)
+  lazy val rp: ReturnPoint = ReturnPoint(func, view)
+  def getNp[T <: Node](node: T): NodePoint[T] =
+    NodePoint(cfg.funcOf(node), node, view)
+
+  // helpers for functions
+  lazy val func = cp.func
+  override lazy val funcId: String = s"cluster${func.id}_$viewStr"
+  override lazy val funcName: String =
+    norm(func.headString) + (if (view.isEmpty) "" else s" [VIEW: $viewStr]")
+
+  // helpers for function exit
+  override lazy val exitColor: String =
+    if (sem.reachable(rp)) REACH else NON_REACH
+  override lazy val exitBgColor: String =
+    if (cur == Some(rp)) CURRENT
+    else if (sem.worklist has rp) WORKLIST
+    else NORMAL
+  override def exitEdgeColor(from: Node): String =
+    if (sem.reachable(getNp(from)) && sem.reachable(rp)) REACH
+    else NON_REACH
+
+  // helpers for nodes
+  override def getId(node: Node): String = s"node${node.id}_$viewStr"
+  override def getColor(node: Node): String =
+    if (sem.reachable(getNp(node))) REACH else NON_REACH
+  override def getBgColor(node: Node): String =
+    val np = getNp(node)
+    if (cur == Some(np)) CURRENT
+    else if (sem.worklist has np) WORKLIST
+    else NORMAL
+  override def getEdgeColor(from: Node, to: Node): String =
+    if (sem.reachable(getNp(from)) && sem.reachable(getNp(to))) REACH
+    else NON_REACH
 
   // normalize strings for view
   private val normPattern = """[-:\[\](),\s~?"]""".r
-  protected def norm(view: View): String = {
+  protected def norm(view: View): String =
     normPattern.replaceAllIn(view.toString, "_")
-  }
 }
 object DotPrinter {
-
+  // path for CFG
   val CFG_PATH = s"$ANALYZE_LOG_DIR/cfg"
 
   // dump CFG in DOT/PDF format
@@ -46,12 +85,11 @@ object DotPrinter {
   }
 
   // dump DOT
-  def dumpDot(dot: String, pdf: Boolean): Unit = {
+  def dumpDot(dot: String, pdf: Boolean): Unit =
     dumpFile(dot, s"$CFG_PATH.dot")
     if (pdf) {
       executeCmd(s"""unflatten -l 10 -o ${CFG_PATH}_trans.dot $CFG_PATH.dot""")
       executeCmd(s"""dot -Tpdf "${CFG_PATH}_trans.dot" -o "$CFG_PATH.pdf"""")
       println(s"Dumped CFG to $CFG_PATH.pdf")
     } else println(s"Dumped CFG to $CFG_PATH.dot")
-  }
 }

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -36,7 +36,14 @@ case class Graph(
         case (Some(cp), Some(depth), _) =>
           val func = cp.func
           val view = sem.getEntryView(cp.view)
-          val dot = ViewDotPrinter(view)
+          val isReturnPointActivated =
+            (sem.worklist has ReturnPoint(func, view)) || (cp.equals(
+              ReturnPoint(func, view),
+            ))
+          val dot = ViewDotPrinter(
+            view,
+            isReturnPointActivated = isReturnPointActivated,
+          )
           val rp = ReturnPoint(func, view)
           dot.addFunc(func, app)
           showPrev(rp, dot, depth, app)
@@ -88,6 +95,7 @@ case class Graph(
   private case class ViewDotPrinter(
     view: View,
     isExit: Boolean = false,
+    isReturnPointActivated: Boolean = false,
   ) extends DotPrinter {
     def getId(func: Func): String = s"cluster${func.id}_${norm(view)}"
     def getId(node: Node): String = s"node${node.id}_${norm(view)}"

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -36,13 +36,13 @@ case class Graph(
         case (Some(cp), Some(depth), _) =>
           val func = cp.func
           val view = sem.getEntryView(cp.view)
-          val isReturnPointActivated =
+          val isExit =
             (sem.worklist has ReturnPoint(func, view)) || (cp.equals(
               ReturnPoint(func, view),
             ))
           val dot = ViewDotPrinter(
             view,
-            isReturnPointActivated = isReturnPointActivated,
+            isExit,
           )
           val rp = ReturnPoint(func, view)
           dot.addFunc(func, app)
@@ -95,7 +95,6 @@ case class Graph(
   private case class ViewDotPrinter(
     view: View,
     isExit: Boolean = false,
-    isReturnPointActivated: Boolean = false,
   ) extends DotPrinter {
     def getId(func: Func): String = s"cluster${func.id}_${norm(view)}"
     def getId(node: Node): String = s"node${node.id}_${norm(view)}"

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -4,133 +4,81 @@ import esmeta.analyzer.*
 import esmeta.cfg.*
 import esmeta.util.Appender
 
-case class Graph(
+class Graph(
   sem: AbsSemantics,
-  curOpt: Option[ControlPoint],
+  cur: Option[ControlPoint],
   depthOpt: Option[Int],
   pathOpt: Option[Path],
 ) {
-  // conversion to DOT
+
+  /** conversion to a DOT format */
   lazy val toDot: String =
-    val app = new Appender
+    given app: Appender = new Appender
     (app >> "digraph").wrap {
       app :> """graph [fontname = "Consolas"]"""
       app :> """node [fontname = "Consolas"]"""
       app :> """edge [fontname = "Consolas"]"""
-      (curOpt, depthOpt, pathOpt) match
+      (cur, depthOpt, pathOpt) match
         case (Some(cp), _, Some(path)) =>
-          val func = cp.func
-          val view = sem.getEntryView(cp.view)
-          val dot = ViewDotPrinter(view)
-          val entry = func.entry
-          var eid = dot.getId(entry)
-          dot.addFunc(func, app)
-          for (np <- path)
-            val func = np.func
-            val view = sem.getEntryView(np.view)
-            val dot = ViewDotPrinter(view)
-            dot.addFunc(func, app)
-            dot.drawCall(np.node, eid, app)
-            val entry = func.entry
-            eid = dot.getId(entry)
+          var calleePrinter = DotPrinter(cp, cur)
+          calleePrinter.addTo(app)
+          for (callerNp <- path)
+            val callerPrinter = DotPrinter(callerNp)
+            callerPrinter.addTo(app)
+            drawCall(callerPrinter, callerNp.node, calleePrinter)
+            calleePrinter = callerPrinter
         case (Some(cp), Some(depth), _) =>
-          val func = cp.func
-          val view = sem.getEntryView(cp.view)
-          val isExitWorklist = sem.worklist has ReturnPoint(func, view)
-          val isExit = cp.equals(ReturnPoint(func, view))
-          val dot = ViewDotPrinter(
-            view,
-            isExit,
-            isExitWorklist,
-          )
-          val rp = ReturnPoint(func, view)
-          dot.addFunc(func, app)
-          showPrev(rp, dot, depth, app)
+          var printer = DotPrinter(cp, cur)
+          printer.addTo(app)
+          showPrev(printer, depth)
         case _ =>
-          val funcs: Set[(Func, View)] =
-            sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
-          for ((func, view) <- funcs)
-            val isExitWorklist = sem.worklist has ReturnPoint(func, view)
-            val isExit = sem.curCp match
-              case Some(x) => x.equals(ReturnPoint(func, view))
-              case None    => false
-            val dot = ViewDotPrinter(view, isExit)
-            dot.addFunc(func, app)
-          // print call edges
-          for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
-            val eid = s"""${ViewDotPrinter(returnView).getId(func)}_entry"""
-            for (callNp @ NodePoint(_, call, callView) <- calls)
-              ViewDotPrinter(sem.getEntryView(callView))
-                .drawCall(call, eid, app),
+          var visited = Set[ReturnPoint]()
+          for {
+            (calleeRp, callerNps) <- sem.retEdges
+            callerNp <- callerNps
+            calleePrinter = DotPrinter(calleeRp, cur)
+            callerPrinter = DotPrinter(callerNp, cur)
+            callerRp = callerPrinter.rp
+          } {
+            if (!visited.contains(calleeRp))
+              visited += calleeRp
+              calleePrinter.addTo(app)
+            if (!visited.contains(callerRp))
+              visited += callerRp
+              callerPrinter.addTo(app)
+            drawCall(callerPrinter, callerNp.node, calleePrinter)
+          }
     }
     app.toString
 
   // show previous traces with depth
   def showPrev(
-    rp: ReturnPoint,
-    dot: DotPrinter,
+    printer: DotPrinter,
     depth: Int,
-    app: Appender,
-  ): Unit =
-    var visited = Set[ReturnPoint]()
-    def aux(
-      rp: ReturnPoint,
-      dot: DotPrinter,
-      depth: Int,
-    ): Unit = if (depth > 0) {
-      val entry = rp.func.entry
-      val entryNp = NodePoint(_, entry, rp.view)
-      val eid = dot.getId(entry)
-      for (callNp @ NodePoint(_, call, callView) <- sem.getRetEdges(rp))
-        val func = callNp.func
-        val entryView = sem.getEntryView(callView)
-        val callRp = ReturnPoint(func, entryView)
-        val callDot = ViewDotPrinter(entryView)
-        if (!(visited contains callRp))
-          visited += callRp
-          callDot.addFunc(func, app)
-          aux(callRp, callDot, depth - 1)
-        callDot.drawCall(call, eid, app)
+  )(using app: Appender): Unit =
+    var visited = Set[ReturnPoint](printer.rp)
+    def aux(calleePrinter: DotPrinter, depth: Int): Unit = if (depth > 0) {
+      val calleeRp = calleePrinter.rp
+      for (callerNp @ NodePoint(_, call, callView) <- sem.getRetEdges(calleeRp))
+        val callerPrinter = DotPrinter(callerNp)
+        val callerRp = callerPrinter.rp
+        if (!visited.contains(callerRp))
+          visited += callerRp
+          callerPrinter.addTo(app)
+          aux(callerPrinter, depth - 1)
+        drawCall(callerPrinter, callerNp.node, calleePrinter)
     }
-    aux(rp, dot, depth)
+    aux(printer, depth)
 
-  private case class ViewDotPrinter(
-    view: View,
-    isExit: Boolean = false,
-    isExitWorklist: Boolean = false,
-  ) extends DotPrinter {
-    def getId(func: Func): String = s"cluster${func.id}_${norm(view)}"
-    def getId(node: Node): String = s"node${node.id}_${norm(view)}"
-    def getName(func: Func): String =
-      val funcName = func.headString.replaceAll("\"", "\\\\\"")
-      val viewName =
-        if (view.isEmpty) ""
-        else " [VIEW: " + view.toString.replaceAll("\"", "\\\\\"") + "]"
-      s"$funcName$viewName"
-    def getColor(node: Node, isExit: Boolean = false): String =
-      val np = NodePoint(cfg.funcOf(node), node, view)
-      if (isExit && !sem.rpMap.isEmpty) REACH
-      else if (!isExit && sem.reachable(np)) REACH
-      else NON_REACH
-    def getEdgeColor(from: Node, to: Node, isExit: Boolean = false): String =
-      val fromNP = NodePoint(cfg.funcOf(from), from, view)
-      val toNP = NodePoint(cfg.funcOf(to), to, view)
-      if (isExit && sem.reachable((fromNP)) && !sem.rpMap.isEmpty) REACH
-      else if (!isExit && sem.reachable(fromNP) && sem.reachable(toNP)) REACH
-      else NON_REACH
-    def getBgColor(node: Node): String =
-      val np = NodePoint(cfg.funcOf(node), node, view)
-      val nps = sem.getNps(np).toSet[ControlPoint]
-      if (curOpt.fold(false)(nps contains _)) CURRENT
-      else if (nps.exists(sem.worklist has _)) SELECTED
-      else NORMAL
-    def apply(app: Appender): Unit = {}
-    def drawCall(
-      call: Call,
-      entryId: String,
-      app: Appender,
-    ): Unit = drawEdge(getId(call), entryId, REACH, Some("call"), app)
-  }
+  // draw call edges
+  def drawCall(
+    callerPrinter: DotPrinter,
+    call: Call,
+    calleePrinter: DotPrinter,
+  )(using app: Appender): Unit =
+    val cid = callerPrinter.getId(call)
+    val eid = calleePrinter.entryId
+    app :> s"$cid -> $eid [label=call]"
 }
 
 // path type

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -51,7 +51,12 @@ case class Graph(
           val funcs: Set[(Func, View)] =
             sem.npMap.keySet.map(np => (np.func, sem.getEntryView(np.view)))
           for ((func, view) <- funcs)
-            val dot = ViewDotPrinter(view)
+            val isExit =
+              (sem.worklist has ReturnPoint(func, view)) || (sem.curCp match {
+                case Some(x) => x.equals(ReturnPoint(func, view))
+                case None    => false
+              })
+            val dot = ViewDotPrinter(view, isExit)
             dot.addFunc(func, app)
           // print call edges
           for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)

--- a/src/main/scala/esmeta/analyzer/util/Graph.scala
+++ b/src/main/scala/esmeta/analyzer/util/Graph.scala
@@ -60,8 +60,7 @@ case class Graph(
             dot.addFunc(func, app)
           // print call edges
           for ((ReturnPoint(func, returnView), calls) <- sem.retEdges)
-            val entry = func.entry
-            val eid = ViewDotPrinter(returnView).getId(entry)
+            val eid = s"""${ViewDotPrinter(returnView).getId(func)}_entry"""
             for (callNp @ NodePoint(_, call, callView) <- calls)
               ViewDotPrinter(sem.getEntryView(callView))
                 .drawCall(call, eid, app),

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -78,8 +78,14 @@ case class Func(
 
   /** conversion to a DOT format */
   def dot: String = toDot()
-  def toDot(nid: Int = -1, _isExit: Boolean = false): String = new DotPrinter {
+  def toDot(
+    nid: Int = -1,
+    _isExit: Boolean = false,
+    _isReturnPointActivated: Boolean = false,
+  ): String = new DotPrinter {
     val isExit: Boolean = _isExit
+
+    val isReturnPointActivated: Boolean = _isReturnPointActivated
     def getId(func: Func): String = s"cluster${func.id}"
     def getId(node: Node): String = s"node${node.id}"
     def getName(func: Func): String = func.headString

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -81,11 +81,8 @@ case class Func(
   def toDot(
     nid: Int = -1,
     _isExit: Boolean = false,
-    _isReturnPointActivated: Boolean = false,
   ): String = new DotPrinter {
     val isExit: Boolean = _isExit
-
-    val isReturnPointActivated: Boolean = _isReturnPointActivated
     def getId(func: Func): String = s"cluster${func.id}"
     def getId(node: Node): String = s"node${node.id}"
     def getName(func: Func): String = func.headString

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -81,13 +81,16 @@ case class Func(
   def toDot(
     nid: Int = -1,
     _isExit: Boolean = false,
+    _isExitWorklist: Boolean = false,
   ): String = new DotPrinter {
     val isExit: Boolean = _isExit
+    val isExitWorklist: Boolean = _isExitWorklist
     def getId(func: Func): String = s"cluster${func.id}"
     def getId(node: Node): String = s"node${node.id}"
     def getName(func: Func): String = func.headString
-    def getColor(node: Node): String = REACH
-    def getColor(from: Node, to: Node): String = REACH
+    def getColor(node: Node, isExit: Boolean = false): String = REACH
+    def getEdgeColor(from: Node, to: Node, isExit: Boolean = false): String =
+      REACH
     def getBgColor(node: Node): String =
       if (node.id == nid) CURRENT else NORMAL
     def apply(app: Appender): Unit = addFunc(func, app)

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -1,6 +1,6 @@
 package esmeta.cfg
 
-import esmeta.cfg.util.*
+import esmeta.cfg.util.{DotPrinter => CFGDotPrinter, *}
 import esmeta.ir.{Param, Type, Name, Func => IRFunc, FuncKind, EYet}
 import esmeta.spec.Head
 import esmeta.ty.*
@@ -78,23 +78,8 @@ case class Func(
 
   /** conversion to a DOT format */
   def dot: String = toDot()
-  def toDot(
-    nid: Int = -1,
-    _isExit: Boolean = false,
-    _isExitWorklist: Boolean = false,
-  ): String = new DotPrinter {
-    val isExit: Boolean = _isExit
-    val isExitWorklist: Boolean = _isExitWorklist
-    def getId(func: Func): String = s"cluster${func.id}"
-    def getId(node: Node): String = s"node${node.id}"
-    def getName(func: Func): String = func.headString
-    def getColor(node: Node, isExit: Boolean = false): String = REACH
-    def getEdgeColor(from: Node, to: Node, isExit: Boolean = false): String =
-      REACH
-    def getBgColor(node: Node): String =
-      if (node.id == nid) CURRENT else NORMAL
-    def apply(app: Appender): Unit = addFunc(func, app)
-  }.toString
+  def toDot(targetId: Int = -1, isExit: Boolean = false): String =
+    new Func.DotPrinter(this, targetId, isExit).toString
 
   /** dump in a DOT format */
   def dumpDot(
@@ -117,4 +102,23 @@ case class Func(
     dotPath: String,
     pdfPath: String,
   ): Unit = dumpDot(dotPath, Some(pdfPath))
+}
+object Func {
+  class DotPrinter(
+    func: Func,
+    targetId: Int = -1,
+    isExit: Boolean = false,
+  ) extends CFGDotPrinter(func) {
+    override lazy val exitBgColor: String = if (isExit) CURRENT else NORMAL
+    override def getBgColor(node: Node): String =
+      if (node.id == targetId) CURRENT else NORMAL
+    override def toString: String =
+      val app = new Appender
+      (app >> "digraph ").wrap {
+        app :> """graph [fontname = "Consolas"]"""
+        app :> """node [fontname = "Consolas"]"""
+        app :> """edge [fontname = "Consolas"]"""
+        addTo(app)
+      }.toString
+  }
 }

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -89,7 +89,7 @@ class DotPrinter(
           case Some(next) =>
             drawEdge(id, getId(next), getEdgeColor(node, next), None)
           case None =>
-            val edgeColor = getEdgeColor(node, node)
+            val edgeColor = exitEdgeColor(node)
             drawEdge(id.toString, exitId, edgeColor, None)
       case Call(_, callInst, nextOpt) =>
         val simpleString = callInst match

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -9,7 +9,6 @@ import scala.collection.mutable.Queue
 trait DotPrinter {
   // exit
   val isExit: Boolean
-  val isReturnPointActivated: Boolean
 
   // helpers
   def getId(func: Func): String
@@ -25,7 +24,6 @@ trait DotPrinter {
   val NON_REACH = """"gray""""
   val NORMAL = """"white""""
   val CURRENT = """"powderblue""""
-  val EXIT = """"red""""
 
   // conversion to string
   override def toString: String = {
@@ -90,8 +88,7 @@ trait DotPrinter {
     val exitId = s"${funcId}_exit"
     val nodeColor = getColor(node)
     val edgeColor = getColor(node, node)
-    val bgColor =
-      if (isExit) CURRENT else if (isReturnPointActivated) EXIT else NORMAL
+    val bgColor = if (isExit) CURRENT else NORMAL
     drawNamingNode(exitId, nodeColor, "Exit", app)
     drawNamingEdge(exitId, nodeColor, app)
     drawNode(exitId, "circle", nodeColor, bgColor, None, app)

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -6,115 +6,92 @@ import esmeta.ir.{Func => IRFunc, *}
 import esmeta.util.{Appender, HtmlUtils}
 import scala.collection.mutable.Queue
 
-trait DotPrinter {
-  // exit
-  val isExit: Boolean
-  val isExitWorklist: Boolean
+/** printer for Graphviz DOT format */
+class DotPrinter(
+  func: Func,
+) {
+  // helpers for functions
+  lazy val funcId: String = s"cluster${func.id}"
+  lazy val funcName: String = norm(func.headString)
 
-  // helpers
-  def getId(func: Func): String
-  def getId(node: Node): String
-  def getName(func: Func): String
-  def getColor(node: Node, isExit: Boolean = false): String
-  def getEdgeColor(from: Node, to: Node, isExit: Boolean = false): String
-  def getBgColor(node: Node): String
-  def apply(app: Appender): Unit
+  // helpers for function entry
+  lazy val entryId: String = s"${funcId}_entry"
+  lazy val entryColor: String = REACH
+  lazy val entryBgColor: String = NORMAL
+  lazy val entryEdgeColor: String = REACH
+
+  // helpers for function exit
+  lazy val exitId: String = s"${funcId}_exit"
+  lazy val exitColor: String = REACH
+  lazy val exitBgColor: String = NORMAL
+  def exitEdgeColor(from: Node): String = REACH
+
+  // helpers for nodes
+  def getId(node: Node): String = s"node${node.id}"
+  def getColor(node: Node): String = REACH
+  def getBgColor(node: Node): String = NORMAL
+  def getEdgeColor(from: Node, to: Node): String = REACH
 
   // colors
-  val REACH = """"black""""
-  val NON_REACH = """"gray""""
-  val NORMAL = """"white""""
-  val CURRENT = """"powderblue""""
-
-  // conversion to string
-  override def toString: String = {
-    val app = Appender()
-    (app >> "digraph ").wrap {
-      app :> """graph [fontname = "Consolas"]"""
-      app :> """node [fontname = "Consolas"]"""
-      app :> """edge [fontname = "Consolas"]"""
-      this(app)
-    }
-    app.toString
-  }
+  def REACH = """"black""""
+  def NON_REACH = """"gray""""
+  def NORMAL = """"white""""
+  def CURRENT = """"powderblue""""
 
   // functions
-  def addFunc(func: Func, app: Appender): Unit = {
-    val appEdge = Appender()
-    val id = getId(func)
-    val name = getName(func)
-    (app :> s"subgraph $id ").wrap {
-      appEdge.wrap("", "") {
-        app :> s"""label = "$name""""
-        app :> s"""style = rounded"""
-        drawReachables(func.entry, id, app)
-      }
+  def addTo(app: Appender): Appender =
+    (app :> "subgraph " >> funcId >> " ").wrap {
+      given Appender = app
+      app :> "label = \"" >> funcName >> "\""
+      app :> "style = rounded"
+      val entry = func.entry
+      var visited = Set[Node](entry)
+      var queue = Queue[Node](entry)
+      def add(nodeOpt: Option[Node]): Unit = for {
+        node <- nodeOpt
+        if !visited.contains(node)
+        _ = queue.enqueue(node)
+        _ = visited += node
+      } ()
+      drawEntry
+      drawExit
+      while (!queue.isEmpty)
+        val cur = queue.dequeue
+        drawNodeWithEdge(cur)
+        cur match
+          case block: Block   => add(block.next)
+          case call: Call     => add(call.next)
+          case branch: Branch => add(branch.thenNode); add(branch.elseNode)
     }
-  }
 
-  def drawReachables(node: Node, funcId: String, app: Appender): Unit = {
-    var visited = Set[Node](node)
-    var queue = Queue[Node](node)
-    def add(nodeOpt: Option[Node]): Unit = nodeOpt.map { node =>
-      if (!visited.contains(node)) { queue.enqueue(node); visited += node }
-    }
-    drawEntry(node, funcId, app)
-    drawExit(node, funcId, app)
-    while (!queue.isEmpty) {
-      val curr = queue.dequeue
-      drawCfgNode(curr, funcId, app)
-      curr match {
-        case block: Block   => add(block.next)
-        case call: Call     => add(call.next)
-        case branch: Branch => add(branch.thenNode); add(branch.elseNode)
-      }
-    }
-  }
+  // ---------------------------------------------------------------------------
+  // protected helper functions
+  // ---------------------------------------------------------------------------
+  protected def drawEntry(using Appender): Unit =
+    drawNaming(entryId, entryColor, "Entry")
+    drawNode(entryId, "circle", entryColor, entryBgColor, None)
+    drawEdge(entryId, getId(func.entry), entryEdgeColor, None)
 
-  def drawEntry(node: Node, funcId: String, app: Appender): Unit = {
-    val nodeId = getId(node)
-    val entryId = s"${funcId}_entry"
-    val nodeColor = getColor(node)
-    val edgeColor = getEdgeColor(node, node)
-    // val bgColor = getBgColor(node)
-    val bgColor = NORMAL
-    drawNamingNode(entryId, nodeColor, "Entry", app)
-    drawNamingEdge(entryId, nodeColor, app)
-    drawNode(entryId, "circle", nodeColor, bgColor, None, app)
-    drawEdge(entryId, nodeId, edgeColor, None, app)
-  }
+  protected def drawExit(using Appender): Unit =
+    drawNaming(exitId, exitColor, "Exit")
+    drawNode(exitId, "circle", exitColor, exitBgColor, None)
 
-  def drawExit(node: Node, funcId: String, app: Appender): Unit = {
-    val nodeId = getId(node)
-    val exitId = s"${funcId}_exit"
-    val nodeColor = getColor(node, true)
-    val edgeColor = getEdgeColor(node, node)
-    val bgColor =
-      if (isExit) CURRENT else if (isExitWorklist) NON_REACH else NORMAL
-    drawNamingNode(exitId, nodeColor, "Exit", app)
-    drawNamingEdge(exitId, nodeColor, app)
-    drawNode(exitId, "circle", nodeColor, bgColor, None, app)
-  }
-
-  def drawCfgNode(node: Node, funcId: String, app: Appender): Unit = {
+  protected def drawNodeWithEdge(node: Node)(using Appender): Unit =
     val id = getId(node)
     val nodeColor = getColor(node)
-    val edgeColor = getEdgeColor(node, node)
     val bgColor = getBgColor(node)
-    drawNamingNode(id, nodeColor, node.simpleString, app)
-    drawNamingEdge(id, nodeColor, app)
-    node match {
-      case Block(_, insts, nextOpt) => {
-        drawNode(id, "box", nodeColor, bgColor, Some(norm(insts)), app)
-        nextOpt match {
+    val edgeColor = getEdgeColor(node, node)
+    drawNaming(id, nodeColor, node.simpleString)
+    node match
+      case Block(_, insts, nextOpt) =>
+        drawNode(id, "box", nodeColor, bgColor, Some(norm(insts)))
+        nextOpt match
           case Some(next) =>
-            drawEdge(id, getId(next), getEdgeColor(node, next), None, app)
+            drawEdge(id, getId(next), getEdgeColor(node, next), None)
           case None =>
-            val edgeColor = getEdgeColor(node, node, true)
-            drawEdge(id.toString, s"${funcId}_exit", edgeColor, None, app)
-        }
-      }
-      case Call(_, callInst, nextOpt) => {
+            val edgeColor = getEdgeColor(node, node)
+            drawEdge(id.toString, exitId, edgeColor, None)
+      case Call(_, callInst, nextOpt) =>
         val simpleString = callInst match
           case ICall(lhs, fexpr, args) =>
             s"${norm(lhs)} = ${norm(fexpr)}(${args.map(norm(_)).mkString(", ")})"
@@ -122,82 +99,60 @@ trait DotPrinter {
             s"${norm(lhs)} = ${norm(base)}-&gt;${norm(method)}(${args.map(norm(_)).mkString(", ")})"
           case ISdoCall(lhs, ast, method, args) =>
             s"${norm(lhs)} = ${norm(ast)}-&gt;$method(${args.map(norm(_)).mkString(", ")})"
-        drawNode(id, "cds", nodeColor, bgColor, Some(simpleString), app)
-        nextOpt match {
+        drawNode(id, "cds", nodeColor, bgColor, Some(simpleString))
+        nextOpt match
           case Some(next) =>
-            drawEdge(id, getId(next), getEdgeColor(node, next), None, app)
+            drawEdge(id, getId(next), getEdgeColor(node, next), None)
           case None =>
-            drawEdge(id.toString, s"${funcId}_exit", edgeColor, None, app)
-        }
-      }
-      case Branch(_, kind, cond, thenOpt, elseOpt) => {
-        drawNode(id, "diamond", nodeColor, bgColor, Some(norm(cond)), app)
+            drawEdge(id.toString, exitId, edgeColor, None)
+      case Branch(_, kind, cond, thenOpt, elseOpt) =>
+        drawNode(id, "diamond", nodeColor, bgColor, Some(norm(cond)))
         thenOpt.map { thn =>
-          drawEdge(id, getId(thn), getEdgeColor(node, thn), Some("true"), app),
+          drawEdge(id, getId(thn), getEdgeColor(node, thn), Some("true")),
         }
         elseOpt.map { els =>
-          drawEdge(id, getId(els), getEdgeColor(node, els), Some("false"), app),
+          drawEdge(id, getId(els), getEdgeColor(node, els), Some("false")),
         }
-      }
-    }
-  }
 
-  def drawNode(
+  protected def drawNode(
     dotId: String,
     shape: String,
     color: String,
     bgColor: String,
     labelOpt: Option[String],
-    app: Appender,
-  ): Unit = {
-    labelOpt match {
-      case Some(label) =>
-        app :> s"""$dotId [shape=$shape, label=<<font color=$color>$label</font>> color=$color fillcolor=$bgColor, style=filled]"""
-      case None =>
-        app :> s"""$dotId [shape=$shape label=" " color=$color fillcolor=$bgColor style=filled]"""
-    }
-  }
+  )(using app: Appender): Unit = labelOpt match
+    case Some(label) =>
+      app :> s"""$dotId [shape=$shape, label=<<font color=$color>$label</font>> color=$color fillcolor=$bgColor, style=filled]"""
+    case None =>
+      app :> s"""$dotId [shape=$shape label=" " color=$color fillcolor=$bgColor style=filled]"""
 
-  def drawEdge(
+  protected def drawEdge(
     fid: String,
     tid: String,
     color: String,
     labelOpt: Option[String],
-    app: Appender,
-  ): Unit = {
+  )(using app: Appender): Unit =
     app :> s"$fid -> $tid ["
     labelOpt.map { label =>
       app >> s"label=<<font color=$color>$label</font>> "
     }
     app >> s"color=$color]"
-  }
 
-  def drawNamingNode(
+  protected def drawNaming(
     id: String,
     color: String,
     name: String,
-    app: Appender,
-  ): Unit = {
-    app :> s"""${id}_name [shape=none, label=<<font color=$color>$name</font>>]"""
-  }
+  )(using app: Appender): Unit =
+    app :> id >> "_name [shape=none, "
+    app >> "label=<<font color=" >> color >> ">" >> name >> "</font>>]"
+    app :> id >> "_name -> " >> id
+    app >> " [arrowhead=none, color=" >> color >> ", style=dashed]"
 
-  def drawNamingEdge(
-    id: String,
-    color: String,
-    app: Appender,
-  ): Unit = {
-    app :> s"""${id}_name -> $id [arrowhead=none, color=$color, style=dashed]"""
-  }
-
-  def norm(str: String): String = str
-    .replaceAll("\u0000", "U+0000")
-  def norm(node: IRElem): String = {
-    norm(
-      HtmlUtils
-        .escapeHtml(node.toString(detail = false, location = false)),
-    )
-  }
-  def norm(insts: Iterable[Inst]): String = (for {
+  def norm(str: String): String =
+    HtmlUtils.escapeHtml(str).replaceAll("\u0000", "U+0000")
+  def norm(node: IRElem): String =
+    norm(node.toString(detail = false, location = false))
+  protected def norm(insts: Iterable[Inst]): String = (for {
     (inst, idx) <- insts.zipWithIndex
     str = norm(inst)
   } yield s"""[$idx] $str<BR ALIGN="LEFT"/>""").mkString

--- a/src/main/scala/esmeta/cfg/util/DotPrinter.scala
+++ b/src/main/scala/esmeta/cfg/util/DotPrinter.scala
@@ -9,6 +9,7 @@ import scala.collection.mutable.Queue
 trait DotPrinter {
   // exit
   val isExit: Boolean
+  val isReturnPointActivated: Boolean
 
   // helpers
   def getId(func: Func): String
@@ -24,6 +25,7 @@ trait DotPrinter {
   val NON_REACH = """"gray""""
   val NORMAL = """"white""""
   val CURRENT = """"powderblue""""
+  val EXIT = """"red""""
 
   // conversion to string
   override def toString: String = {
@@ -88,7 +90,8 @@ trait DotPrinter {
     val exitId = s"${funcId}_exit"
     val nodeColor = getColor(node)
     val edgeColor = getColor(node, node)
-    val bgColor = if (isExit) CURRENT else NORMAL
+    val bgColor =
+      if (isExit) CURRENT else if (isReturnPointActivated) EXIT else NORMAL
     drawNamingNode(exitId, nodeColor, "Exit", app)
     drawNamingEdge(exitId, nodeColor, app)
     drawNode(exitId, "circle", nodeColor, bgColor, None, app)


### PR DESCRIPTION
I added a colored exit node when ReturnPoint is the current control point or in the current worklist.
I fixed the call edge to point out the entry node. Originally, it pointed next node of the entry node.