### PR TITLE
Dev runtime typechecker

### DIFF
--- a/.completion
+++ b/.completion
@@ -19,7 +19,7 @@ _esmeta_completions() {
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:ignore -tycheck:log"
   parseOpt="-parse:debug"
-  evalOpt="-eval:timeout -eval:log"
+  evalOpt="-eval:timeout -eval:tycheck -eval:log"
   webOpt="-web:port"
   test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log"
   injectOpt="-inject:defs -inject:out -inject:log"

--- a/.completion
+++ b/.completion
@@ -19,7 +19,7 @@ _esmeta_completions() {
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:ignore -tycheck:log"
   parseOpt="-parse:debug"
-  evalOpt="-eval:timeout -eval:tycheck -eval:log"
+  evalOpt="-eval:timeout -eval:tycheck -eval:multiple -eval:log"
   webOpt="-web:port"
   test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log"
   injectOpt="-inject:defs -inject:out -inject:log"

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val langStringifyTest =
 
 // ty
 lazy val tyTest = taskKey[Unit]("Launch ty tests")
+lazy val tyContainsTest = taskKey[Unit]("Launch contains tests for ty (tiny)")
 lazy val tyStringifyTest =
   taskKey[Unit]("Launch stringify tests for ty (tiny)")
 
@@ -213,6 +214,9 @@ lazy val root = project
       .value,
     // ty
     tyTest := (Test / testOnly).toTask(" *.ty.*Test").value,
+    tyContainsTest := (Test / testOnly)
+      .toTask(" *.ty.Contains*Test")
+      .value,
     tyStringifyTest := (Test / testOnly)
       .toTask(" *.ty.Stringify*Test")
       .value,

--- a/src/main/resources/manuals/d711ba960cd12b76/tycheck-ignore.json
+++ b/src/main/resources/manuals/d711ba960cd12b76/tycheck-ignore.json
@@ -1,4 +1,5 @@
 [
+  "AddEntriesFromIterable",
   "AsyncGeneratorBody[0,0].EvaluateAsyncGeneratorBody",
   "BoundFunctionCreate",
   "CaseBlock[0,1].CaseBlockEvaluation",

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -8,8 +8,8 @@
 - algorithms: 2623 (87.08%)
   - complete: 2284
   - incomplete: 339
-- algorithm steps: 19063 (96.33%)
-  - complete: 18363
+- algorithm steps: 19062 (96.33%)
+  - complete: 18362
   - incomplete: 700
 - types: 5908 (92.16%)
   - known: 5445

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -721,8 +721,6 @@ class Compiler(
       case ExpressionCondition(expr) =>
         compile(fb, expr)
       case InstanceOfCondition(expr, neg, tys) =>
-        // val (x, xExpr) = fb.newTIdWithExpr
-        // fb.addInst(IAssign(x, compile(fb, expr)))
         val xExpr = compile(fb, expr)
         val e =
           tys

--- a/src/main/scala/esmeta/error/InterpreterError.scala
+++ b/src/main/scala/esmeta/error/InterpreterError.scala
@@ -5,6 +5,7 @@ import esmeta.es.*
 import esmeta.ir.*
 import esmeta.cfg.*
 import esmeta.state.*
+import esmeta.ty.*
 
 // TODO change to abstract class after refactoring of error in interp
 sealed class InterpreterError(msg: String)
@@ -37,6 +38,8 @@ case class InvalidExit(value: Value)
   extends InterpreterError(s"return not undefined: $value")
 case class InvalidASTChildren(ast: Ast)
   extends InterpreterError(s"no children for lexical node: ${ast.name}")
+case class InvalidTypedValue(value: Value, ty: Ty)
+  extends InterpreterError(s"unexpected typed value: $value (expected: $ty)")
 
 // invalid operands for an operator
 case class InvalidUnaryOp(uop: UOp, v: Value)

--- a/src/main/scala/esmeta/es/Ast.scala
+++ b/src/main/scala/esmeta/es/Ast.scala
@@ -20,6 +20,12 @@ sealed trait Ast extends ESElem with Locational {
     case lex: Lexical               => 0
     case Syntactic(_, _, rhsIdx, _) => rhsIdx
 
+  /** sub index */
+  def subIdx: Int = this match
+    case lex: Lexical => 0
+    case Syntactic(_, _, _, children) =>
+      children.map(child => if (child.isDefined) 1 else 0).fold(0)(_ * 2 + _)
+
   /** validity check */
   def valid(grammar: Grammar): Boolean = AstValidityChecker(grammar, this)
 

--- a/src/main/scala/esmeta/es/Initialize.scala
+++ b/src/main/scala/esmeta/es/Initialize.scala
@@ -12,11 +12,16 @@ import scala.collection.mutable.{Map => MMap}
 class Initialize(cfg: CFG) {
 
   /** the result state of initialization */
-  def getResult(sourceText: String, cachedAst: Option[Ast]): State = State(
+  def getResult(
+    sourceText: String,
+    cachedAst: Option[Ast],
+    filename: Option[String],
+  ): State = State(
     cfg,
     context = Context(cfg.main),
     sourceText = Some(sourceText),
     cachedAst = cachedAst,
+    filename = filename,
     globals = MMap.from(initGlobal + (Global(SOURCE_TEXT) -> Str(sourceText))),
     heap = initHeap,
   )
@@ -202,9 +207,10 @@ object Initialize {
     cfg: CFG,
     sourceText: String,
     cachedAst: Option[Ast] = None,
-  ): State = new Initialize(cfg).getResult(sourceText, cachedAst)
+    filename: Option[String] = None,
+  ): State = new Initialize(cfg).getResult(sourceText, cachedAst, filename)
 
   /** initialize from file */
   def fromFile(cfg: CFG, filename: String): State =
-    apply(cfg, readFile(filename))
+    apply(cfg, readFile(filename), filename = Some(filename))
 }

--- a/src/main/scala/esmeta/injector/ExitStateExtractor.scala
+++ b/src/main/scala/esmeta/injector/ExitStateExtractor.scala
@@ -2,6 +2,7 @@ package esmeta.injector
 
 import esmeta.error.*
 import esmeta.interpreter.Interpreter
+import esmeta.ir.Return
 import esmeta.state.*
 import scala.collection.mutable.{Map => MMap}
 
@@ -17,8 +18,8 @@ class ExitStateExtractor(val initSt: State) extends Interpreter(initSt) {
     catch { case e: InterpreterError => throw InterpreterErrorAt(e, cursor) }
 
   /** hook return points to keep address name mapping */
-  override def setReturn(value: Value): Unit = {
-    super.setReturn(value)
+  override def setReturn(value: Value, ret: Return): Unit = {
+    super.setReturn(value, ret)
     if (this.st.context.name == "MakeBasicObject") {
       val contexts = (this.st.context :: this.st.callStack.map(_.context))
         .filter(c => c.func.isSDO || c.func.isBuiltin)

--- a/src/main/scala/esmeta/interpreter/ReturnValue.scala
+++ b/src/main/scala/esmeta/interpreter/ReturnValue.scala
@@ -1,6 +1,7 @@
 package esmeta.interpreter
 
+import esmeta.ir.Return
 import esmeta.state.Value
 
 /** special class for handle return */
-case class ReturnValue(value: Value) extends Throwable
+case class ReturnValue(value: Value, ret: Return) extends Throwable

--- a/src/main/scala/esmeta/phase/Eval.scala
+++ b/src/main/scala/esmeta/phase/Eval.scala
@@ -19,7 +19,12 @@ case object Eval extends Phase[CFG, State] {
   ): State =
     val filename = getFirstFilename(cmdConfig, this.name)
     val initSt = Initialize.fromFile(cfg, filename)
-    val st = Interpreter(initSt, log = config.log, timeLimit = config.timeLimit)
+    val st = Interpreter(
+      initSt,
+      log = config.log,
+      timeLimit = config.timeLimit,
+      tycheck = config.tycheck,
+    )
     st
   def defaultConfig: Config = Config()
   val options: List[PhaseOption[Config]] = List(
@@ -29,6 +34,11 @@ case object Eval extends Phase[CFG, State] {
       "set the time limit in seconds (default: no limit).",
     ),
     (
+      "tycheck",
+      BoolOption(c => c.tycheck = true),
+      "turn on type check mode.",
+    ),
+    (
       "log",
       BoolOption(c => c.log = true),
       "turn on logging mode.",
@@ -36,6 +46,7 @@ case object Eval extends Phase[CFG, State] {
   )
   case class Config(
     var timeLimit: Option[Int] = None,
+    var tycheck: Boolean = false,
     var log: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/state/Context.scala
+++ b/src/main/scala/esmeta/state/Context.scala
@@ -22,7 +22,7 @@ case class Context(
     case _                        => error("cursor can't move to next")
 
   /** return variable */
-  var retVal: Option[Value] = None
+  var retVal: Option[(Return, Value)] = None
 
   /** copy contexts */
   def copied: Context = {

--- a/src/main/scala/esmeta/state/Value.scala
+++ b/src/main/scala/esmeta/state/Value.scala
@@ -90,15 +90,21 @@ given Ordering[Addr] = Ordering.by(_ match
   case DynamicAddr(long) => (long, ""),
 )
 
+/** function values */
+sealed trait FuncValue extends PureValue {
+  def func: Func
+  def captured: Map[Name, Value]
+}
+
 /** closures */
-case class Clo(func: Func, captured: Map[Name, Value]) extends PureValue
+case class Clo(func: Func, captured: Map[Name, Value]) extends FuncValue
 
 /** continuations */
 case class Cont(
   func: Func,
   captured: Map[Name, Value],
   callStack: List[CallContext],
-) extends PureValue
+) extends FuncValue
 
 /** abstract syntax tree (AST) values */
 case class AstValue(ast: Ast) extends PureValue

--- a/src/main/scala/esmeta/state/util/Stringifier.scala
+++ b/src/main/scala/esmeta/state/util/Stringifier.scala
@@ -35,6 +35,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
   // states
   given stRule: Rule[State] = (app, st) =>
     app.wrap {
+      st.filename.map(app :> "filename: " >> _)
       app :> "context: " >> st.context
       given Rule[List[String]] = iterableRule("[", ", ", "]")
       app :> "call-stack: "

--- a/src/main/scala/esmeta/state/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/state/util/UnitWalker.scala
@@ -19,7 +19,7 @@ trait UnitWalker extends BasicUnitWalker {
 
   // states
   def walk(st: State): Unit =
-    val State(_, context, _, _, callStack, globals, heap) = st
+    val State(_, context, _, _, _, callStack, globals, heap) = st
     walk(context)
     walkList(callStack, walk)
     walkMMap(globals, walk, walk)
@@ -28,7 +28,7 @@ trait UnitWalker extends BasicUnitWalker {
   // context
   def walk(context: Context): Unit =
     walkMMap(context.locals, walk, walk)
-    walkOpt(context.retVal, walk)
+    context.retVal.map { case (_, value) => walk(value) }
 
   // cursor
   def walk(cursor: Cursor): Unit = {}

--- a/src/main/scala/esmeta/ty/AstValueTy.scala
+++ b/src/main/scala/esmeta/ty/AstValueTy.scala
@@ -69,6 +69,6 @@ sealed trait AstNonTopTy extends AstValueTy {
 case class AstNameTy(names: Set[String] = Set()) extends AstNonTopTy
 case class AstSingleTy(name: String, idx: Int, subIdx: Int) extends AstNonTopTy
 object AstValueTy extends Parser.From(Parser.astValueTy) {
-  val Top = AstTopTy
-  val Bot: AstNameTy = AstNameTy()
+  lazy val Top = AstTopTy
+  lazy val Bot: AstNameTy = AstNameTy()
 }

--- a/src/main/scala/esmeta/ty/BoolTy.scala
+++ b/src/main/scala/esmeta/ty/BoolTy.scala
@@ -27,10 +27,13 @@ case class BoolTy(set: Set[Boolean] = Set())
   /** prune type */
   def --(that: => BoolTy): BoolTy = BoolTy(this.set -- that.set)
 
+  /** inclusion check */
+  def contains(b: Boolean): Boolean = set contains b
+
   /** get single value */
   def getSingle: Flat[Boolean] = Flat(set)
 }
 object BoolTy extends Parser.From(Parser.boolTy) {
-  val Top: BoolTy = BoolTy(Set(false, true))
-  val Bot: BoolTy = BoolTy()
+  lazy val Top: BoolTy = BoolTy(Set(false, true))
+  lazy val Bot: BoolTy = BoolTy()
 }

--- a/src/main/scala/esmeta/ty/CompTy.scala
+++ b/src/main/scala/esmeta/ty/CompTy.scala
@@ -71,6 +71,6 @@ case class CompTy(
     else normal.getSingle.map(AComp(Const("normal"), _, None))
 }
 object CompTy extends Parser.From(Parser.compTy) {
-  val Bot: CompTy = CompTy()
-  val Top = CompTy(PureValueTy.Top, Inf)
+  lazy val Bot: CompTy = CompTy()
+  lazy val Top = CompTy(PureValueTy.Top, Inf)
 }

--- a/src/main/scala/esmeta/ty/ListTy.scala
+++ b/src/main/scala/esmeta/ty/ListTy.scala
@@ -53,6 +53,6 @@ case class ListTy(elem: Option[ValueTy] = None)
   def getSingle: Flat[Nothing] = if (elem.isEmpty) Zero else Many
 }
 object ListTy extends Parser.From(Parser.listTy) {
-  val Top: ListTy = ListTy(Some(ValueTy.Top))
-  val Bot: ListTy = ListTy()
+  lazy val Top: ListTy = ListTy(Some(ValueTy.Top))
+  lazy val Bot: ListTy = ListTy()
 }

--- a/src/main/scala/esmeta/ty/NameTy.scala
+++ b/src/main/scala/esmeta/ty/NameTy.scala
@@ -57,6 +57,6 @@ case class NameTy(set: BSet[String] = Fin())
   def getSingle: Flat[Nothing] = if (isBottom) Zero else Many
 }
 object NameTy extends Parser.From(Parser.nameTy) {
-  val Top: NameTy = NameTy(Inf)
-  val Bot: NameTy = NameTy()
+  lazy val Top: NameTy = NameTy(Inf)
+  lazy val Bot: NameTy = NameTy()
 }

--- a/src/main/scala/esmeta/ty/PureValueTy.scala
+++ b/src/main/scala/esmeta/ty/PureValueTy.scala
@@ -212,7 +212,7 @@ sealed trait PureValueTy extends TyElem with Lattice[PureValueTy] {
 }
 
 case object PureValueTopTy extends PureValueTy {
-  def clo: BSet[String] = Fin() // unsound but need to remove cycle
+  def clo: BSet[String] = Fin() // TODO unsound but need to remove cycle
   def cont: BSet[Int] = Fin() // unsound but need to remove cycle
   def name: NameTy = NameTy.Bot // unsound but need to remove cycle
   def record: RecordTy = RecordTy.Bot // unsound but need to remove cycle
@@ -292,6 +292,6 @@ object PureValueTy extends Parser.From(Parser.pureValueTy) {
     nullv,
     absent,
   ).norm
-  val Top: PureValueTy = PureValueTopTy
-  val Bot: PureValueTy = PureValueElemTy()
+  lazy val Top: PureValueTy = PureValueTopTy
+  lazy val Bot: PureValueTy = PureValueElemTy()
 }

--- a/src/main/scala/esmeta/ty/RecordTy.scala
+++ b/src/main/scala/esmeta/ty/RecordTy.scala
@@ -77,6 +77,6 @@ object RecordTy extends Parser.From(Parser.recordTy) {
   def apply(fields: Map[String, ValueTy]): RecordTy = Elem(fields).norm
   val Elem = RecordElemTy
   type Elem = RecordElemTy
-  val Top = RecordTopTy
-  val Bot = Elem()
+  lazy val Top = RecordTopTy
+  lazy val Bot = Elem()
 }

--- a/src/main/scala/esmeta/ty/Ty.scala
+++ b/src/main/scala/esmeta/ty/Ty.scala
@@ -1,5 +1,6 @@
 package esmeta.ty
 
+import esmeta.state.*
 import esmeta.ty.util.Parser
 
 /** types */
@@ -12,5 +13,8 @@ trait Ty extends TyElem {
 
   /** completion check */
   def isCompletion: Boolean
+
+  /** value containment check */
+  def contains(value: Value, state: State): Boolean
 }
 object Ty extends Parser.From(Parser.ty)

--- a/src/main/scala/esmeta/ty/Ty.scala
+++ b/src/main/scala/esmeta/ty/Ty.scala
@@ -15,6 +15,7 @@ trait Ty extends TyElem {
   def isCompletion: Boolean
 
   /** value containment check */
-  def contains(value: Value, state: State): Boolean
+  def contains(value: Value, st: State): Boolean = contains(value, st.heap)
+  def contains(value: Value, heap: Heap): Boolean
 }
 object Ty extends Parser.From(Parser.ty)

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -1,5 +1,6 @@
 package esmeta.ty
 
+import esmeta.util.*
 import esmeta.util.BaseUtils.*
 import scala.annotation.tailrec
 
@@ -47,6 +48,9 @@ case class TyModel(infos: Map[String, TyInfo] = Map()) {
     (l == r) || subTys.get(r).fold(false)(_ contains l)
   def isSubTy(l: String, rset: Set[String]): Boolean =
     rset.exists(r => isSubTy(l, r))
+  def isSubTy(l: String, rset: BSet[String]): Boolean = rset match
+    case Inf       => true
+    case Fin(rset) => isSubTy(l, rset)
   def isSubTy(lset: Set[String], rset: Set[String]): Boolean =
     lset.forall(l => isSubTy(l, rset))
 

--- a/src/main/scala/esmeta/ty/UnknownTy.scala
+++ b/src/main/scala/esmeta/ty/UnknownTy.scala
@@ -9,7 +9,7 @@ case class UnknownTy(msg: Option[String] = None) extends Ty {
   def isCompletion: Boolean = msg.exists(_ contains "Completion")
 
   /** value containment check */
-  def contains(value: Value, state: State): Boolean = true
+  def contains(value: Value, heap: Heap): Boolean = true
 }
 object UnknownTy:
   def apply(str: String): UnknownTy = UnknownTy(Some(str))

--- a/src/main/scala/esmeta/ty/UnknownTy.scala
+++ b/src/main/scala/esmeta/ty/UnknownTy.scala
@@ -1,10 +1,15 @@
 package esmeta.ty
 
+import esmeta.state.*
+
 /** unknown type */
 case class UnknownTy(msg: Option[String] = None) extends Ty {
 
   /** completion check */
   def isCompletion: Boolean = msg.exists(_ contains "Completion")
+
+  /** value containment check */
+  def contains(value: Value, state: State): Boolean = true
 }
 object UnknownTy:
   def apply(str: String): UnknownTy = UnknownTy(Some(str))

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -112,18 +112,18 @@ case class ValueTy(
     case Comp(ty, value, target) => isCompletion
     case a: Addr =>
       state.heap(a) match {
-        case m @ MapObj(ty, props, _) =>
-          (names contains ty) | m.keys.foldLeft(true)({
-            case (t, key) => (
-              t && (record.map.get(key.asStr) match
-                case None => false
-                case Some(v) =>
-                  v match
-                    case None    => true
-                    case Some(v) => v.contains(props.get(key).get.value, state)
-              )
-            )
-          })
+        case m @ MapObj(ty, props, _) => ???
+        // (names contains ty) | m.keys.foldLeft(true)({
+        //   case (t, key) => (
+        //     t && (record.map.get(key.asStr) match
+        //       case None => false
+        //       case Some(v) =>
+        //         v match
+        //           case None    => true
+        //           case Some(v) => v.contains(props.get(key).get.value, state)
+        //     )
+        //   )
+        // })
         case ListObj(values) =>
           list.elem match
             case None => false
@@ -140,17 +140,18 @@ case class ValueTy(
       astValue match
         case AstTopTy       => true
         case a: AstNonTopTy => a.toName.names contains ast.name
-    case g @ Grammar(name, params) => grammar contains g
+    case g @ Grammar(name, params) => ??? // grammar contains g
     case Math(n)                   => math contains n
     case Const(name)               => const contains name
     case CodeUnit(c)               => codeUnit
     case num @ Number(n)           => number contains num
     case BigInt(n)                 => bigInt
     case Str(s)                    => str contains s
-    case Bool(b)                   => bool contains b
+    case Bool(b)                   => ??? // bool contains b
     case Undef                     => undef
     case Null                      => nullv
     case Absent                    => absent
+    case _                         => ???
 }
 object ValueTy {
   def apply(

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -109,11 +109,43 @@ case class ValueTy(
 
   /** value containment check */
   def contains(value: Value, state: State): Boolean = value match
-    case Comp(ty, value, target)         => isCompletion
-    case NamedAddr(name)                 => ???
-    case DynamicAddr(long)               => ???
-    case Clo(func, captured)             => ???
-    case Cont(func, captured, callStack) => ??? // cont.isBottom
+    case Comp(ty, value, target) => isCompletion
+    // address 굳이 두개로 나누지 않아도 됨.
+    case a: Addr =>
+      state.heap(a) match {
+        case m @ MapObj(ty, props, _) =>
+          (names contains ty) | m.keys.foldLeft(true)({
+            case (t, key) => (
+              t && (record.map.get(key.asStr) match
+                case None => false
+                case Some(v) =>
+                  v match
+                    case None    => true
+                    case Some(v) => v.contains(props.get(key).get.value, state)
+              )
+            )
+          }) // MapObj 는 purevalue -> props 이고 record type은 string -> valueTy 인데 key.asStr 으로 넘길 수 있는지..
+        // or named record 즉 (mapobj의 ty 가 names 안에 존재한다면) 면 name 안에 들어갈 시 그냥 바로 true retur면
+        // 아닐경우 mapobj 의 pairs 를 가져와서 record의 keyset의 subset인지 확인하고 각 mapobj 의 value가 record에서 지정된 type 안에 들어가는지 체크
+        // record에서 value type은 none일 경우 bottom Some(none)일 경우 Top
+        // 각 value in mapobj pair 가 record의 valuetype에 들어가는 지 체크해주어야함.
+        case ListObj(values) =>
+          list.elem match
+            case None => false
+            case Some(ty) =>
+              values.foldLeft(true)({
+                case (t, v) => t && (ty.contains(v, state))
+              })
+
+        // ListObj(p) 에서 p에 각 element 마다 for each 로 check 다 해주어야함
+        // list 로 가져온거중에 elem 이 none 일 경우 아무것도 올 수 없다.
+        // list 로 가져온거중에 elem 이 Some(type)인 경우 for each 로 ListObj(p)에 p를 iterate 해야함
+        case SymbolObj(_) => symbol
+        case YetObj(_, _) => true
+      }
+    case Clo(func, captured)             => clo contains func.irFunc.name
+    case Cont(func, captured, callStack) => cont contains func.id
+    // why does clo return BSet[String] and why does cont return BSet[Int]
     case AstValue(ast) =>
       astValue match
         case AstTopTy       => true
@@ -122,7 +154,7 @@ case class ValueTy(
     case Math(n)                   => math contains n
     case Const(name)               => const contains name
     case CodeUnit(c)               => codeUnit
-    case Number(n)                 => number contains n
+    case num @ Number(n)           => number contains num
     case BigInt(n)                 => bigInt
     case Str(s)                    => str contains s
     case Bool(b)                   => bool contains b

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -106,6 +106,26 @@ case class ValueTy(
   def undef: Boolean = pureValue.undef
   def nullv: Boolean = pureValue.nullv
   def absent: Boolean = pureValue.absent
+
+  /** value containment check */
+  def contains(value: Value, state: State): Boolean = value match
+    case Comp(ty, value, target)         => ???
+    case NamedAddr(name)                 => ???
+    case DynamicAddr(long)               => ???
+    case Clo(func, captured)             => ???
+    case Cont(func, captured, callStack) => ???
+    case AstValue(ast)                   => ???
+    case Grammar(name, params)           => ???
+    case Math(n)                         => ???
+    case Const(name)                     => ???
+    case CodeUnit(c)                     => ???
+    case Number(n)                       => number contains n
+    case BigInt(n)                       => ???
+    case Str(str)                        => ???
+    case Bool(bool)                      => ???
+    case Undef                           => ???
+    case Null                            => ???
+    case Absent                          => ???
 }
 object ValueTy {
   def apply(

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -108,49 +108,53 @@ case class ValueTy(
   def absent: Boolean = pureValue.absent
 
   /** value containment check */
-  def contains(value: Value, state: State): Boolean = value match
-    case Comp(ty, value, target) => isCompletion
-    case a: Addr =>
-      state.heap(a) match {
-        case m @ MapObj(ty, props, _) => ???
-        // (names contains ty) | m.keys.foldLeft(true)({
-        //   case (t, key) => (
-        //     t && (record.map.get(key.asStr) match
-        //       case None => false
-        //       case Some(v) =>
-        //         v match
-        //           case None    => true
-        //           case Some(v) => v.contains(props.get(key).get.value, state)
-        //     )
-        //   )
-        // })
-        case ListObj(values) =>
-          list.elem match
-            case None => false
-            case Some(ty) =>
-              values.foldLeft(true)({
-                case (t, v) => t && (ty.contains(v, state))
-              })
-        case SymbolObj(_) => symbol
-        case YetObj(_, _) => true
-      }
-    case Clo(func, captured)             => clo contains func.irFunc.name
-    case Cont(func, captured, callStack) => cont contains func.id
-    case AstValue(ast) =>
-      astValue match
-        case AstTopTy       => true
-        case a: AstNonTopTy => a.toName.names contains ast.name
-    case Nt(name, params) => ??? // grammar contains g
-    case Math(n)          => math contains n
-    case Const(name)      => const contains name
-    case CodeUnit(c)      => codeUnit
-    case num @ Number(n)  => number contains num
-    case BigInt(n)        => bigInt
-    case Str(s)           => str contains s
-    case Bool(b)          => ??? // bool contains b
-    case Undef            => undef
-    case Null             => nullv
-    case Absent           => absent
+  def contains(value: Value, heap: Heap): Boolean =
+    (pureValue.isTop && value.isInstanceOf[PureValue]) || (value match
+      case NormalComp(value) =>
+        ValueTy(pureValue = comp.normal).contains(value, heap)
+      case Comp(Const(tyStr), _, _) => comp.abrupt contains tyStr
+      case a: Addr =>
+        heap(a) match
+          case MapObj(tname, props, _) =>
+            (name.set contains tname) ||
+            (tname == "Record" && (props.forall {
+              case (Str(key), MapObj.Prop(value, _)) =>
+                record(key).contains(value, heap)
+              case _ => false
+            })) ||
+            (tname == "SubMap" && (props.forall {
+              case (key, MapObj.Prop(value, _)) =>
+                ValueTy(pureValue = subMap.key).contains(key, heap) &&
+                ValueTy(pureValue = subMap.value).contains(value, heap)
+            }))
+          case ListObj(values) =>
+            list.elem match
+              case None     => false
+              case Some(ty) => values.forall(ty.contains(_, heap))
+          case SymbolObj(_) => symbol
+          case YetObj(_, _) => true
+      case Clo(func, captured)             => clo contains func.irFunc.name
+      case Cont(func, captured, callStack) => cont contains func.id
+      case AstValue(ast) =>
+        astValue match
+          case AstTopTy         => true
+          case AstNameTy(names) => names contains ast.name
+          case AstSingleTy(name, idx, subIdx) =>
+            ast.name == name &&
+            ast.idx == idx &&
+            ast.subIdx == subIdx
+      case x @ Nt(name, params) => nt contains x
+      case Math(n)              => math contains n
+      case Const(name)          => const contains name
+      case CodeUnit(c)          => codeUnit
+      case num @ Number(n)      => number contains num
+      case BigInt(n)            => bigInt
+      case Str(s)               => str contains s
+      case Bool(b)              => bool contains b
+      case Undef                => undef
+      case Null                 => nullv
+      case Absent               => absent
+    )
 }
 object ValueTy {
   def apply(
@@ -201,6 +205,6 @@ object ValueTy {
     ),
     subMap = subMap,
   )
-  val Top: ValueTy = ValueTy(CompTy.Top, PureValueTy.Top, SubMapTy.Top)
-  val Bot: ValueTy = ValueTy()
+  lazy val Top: ValueTy = ValueTy(CompTy.Top, PureValueTy.Top, SubMapTy.Top)
+  lazy val Bot: ValueTy = ValueTy()
 }

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -109,23 +109,26 @@ case class ValueTy(
 
   /** value containment check */
   def contains(value: Value, state: State): Boolean = value match
-    case Comp(ty, value, target)         => ???
+    case Comp(ty, value, target)         => isCompletion
     case NamedAddr(name)                 => ???
     case DynamicAddr(long)               => ???
     case Clo(func, captured)             => ???
-    case Cont(func, captured, callStack) => ???
-    case AstValue(ast)                   => ???
-    case Grammar(name, params)           => ???
-    case Math(n)                         => ???
-    case Const(name)                     => ???
-    case CodeUnit(c)                     => ???
-    case Number(n)                       => number contains n
-    case BigInt(n)                       => ???
-    case Str(str)                        => ???
-    case Bool(bool)                      => ???
-    case Undef                           => ???
-    case Null                            => ???
-    case Absent                          => ???
+    case Cont(func, captured, callStack) => ??? // cont.isBottom
+    case AstValue(ast) =>
+      astValue match
+        case AstTopTy       => true
+        case a: AstNonTopTy => a.toName.names contains ast.name
+    case g @ Grammar(name, params) => grammar contains g
+    case Math(n)                   => math contains n
+    case Const(name)               => const contains name
+    case CodeUnit(c)               => codeUnit
+    case Number(n)                 => number contains n
+    case BigInt(n)                 => bigInt
+    case Str(s)                    => str contains s
+    case Bool(b)                   => bool contains b
+    case Undef                     => undef
+    case Null                      => nullv
+    case Absent                    => absent
 }
 object ValueTy {
   def apply(

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -110,7 +110,6 @@ case class ValueTy(
   /** value containment check */
   def contains(value: Value, state: State): Boolean = value match
     case Comp(ty, value, target) => isCompletion
-    // address 굳이 두개로 나누지 않아도 됨.
     case a: Addr =>
       state.heap(a) match {
         case m @ MapObj(ty, props, _) =>
@@ -124,11 +123,7 @@ case class ValueTy(
                     case Some(v) => v.contains(props.get(key).get.value, state)
               )
             )
-          }) // MapObj 는 purevalue -> props 이고 record type은 string -> valueTy 인데 key.asStr 으로 넘길 수 있는지..
-        // or named record 즉 (mapobj의 ty 가 names 안에 존재한다면) 면 name 안에 들어갈 시 그냥 바로 true retur면
-        // 아닐경우 mapobj 의 pairs 를 가져와서 record의 keyset의 subset인지 확인하고 각 mapobj 의 value가 record에서 지정된 type 안에 들어가는지 체크
-        // record에서 value type은 none일 경우 bottom Some(none)일 경우 Top
-        // 각 value in mapobj pair 가 record의 valuetype에 들어가는 지 체크해주어야함.
+          })
         case ListObj(values) =>
           list.elem match
             case None => false
@@ -136,16 +131,11 @@ case class ValueTy(
               values.foldLeft(true)({
                 case (t, v) => t && (ty.contains(v, state))
               })
-
-        // ListObj(p) 에서 p에 각 element 마다 for each 로 check 다 해주어야함
-        // list 로 가져온거중에 elem 이 none 일 경우 아무것도 올 수 없다.
-        // list 로 가져온거중에 elem 이 Some(type)인 경우 for each 로 ListObj(p)에 p를 iterate 해야함
         case SymbolObj(_) => symbol
         case YetObj(_, _) => true
       }
     case Clo(func, captured)             => clo contains func.irFunc.name
     case Cont(func, captured, callStack) => cont contains func.id
-    // why does clo return BSet[String] and why does cont return BSet[Int]
     case AstValue(ast) =>
       astValue match
         case AstTopTy       => true

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -13,6 +13,7 @@ case class ValueTy(
 ) extends Ty
   with Lattice[ValueTy] {
   import ValueTy.*
+  import TyModel.es.isSubTy
 
   /** top check */
   def isTop: Boolean =
@@ -116,7 +117,7 @@ case class ValueTy(
       case a: Addr =>
         heap(a) match
           case MapObj(tname, props, _) =>
-            (name.set contains tname) ||
+            isSubTy(tname, name.set) ||
             (tname == "Record" && (props.forall {
               case (Str(key), MapObj.Prop(value, _)) =>
                 record(key).contains(value, heap)

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -140,18 +140,17 @@ case class ValueTy(
       astValue match
         case AstTopTy       => true
         case a: AstNonTopTy => a.toName.names contains ast.name
-    case g @ Grammar(name, params) => ??? // grammar contains g
-    case Math(n)                   => math contains n
-    case Const(name)               => const contains name
-    case CodeUnit(c)               => codeUnit
-    case num @ Number(n)           => number contains num
-    case BigInt(n)                 => bigInt
-    case Str(s)                    => str contains s
-    case Bool(b)                   => ??? // bool contains b
-    case Undef                     => undef
-    case Null                      => nullv
-    case Absent                    => absent
-    case _                         => ???
+    case Nt(name, params) => ??? // grammar contains g
+    case Math(n)          => math contains n
+    case Const(name)      => const contains name
+    case CodeUnit(c)      => codeUnit
+    case num @ Number(n)  => number contains num
+    case BigInt(n)        => bigInt
+    case Str(s)           => str contains s
+    case Bool(b)          => ??? // bool contains b
+    case Undef            => undef
+    case Null             => nullv
+    case Absent           => absent
 }
 object ValueTy {
   def apply(

--- a/src/main/scala/esmeta/ty/package.scala
+++ b/src/main/scala/esmeta/ty/package.scala
@@ -28,6 +28,7 @@ lazy val NormalT: ValueTy = ValueTy(normal = PureValueTy.Top)
 def NormalT(value: ValueTy): ValueTy =
   if (value.pureValue.isBottom) ValueTy.Bot
   else ValueTy(normal = value.pureValue)
+def SubMapT: ValueTy = ValueTy(subMap = SubMapTy.Top)
 def SubMapT(key: ValueTy, value: ValueTy): ValueTy =
   if (key.isBottom || value.isBottom) ValueTy.Bot
   else ValueTy(subMap = SubMapTy(key.pureValue, value.pureValue))
@@ -58,6 +59,7 @@ lazy val ESPrimT: ValueTy = ValueTy(
 )
 lazy val ESValueT: ValueTy = ObjectT || ESPrimT
 lazy val ESPureValueT: PureValueTy = ESValueT.pureValue
+lazy val RecordT: ValueTy = ValueTy(record = RecordTy.Top)
 def RecordT(fields: Set[String]): ValueTy =
   if (fields.isEmpty) ValueTy.Bot
   else ValueTy(record = RecordTy(fields))
@@ -68,6 +70,7 @@ def RecordT(pairs: (String, ValueTy)*): ValueTy =
   if (pairs.isEmpty) ValueTy.Bot
   else ValueTy(record = RecordTy(pairs.toMap).norm)
 def NilT: ValueTy = ValueTy(list = ListTy(Some(BotT)))
+def ListT: ValueTy = ValueTy(list = ListTy.Top)
 def ListT(ty: ValueTy): ValueTy =
   if (ty.isBottom) ValueTy.Bot
   else ValueTy(list = ListTy(Some(ty)))
@@ -78,10 +81,12 @@ def AstT(xs: String*): ValueTy =
   else ValueTy(astValue = AstNameTy(xs.toSet))
 def AstSingleT(name: String, idx: Int, subIdx: Int): ValueTy =
   ValueTy(astValue = AstSingleTy(name, idx, subIdx))
+def NtT: ValueTy = ValueTy(nt = Inf)
 def NtT(xs: Nt*): ValueTy =
   if (xs.isEmpty) ValueTy.Bot
   else ValueTy(nt = Fin(xs.toSet))
 lazy val CodeUnitT: ValueTy = ValueTy(codeUnit = true)
+def ConstT: ValueTy = ValueTy(const = Inf)
 def ConstT(xs: String*): ValueTy =
   if (xs.isEmpty) ValueTy.Bot
   else ValueTy(const = Fin(xs.toSet))

--- a/src/main/scala/esmeta/ty/package.scala
+++ b/src/main/scala/esmeta/ty/package.scala
@@ -18,7 +18,7 @@ trait TyElem {
 // -----------------------------------------------------------------------------
 lazy val AnyT: ValueTy = ValueTy.Top
 lazy val PureValueT: ValueTy = ValueTy(pureValue = PureValueTy.Top)
-lazy val CompT: ValueTy = ValueTy(normal = PureValueTy.Top)
+lazy val CompT: ValueTy = ValueTy(comp = CompTy.Top)
 def CompT(normal: ValueTy, abrupt: BSet[String]): ValueTy =
   if (normal.pureValue.isBottom && abrupt.isBottom) ValueTy.Bot
   else ValueTy(normal = normal.pureValue, abrupt = abrupt)

--- a/src/main/scala/esmeta/ty/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ty/util/Stringifier.scala
@@ -49,10 +49,12 @@ object Stringifier {
   /** completion record types */
   given compTyRule: Rule[CompTy] = (app, ty) =>
     given Rule[PureValueTy] = topRule(pureValueTyRule)
-    FilterApp(app)
-      .add(ty.normal, !ty.normal.isBottom, "Normal")
-      .add(ty.abrupt, !ty.abrupt.isBottom, "Abrupt")
-      .app
+    if (ty.isTop) app >> "CompletionRecord"
+    else
+      FilterApp(app)
+        .add(ty.normal, !ty.normal.isBottom, "Normal")
+        .add(ty.abrupt, !ty.abrupt.isBottom, "Abrupt")
+        .app
 
   /** list types */
   given listTyRule: Rule[ListTy] = (app, ty) =>

--- a/src/main/scala/esmeta/util/BaseUtils.scala
+++ b/src/main/scala/esmeta/util/BaseUtils.scala
@@ -26,10 +26,10 @@ object BaseUtils {
   }
 
   /** throw a simple error */
-  def error(msg: String): Nothing = throw ESMetaError(msg)
+  def error(any: Any): Nothing = throw ESMetaError(any.toString)
 
   /** show a warning message */
-  def warn(msg: String): Unit = Console.err.println(s"[WARNING] $msg")
+  def warn(any: Any): Unit = Console.err.println(s"[WARNING] $any")
 
   /** get duration time */
   def time[T](f: => T): (Long, T) = {

--- a/src/test/scala/esmeta/es/ESTest.scala
+++ b/src/test/scala/esmeta/es/ESTest.scala
@@ -51,13 +51,14 @@ object ESTest {
     str: String,
     checkAfter: List[NormalInst] = Nil,
     cachedAst: Option[Ast] = None,
+    filename: Option[String] = None,
   ): State =
-    new CheckAfter(Initialize(cfg, str, cachedAst), checkAfter).result
+    new CheckAfter(Initialize(cfg, str, cachedAst, filename), checkAfter).result
   def evalFile(
     filename: String,
     checkAfter: List[NormalInst] = Nil,
     cachedAst: Option[Ast] = None,
-  ): State = eval(readFile(filename), checkAfter, cachedAst)
+  ): State = eval(readFile(filename), checkAfter, cachedAst, Some(filename))
 
   // ---------------------------------------------------------------------------
   // analyzer helpers

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -43,7 +43,6 @@ class ContainsTinyTest extends TyTest {
           st,
         ),
       )
-      // Test for AstNonTopT required
       assert(GrammarT(Grammar("", Nil)).contains(Grammar("", Nil), st))
       assert(ConstT("const").contains(Const("const"), st))
       assert(CodeUnitT.contains(CodeUnit(' '), st))
@@ -51,6 +50,8 @@ class ContainsTinyTest extends TyTest {
       assert(NullT.contains(Null, st))
       assert(AbsentT.contains(Absent, st))
       assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
+      // TODO Test for addr, clo, cont
+      // Stringifier 참고해서 넣기.
     }
   }
   init

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -19,7 +19,13 @@ class ContainsTinyTest extends TyTest {
     )
     lazy val ctxt = Context(func, MMap())
     // TODO fill out
-    lazy val heap = Heap(MMap(DynamicAddr(0) -> MapObj("A", MMap(), 0)), 1)
+    lazy val heap = Heap(
+      MMap(
+        DynamicAddr(0) -> MapObj("A", MMap(), 0),
+        DynamicAddr(1) -> ListObj(Vector(Math(5))),
+      ),
+      1,
+    )
     lazy val st = State(CFG(List(func)), ctxt, heap = heap)
 
     check("ty.contains") {
@@ -54,9 +60,54 @@ class ContainsTinyTest extends TyTest {
         RecordT("A" -> Some(NumberTopT), "B" -> Some(BoolT))
           .contains(DynamicAddr(0), st),
       )
-      
-      // TODO Test for addr, clo, cont
-      // Stringifier 참고해서 넣기.
+      assert(
+        ListT(MathTopT)
+          .contains(DynamicAddr(1), st),
+      )
+      assert(
+        CloTopT.contains(
+          Clo(
+            Func(
+              1,
+              IRFunc(
+                true,
+                IRFuncKind.Clo,
+                "test",
+                Nil,
+                UnknownType,
+                INop(),
+                None,
+              ),
+              Block(1),
+            ),
+            Map(),
+          ),
+          st,
+        ),
+      )
+      assert(
+        ContTopT.contains(
+          Cont(
+            Func(
+              1,
+              IRFunc(
+                true,
+                IRFuncKind.Clo,
+                "test",
+                Nil,
+                UnknownType,
+                INop(),
+                None,
+              ),
+              Block(1),
+            ),
+            Map(),
+            Nil,
+          ),
+          st,
+        ),
+      )
+
     }
   }
   init

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -50,6 +50,11 @@ class ContainsTinyTest extends TyTest {
       assert(NullT.contains(Null, st))
       assert(AbsentT.contains(Absent, st))
       assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
+      assert(
+        RecordT("A" -> Some(NumberTopT), "B" -> Some(BoolT))
+          .contains(DynamicAddr(0), st),
+      )
+      
       // TODO Test for addr, clo, cont
       // Stringifier 참고해서 넣기.
     }

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -10,104 +10,189 @@ import esmeta.es.*
 class ContainsTinyTest extends TyTest {
   val name: String = "tyContainsTest"
 
+  case class Neg(name: String, heap: Heap) {
+    def neg(ps: (Ty, Value)*): Unit =
+      given Heap = heap
+      checkContains(name, expected = false)(ps: _*)
+  }
+
+  // check containment of values for types
+  def checkContains(name: String, expected: Boolean = true)(using heap: Heap)(
+    ps: (Ty, Value)*,
+  ): Neg =
+    val desc = name + (if (expected) "" else " (negative)")
+    check(desc)(for {
+      (ty, value) <- ps
+      if expected != ty.contains(value, heap)
+    } {
+      println(s"[FAILED] $desc")
+      fail(s"$ty contains $value should be $expected")
+    })
+    Neg(name, heap)
+
   // registration
   def init: Unit = {
-    // lazy val func = Func(
-    //   0,
-    //   IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
-    //   Block(0),
-    // )
-    // lazy val ctxt = Context(func, MMap())
-    // // TODO fill out
-    // lazy val heap = Heap(
-    //   MMap(
-    //     DynamicAddr(0) -> MapObj("A", MMap(), 0),
-    //     DynamicAddr(1) -> ListObj(Vector(Math(5))),
-    //   ),
-    //   1,
-    // )
-    // lazy val st = State(CFG(List(func)), ctxt, heap = heap)
+    // pre-defined CFG function
+    lazy val func = Func(
+      0,
+      IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
+      Block(0),
+    )
 
-    check("ty.contains") {
-      // // TODO fill out remaining cases
-      // assert(NumberTopT.contains(Number(42), st))
-      // assert(BoolT.contains(Bool(true), st))
-      // assert(BigIntT.contains(BigInt(42), st))
-      // assert(StrTopT.contains(Str("test"), st))
-      // assert(MathTopT.contains(Math(52), st))
-      // assert(
-      //   AstTopT.contains(
-      //     AstValue(Syntactic("", Nil, 5, List(Some(Lexical("name", "str"))))),
-      //     st,
-      //   ),
-      // )
-      // assert(
-      //   AstT("name").contains(
-      //     AstValue(
-      //       Syntactic("name", Nil, 5, List(Some(Lexical("name", "str")))),
-      //     ),
-      //     st,
-      //   ),
-      // )
-      // assert(GrammarT(Grammar("", Nil)).contains(Grammar("", Nil), st))
-      // assert(ConstT("const").contains(Const("const"), st))
-      // assert(CodeUnitT.contains(CodeUnit(' '), st))
-      // assert(UndefT.contains(Undef, st))
-      // assert(NullT.contains(Null, st))
-      // assert(AbsentT.contains(Absent, st))
-      // assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
-      // assert(
-      //   RecordT("A" -> Some(NumberTopT), "B" -> Some(BoolT))
-      //     .contains(DynamicAddr(0), st),
-      // )
-      // assert(
-      //   ListT(MathTopT)
-      //     .contains(DynamicAddr(1), st),
-      // )
-      // assert(
-      //   CloTopT.contains(
-      //     Clo(
-      //       Func(
-      //         1,
-      //         IRFunc(
-      //           true,
-      //           IRFuncKind.Clo,
-      //           "test",
-      //           Nil,
-      //           UnknownType,
-      //           INop(),
-      //           None,
-      //         ),
-      //         Block(1),
-      //       ),
-      //       Map(),
-      //     ),
-      //     st,
-      //   ),
-      // )
-      // assert(
-      //   ContTopT.contains(
-      //     Cont(
-      //       Func(
-      //         1,
-      //         IRFunc(
-      //           true,
-      //           IRFuncKind.Clo,
-      //           "test",
-      //           Nil,
-      //           UnknownType,
-      //           INop(),
-      //           None,
-      //         ),
-      //         Block(1),
-      //       ),
-      //       Map(),
-      //       Nil,
-      //     ),
-      //     st,
-      //   ),
-      // )
-    }
+    // pre-defined heap
+    lazy val mapAddr = NamedAddr("mapAddr")
+    lazy val mapObj = MapObj("A", MMap(), 0)
+    lazy val recordAddr = NamedAddr("recordAddr")
+    lazy val recordObj =
+      MapObj("Record", MMap(Str("P") -> MapObj.Prop(Number(42), 0)), 1)
+    lazy val nilAddr = NamedAddr("nilAddr")
+    lazy val nilObj = ListObj(Vector())
+    lazy val listAddr = NamedAddr("listAddr")
+    lazy val listObj = ListObj(Vector(Math(5)))
+    lazy val symbolAddr = NamedAddr("symbolAddr")
+    lazy val symbolObj = SymbolObj(Str("desc"))
+    lazy val subMapAddr = NamedAddr("subMapAddr")
+    lazy val subMapObj =
+      MapObj("SubMap", MMap(symbolAddr -> MapObj.Prop(Number(42), 0)), 1)
+    given Heap = Heap(
+      MMap(
+        mapAddr -> mapObj,
+        recordAddr -> recordObj,
+        subMapAddr -> subMapObj,
+        nilAddr -> nilObj,
+        listAddr -> listObj,
+        symbolAddr -> symbolObj,
+      ),
+    )
+
+    lazy val normalComp = NormalComp(Str("a"))
+    lazy val throwComp = Comp(Const("throw"), Str("a"), None)
+    lazy val returnComp = Comp(Const("return"), Str("a"), None)
+    checkContains("completion values")(
+      NormalT -> normalComp,
+      NormalT(StrT) -> normalComp,
+      AbruptT -> throwComp,
+      AbruptT("throw") -> throwComp,
+    ).neg(
+      NormalT -> throwComp,
+      NormalT(NumberT) -> normalComp,
+      AbruptT -> normalComp,
+      AbruptT("throw") -> returnComp,
+    )
+
+    checkContains("map objects")(
+      NameT -> mapAddr,
+      NameT("A") -> mapAddr,
+      RecordT -> recordAddr,
+      RecordT(Set("P")) -> recordAddr,
+      RecordT("P" -> NumberT) -> recordAddr,
+      SubMapT -> subMapAddr,
+      SubMapT(SymbolT, NumberT) -> subMapAddr,
+    ).neg(
+      NameT("B") -> mapAddr,
+      NameT("B") -> recordAddr,
+      RecordT -> mapAddr,
+      RecordT(Set("Q")) -> recordAddr,
+      RecordT("P" -> BoolT) -> recordAddr,
+      SubMapT(SymbolT, BoolT) -> subMapAddr,
+      SubMapT(StrT, NumberT) -> subMapAddr,
+    )
+
+    checkContains("list objects")(
+      ListT -> nilAddr,
+      ListT -> listAddr,
+      NilT -> nilAddr,
+      ListT(MathT) -> nilAddr,
+      ListT(MathT) -> listAddr,
+    ).neg(
+      NilT -> listAddr,
+      ListT(StrT) -> listAddr,
+    )
+
+    checkContains("symbol objects")(
+      SymbolT -> symbolAddr,
+    ).neg(
+      SymbolT -> nilAddr,
+    )
+
+    lazy val clo = Clo(func, Map())
+    checkContains("closures")(
+      CloT -> clo,
+      CloT("f") -> clo,
+    ).neg(
+      CloT("g") -> clo,
+    )
+
+    lazy val cont = Cont(func, Map(), Nil)
+    checkContains("continuations")(
+      ContT -> cont,
+      ContT(0) -> cont,
+    ).neg(
+      ContT(42) -> cont,
+    )
+
+    lazy val ast1 = Syntactic("A", List(false, true), 5, Nil)
+    lazy val astValue1 = AstValue(ast1)
+    lazy val ast2 = Syntactic("B", List(false, true), 5, List(Some(ast1), None))
+    lazy val astValue2 = AstValue(ast2)
+    checkContains("abstract syntax tree (AST) values")(
+      AstT -> astValue1,
+      AstT("A") -> astValue1,
+      AstSingleT("B", 5, 2) -> astValue2,
+    ).neg(
+      AstT("B") -> astValue1,
+      AstSingleT("A", 5, 2) -> astValue2,
+      AstSingleT("B", 3, 2) -> astValue2,
+      AstSingleT("B", 5, 1) -> astValue2,
+    )
+
+    lazy val ntA = Nt("A", List(true, false, true))
+    lazy val ntB = Nt("B", Nil)
+    checkContains("nonterminals")(
+      NtT -> ntA,
+      NtT(ntA) -> ntA,
+    ).neg(
+      NtT(ntB) -> ntA,
+    )
+
+    checkContains("math values")(
+      MathT -> Math(52.24),
+      MathT(52.24) -> Math(52.24),
+    ).neg(
+      MathT(52.24) -> Math(1.5),
+    )
+
+    checkContains("constants")(
+      ConstT -> Const("empty"),
+      ConstT("empty") -> Const("empty"),
+    ).neg(
+      ConstT("empty") -> Const("iterate"),
+    )
+
+    checkContains("code units")(
+      CodeUnitT -> CodeUnit(' '),
+    )
+
+    checkContains("numeric values")(
+      NumberT -> Number(42),
+      NumberT(Number(1.2)) -> Number(1.2),
+      BigIntT -> BigInt(42),
+    ).neg(
+      NumberT(Number(1.2)) -> Number(5.7),
+    )
+
+    checkContains("non-numeric simple values")(
+      StrT -> Str("test"),
+      StrT("a", "b") -> Str("a"),
+      BoolT -> Bool(false),
+      BoolT(true) -> Bool(true),
+      UndefT -> Undef,
+      NullT -> Null,
+      AbsentT -> Absent,
+    ).neg(
+      StrT("a") -> Str("b"),
+      BoolT(true) -> Bool(false),
+    )
   }
   init
 }

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -4,6 +4,7 @@ import esmeta.cfg.*
 import esmeta.ir.{Func => IRFunc, FuncKind => IRFuncKind, *}
 import esmeta.state.*
 import scala.collection.mutable.{Map => MMap}
+import esmeta.es.*
 
 /** contains test */
 class ContainsTinyTest extends TyTest {
@@ -24,6 +25,32 @@ class ContainsTinyTest extends TyTest {
     check("ty.contains") {
       // TODO fill out remaining cases
       assert(NumberTopT.contains(Number(42), st))
+      assert(BoolT.contains(Bool(true), st))
+      assert(BigIntT.contains(BigInt(42), st))
+      assert(StrTopT.contains(Str("test"), st))
+      assert(MathTopT.contains(Math(52), st))
+      assert(
+        AstTopT.contains(
+          AstValue(Syntactic("", Nil, 5, List(Some(Lexical("name", "str"))))),
+          st,
+        ),
+      )
+      assert(
+        AstT("name").contains(
+          AstValue(
+            Syntactic("name", Nil, 5, List(Some(Lexical("name", "str")))),
+          ),
+          st,
+        ),
+      )
+      // Test for AstNonTopT required
+      assert(GrammarT(Grammar("", Nil)).contains(Grammar("", Nil), st))
+      assert(ConstT("const").contains(Const("const"), st))
+      assert(CodeUnitT.contains(CodeUnit(' '), st))
+      assert(UndefT.contains(Undef, st))
+      assert(NullT.contains(Null, st))
+      assert(AbsentT.contains(Absent, st))
+      assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
     }
   }
   init

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -12,102 +12,101 @@ class ContainsTinyTest extends TyTest {
 
   // registration
   def init: Unit = {
-    lazy val func = Func(
-      0,
-      IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
-      Block(0),
-    )
-    lazy val ctxt = Context(func, MMap())
-    // TODO fill out
-    lazy val heap = Heap(
-      MMap(
-        DynamicAddr(0) -> MapObj("A", MMap(), 0),
-        DynamicAddr(1) -> ListObj(Vector(Math(5))),
-      ),
-      1,
-    )
-    lazy val st = State(CFG(List(func)), ctxt, heap = heap)
+    // lazy val func = Func(
+    //   0,
+    //   IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
+    //   Block(0),
+    // )
+    // lazy val ctxt = Context(func, MMap())
+    // // TODO fill out
+    // lazy val heap = Heap(
+    //   MMap(
+    //     DynamicAddr(0) -> MapObj("A", MMap(), 0),
+    //     DynamicAddr(1) -> ListObj(Vector(Math(5))),
+    //   ),
+    //   1,
+    // )
+    // lazy val st = State(CFG(List(func)), ctxt, heap = heap)
 
     check("ty.contains") {
-      // TODO fill out remaining cases
-      assert(NumberTopT.contains(Number(42), st))
-      assert(BoolT.contains(Bool(true), st))
-      assert(BigIntT.contains(BigInt(42), st))
-      assert(StrTopT.contains(Str("test"), st))
-      assert(MathTopT.contains(Math(52), st))
-      assert(
-        AstTopT.contains(
-          AstValue(Syntactic("", Nil, 5, List(Some(Lexical("name", "str"))))),
-          st,
-        ),
-      )
-      assert(
-        AstT("name").contains(
-          AstValue(
-            Syntactic("name", Nil, 5, List(Some(Lexical("name", "str")))),
-          ),
-          st,
-        ),
-      )
-      assert(GrammarT(Grammar("", Nil)).contains(Grammar("", Nil), st))
-      assert(ConstT("const").contains(Const("const"), st))
-      assert(CodeUnitT.contains(CodeUnit(' '), st))
-      assert(UndefT.contains(Undef, st))
-      assert(NullT.contains(Null, st))
-      assert(AbsentT.contains(Absent, st))
-      assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
-      assert(
-        RecordT("A" -> Some(NumberTopT), "B" -> Some(BoolT))
-          .contains(DynamicAddr(0), st),
-      )
-      assert(
-        ListT(MathTopT)
-          .contains(DynamicAddr(1), st),
-      )
-      assert(
-        CloTopT.contains(
-          Clo(
-            Func(
-              1,
-              IRFunc(
-                true,
-                IRFuncKind.Clo,
-                "test",
-                Nil,
-                UnknownType,
-                INop(),
-                None,
-              ),
-              Block(1),
-            ),
-            Map(),
-          ),
-          st,
-        ),
-      )
-      assert(
-        ContTopT.contains(
-          Cont(
-            Func(
-              1,
-              IRFunc(
-                true,
-                IRFuncKind.Clo,
-                "test",
-                Nil,
-                UnknownType,
-                INop(),
-                None,
-              ),
-              Block(1),
-            ),
-            Map(),
-            Nil,
-          ),
-          st,
-        ),
-      )
-
+      // // TODO fill out remaining cases
+      // assert(NumberTopT.contains(Number(42), st))
+      // assert(BoolT.contains(Bool(true), st))
+      // assert(BigIntT.contains(BigInt(42), st))
+      // assert(StrTopT.contains(Str("test"), st))
+      // assert(MathTopT.contains(Math(52), st))
+      // assert(
+      //   AstTopT.contains(
+      //     AstValue(Syntactic("", Nil, 5, List(Some(Lexical("name", "str"))))),
+      //     st,
+      //   ),
+      // )
+      // assert(
+      //   AstT("name").contains(
+      //     AstValue(
+      //       Syntactic("name", Nil, 5, List(Some(Lexical("name", "str")))),
+      //     ),
+      //     st,
+      //   ),
+      // )
+      // assert(GrammarT(Grammar("", Nil)).contains(Grammar("", Nil), st))
+      // assert(ConstT("const").contains(Const("const"), st))
+      // assert(CodeUnitT.contains(CodeUnit(' '), st))
+      // assert(UndefT.contains(Undef, st))
+      // assert(NullT.contains(Null, st))
+      // assert(AbsentT.contains(Absent, st))
+      // assert(AbruptT.contains(Comp(Const(" "), Math(5), None), st))
+      // assert(
+      //   RecordT("A" -> Some(NumberTopT), "B" -> Some(BoolT))
+      //     .contains(DynamicAddr(0), st),
+      // )
+      // assert(
+      //   ListT(MathTopT)
+      //     .contains(DynamicAddr(1), st),
+      // )
+      // assert(
+      //   CloTopT.contains(
+      //     Clo(
+      //       Func(
+      //         1,
+      //         IRFunc(
+      //           true,
+      //           IRFuncKind.Clo,
+      //           "test",
+      //           Nil,
+      //           UnknownType,
+      //           INop(),
+      //           None,
+      //         ),
+      //         Block(1),
+      //       ),
+      //       Map(),
+      //     ),
+      //     st,
+      //   ),
+      // )
+      // assert(
+      //   ContTopT.contains(
+      //     Cont(
+      //       Func(
+      //         1,
+      //         IRFunc(
+      //           true,
+      //           IRFuncKind.Clo,
+      //           "test",
+      //           Nil,
+      //           UnknownType,
+      //           INop(),
+      //           None,
+      //         ),
+      //         Block(1),
+      //       ),
+      //       Map(),
+      //       Nil,
+      //     ),
+      //     st,
+      //   ),
+      // )
     }
   }
   init

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -1,0 +1,30 @@
+package esmeta.ty
+
+import esmeta.cfg.*
+import esmeta.ir.{Func => IRFunc, FuncKind => IRFuncKind, *}
+import esmeta.state.*
+import scala.collection.mutable.{Map => MMap}
+
+/** contains test */
+class ContainsTinyTest extends TyTest {
+  val name: String = "tyContainsTest"
+
+  // registration
+  def init: Unit = {
+    lazy val func = Func(
+      0,
+      IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
+      Block(0),
+    )
+    lazy val ctxt = Context(func, MMap())
+    // TODO fill out
+    lazy val heap = Heap(MMap(DynamicAddr(0) -> MapObj("A", MMap(), 0)), 1)
+    lazy val st = State(CFG(List(func)), ctxt, heap = heap)
+
+    check("ty.contains") {
+      // TODO fill out remaining cases
+      assert(NumberTopT.contains(Number(42), st))
+    }
+  }
+  init
+}

--- a/tests/result/ty/ContainsTinyTest
+++ b/tests/result/ty/ContainsTinyTest
@@ -1,0 +1,1 @@
+ty.ContainsTinyTest: 1 / 1

--- a/tests/result/ty/ContainsTinyTest
+++ b/tests/result/ty/ContainsTinyTest
@@ -1,1 +1,1 @@
-ty.ContainsTinyTest: 1 / 1
+ty.ContainsTinyTest: 25 / 25

--- a/tests/result/ty/ContainsTinyTest.json
+++ b/tests/result/ty/ContainsTinyTest.json
@@ -1,0 +1,3 @@
+{
+  "ty.contains" : true
+}

--- a/tests/result/ty/ContainsTinyTest.json
+++ b/tests/result/ty/ContainsTinyTest.json
@@ -1,3 +1,27 @@
 {
-  "ty.contains" : true
+  "abstract syntax tree (AST) values" : true,
+  "abstract syntax tree (AST) values (negative)" : true,
+  "closures" : true,
+  "closures (negative)" : true,
+  "code units" : true,
+  "completion values" : true,
+  "completion values (negative)" : true,
+  "constants" : true,
+  "constants (negative)" : true,
+  "continuations" : true,
+  "continuations (negative)" : true,
+  "list objects" : true,
+  "list objects (negative)" : true,
+  "map objects" : true,
+  "map objects (negative)" : true,
+  "math values" : true,
+  "math values (negative)" : true,
+  "non-numeric simple values" : true,
+  "non-numeric simple values (negative)" : true,
+  "nonterminals" : true,
+  "nonterminals (negative)" : true,
+  "numeric values" : true,
+  "numeric values (negative)" : true,
+  "symbol objects" : true,
+  "symbol objects (negative)" : true
 }


### PR DESCRIPTION
A runtime type checker for interpreter that helps detect bugs in type annotation.
(ContainsTinyTest are testcases for check containment of values for types)

new option `-eval:tycheck` is now available. 
