### PR TITLE
Fix test262 Bigint tests

### DIFF
--- a/src/main/resources/manuals/default/funcs/BigInt::asIntN.ir
+++ b/src/main/resources/manuals/default/funcs/BigInt::asIntN.ir
@@ -1,0 +1,18 @@
+def <BUILTIN>:INTRINSICS.BigInt.asIntN(
+  this: ESValue,
+  argumentsList: List[ESValue],
+  NewTarget: Object | Undefined,
+): Unknown {
+  if (< 0 argumentsList.length) let bits = (pop < argumentsList) else let bits = absent
+  if (< 0 argumentsList.length) let bigint = (pop < argumentsList) else let bigint = absent
+  call %0 = clo<ToIndex>(bits)
+  bits = [? %0]
+  call %1 = clo<ToBigInt>(bigint)
+  bigint = [? %1]
+  let mod = (% ([math] bigint) (** 2 bits))
+  if (! (< mod (** 2 (- bits 1)))) {
+    return ([bigInt] (- mod (** 2 bits)))
+  } else {
+    return ([bigInt] mod)
+  }
+}

--- a/src/main/resources/manuals/default/funcs/BigInt::asIntN.ir
+++ b/src/main/resources/manuals/default/funcs/BigInt::asIntN.ir
@@ -6,12 +6,13 @@ def <BUILTIN>:INTRINSICS.BigInt.asIntN(
   if (< 0 argumentsList.length) let bits = (pop < argumentsList) else let bits = absent
   if (< 0 argumentsList.length) let bigint = (pop < argumentsList) else let bigint = absent
   call %0 = clo<ToIndex>(bits)
-  bits = [? %0]
+  bits = ([bigInt] [? %0])
   call %1 = clo<ToBigInt>(bigint)
   bigint = [? %1]
-  let mod = (% ([math] bigint) (** 2 bits))
-  if (! (< mod (** 2 (- bits 1)))) {
-    return ([bigInt] (- mod (** 2 bits)))
+  let mod = (% bigint (** ([bigInt] 2) bits))
+  if (== bits 0n) return ([bigInt] 0) else 0
+  if (! (< mod (** ([bigInt] 2) (- bits ([bigInt] 1))))) {
+    return ([bigInt] (- mod (** ([bigInt] 2) bits)))
   } else {
     return ([bigInt] mod)
   }

--- a/src/main/resources/manuals/default/funcs/BigInt::asUintN.ir
+++ b/src/main/resources/manuals/default/funcs/BigInt::asUintN.ir
@@ -1,0 +1,13 @@
+def <BUILTIN>:INTRINSICS.BigInt.asUintN(
+  this: ESValue,
+  argumentsList: List[ESValue],
+  NewTarget: Object | Undefined,
+): Unknown {
+  if (< 0 argumentsList.length) let bits = (pop < argumentsList) else let bits = absent
+  if (< 0 argumentsList.length) let bigint = (pop < argumentsList) else let bigint = absent
+  call %0 = clo<ToIndex>(bits)
+  bits = [? %0]
+  call %1 = clo<ToBigInt>(bigint)
+  bigint = [? %1]
+  return ([bigInt] (% ([math] bigint) (** 2 bits)))
+}

--- a/src/main/resources/manuals/default/funcs/BigInt::asUintN.ir
+++ b/src/main/resources/manuals/default/funcs/BigInt::asUintN.ir
@@ -6,8 +6,8 @@ def <BUILTIN>:INTRINSICS.BigInt.asUintN(
   if (< 0 argumentsList.length) let bits = (pop < argumentsList) else let bits = absent
   if (< 0 argumentsList.length) let bigint = (pop < argumentsList) else let bigint = absent
   call %0 = clo<ToIndex>(bits)
-  bits = [? %0]
+  bits = ([bigInt] [? %0])
   call %1 = clo<ToBigInt>(bigint)
   bigint = [? %1]
-  return ([bigInt] (% ([math] bigint) (** 2 bits)))
+  return ([bigInt] (% bigint (** ([bigInt] 2) bits)))
 }

--- a/src/main/resources/manuals/default/test262/filtered.json
+++ b/src/main/resources/manuals/default/test262/filtered.json
@@ -309,8 +309,6 @@
     "built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-rejected",
     "built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result",
     "built-ins/Atomics/wait/good-views",
-    "built-ins/BigInt/asIntN/arithmetic",
-    "built-ins/BigInt/asUintN/arithmetic",
     "built-ins/BigInt/wrapper-object-ordinary-toprimitive",
     "built-ins/Boolean/prototype/S15.6.3.1_A1",
     "built-ins/Function/private-identifiers-not-empty",

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -662,7 +662,9 @@ object Interpreter {
       case (Mul, Number(l), Number(r))  => Number(l * r)
       case (Pow, Number(l), Number(r))  => Number(math.pow(l, r))
       case (Div, Number(l), Number(r))  => Number(l / r)
-      case (Mod, Number(l), Number(r))  => Number(l % r)
+      case (Mod, Number(l), Number(r)) =>
+        val m = l % r
+        Number(if (m * r) < 0 then r + m else m)
       case (UMod, Number(l), Number(r)) => Number(l %% r)
       case (Lt, Number(l), Number(r)) if (l equals -0.0) && (r equals 0.0) =>
         Bool(true)
@@ -719,7 +721,9 @@ object Interpreter {
       case (Sub, BigInt(l), BigInt(r))     => BigInt(l - r)
       case (Mul, BigInt(l), BigInt(r))     => BigInt(l * r)
       case (Div, BigInt(l), BigInt(r))     => BigInt(l / r)
-      case (Mod, BigInt(l), BigInt(r))     => BigInt(l % r)
+      case (Mod, BigInt(l), BigInt(r)) =>
+        val m = l % r
+        BigInt(if (m * r) < 0 then r + m else m)
       case (UMod, BigInt(l), BigInt(r))    => BigInt(l %% r)
       case (Lt, BigInt(l), BigInt(r))      => Bool(l < r)
       case (BAnd, BigInt(l), BigInt(r))    => BigInt(l & r)

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -1,16 +1,18 @@
 package esmeta.interpreter
 
 import esmeta.EVAL_LOG_DIR
+import esmeta.TEST_MODE
 import esmeta.cfg.*
 import esmeta.error.*
-import esmeta.ir.{Func => IRFunc, *}
 import esmeta.es.*
-import esmeta.parser.{ESParser, ESValueParser}
+import esmeta.ir.{Func => IRFunc, _}
+import esmeta.parser.ESParser
+import esmeta.parser.ESValueParser
 import esmeta.state.*
 import esmeta.ty.*
-import esmeta.util.BaseUtils.{error => _, *}
+import esmeta.util.BaseUtils.{error => _, _}
 import esmeta.util.SystemUtils.*
-import esmeta.TEST_MODE
+
 import java.io.PrintWriter
 import scala.annotation.tailrec
 import scala.collection.mutable.{Map => MMap}
@@ -657,11 +659,11 @@ object Interpreter {
     import BOp.*
     (bop, left, right) match {
       // double operations
-      case (Add, Number(l), Number(r))  => Number(l + r)
-      case (Sub, Number(l), Number(r))  => Number(l - r)
-      case (Mul, Number(l), Number(r))  => Number(l * r)
-      case (Pow, Number(l), Number(r))  => Number(math.pow(l, r))
-      case (Div, Number(l), Number(r))  => Number(l / r)
+      case (Add, Number(l), Number(r)) => Number(l + r)
+      case (Sub, Number(l), Number(r)) => Number(l - r)
+      case (Mul, Number(l), Number(r)) => Number(l * r)
+      case (Pow, Number(l), Number(r)) => Number(math.pow(l, r))
+      case (Div, Number(l), Number(r)) => Number(l / r)
       case (Mod, Number(l), Number(r)) =>
         val m = l % r
         Number(if (m * r) < 0 then r + m else m)
@@ -724,12 +726,12 @@ object Interpreter {
       case (Mod, BigInt(l), BigInt(r)) =>
         val m = l % r
         BigInt(if (m * r) < 0 then r + m else m)
-      case (UMod, BigInt(l), BigInt(r))    => BigInt(l %% r)
-      case (Lt, BigInt(l), BigInt(r))      => Bool(l < r)
-      case (BAnd, BigInt(l), BigInt(r))    => BigInt(l & r)
-      case (BOr, BigInt(l), BigInt(r))     => BigInt(l | r)
-      case (BXOr, BigInt(l), BigInt(r))    => BigInt(l ^ r)
-      case (Pow, BigInt(l), BigInt(r))     => BigInt(l.pow(r.toInt))
+      case (UMod, BigInt(l), BigInt(r)) => BigInt(l %% r)
+      case (Lt, BigInt(l), BigInt(r))   => Bool(l < r)
+      case (BAnd, BigInt(l), BigInt(r)) => BigInt(l & r)
+      case (BOr, BigInt(l), BigInt(r))  => BigInt(l | r)
+      case (BXOr, BigInt(l), BigInt(r)) => BigInt(l ^ r)
+      case (Pow, BigInt(l), BigInt(r))  => BigInt(l.pow(r.toInt))
 
       case (_, lval, rval) => throw InvalidBinaryOp(bop, lval, rval)
     }


### PR DESCRIPTION
Fixes #107.

3229ef8 copies ir generated by esmeta.

39d3553 apply manual changes to the IRs to fix problem no.1 mentioned in #107.

b91ea0f makes scala behave the way spec expects wrt to modulo operation.