### PR TITLE
Add e2e tests to ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,27 @@
+name: e2e
+on:
+  push:
+  pull_request:
+env:
+  ESMETA_HOME: ${{ github.workspace }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Run e2e tests
+      run: |
+        sbt assembly
+        cd $ESMETA_HOME/client 
+        npm ci
+        npx playwright install chromium --with-deps
+        npx playwright test --project=chromium
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30


### PR DESCRIPTION
Use [playwright](https://playwright.dev/) as an e2e testing tool.

Though I'm a little worried about test flakiness, which I suffered first-hand for months, which also surfaced during testing, as evidenced by [this run](https://github.com/doehyunbaek/esmeta/actions/runs/3569481008/jobs/5999486116) and [this run](https://github.com/doehyunbaek/esmeta/actions/runs/3564971053/jobs/5989567431).

However, with suitable strategies to control flakiness like retry, I think benefit outweight the harm. So I propose integrating e2e as a trial for 2~3 months and test whether it works well. Until the decision to remove e2e tests, I'll maintaini the flaky tests if it arises.