### PR TITLE
Fixed bugs in metalanguage parser for `this` nonterminals

### DIFF
--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -501,7 +501,8 @@ trait Parsers extends IndentParsers {
   // literals
   // GetIdentifierReference uses 'the value'
   lazy val literal: PL[Literal] = opt("the" ~ opt(langType) ~ "value") ~> (
-    (opt("the") ~> "*this* value" | "this Parse Node") ^^! ThisLiteral() |||
+    opt("the") ~> "*this* value" ^^! ThisLiteral() |||
+    "this" ~ ("Parse Node" | ntLiteral) ^^! ThisLiteral() |||
     "NewTarget" ^^! NewTargetLiteral() |||
     hexLiteral |||
     "`[^`]+`".r ^^ { case s => CodeLiteral(s.substring(1, s.length - 1)) } |||
@@ -554,7 +555,7 @@ trait Parsers extends IndentParsers {
   lazy val ntLiteral: PL[NonterminalLiteral] =
     lazy val flags: P[List[String]] =
       "[" ~> repsep("^[~+][A-Z][a-z]+".r, ",") <~ "]" | "" ^^^ Nil
-    opt("the grammar symbol" | "the" | "this") ~> opt(ordinal) ~
+    opt("the grammar symbol" | "the") ~> opt(ordinal) ~
     ("|" ~> word <~ opt("?")) ~ flags <~ "|" ^^ {
       case ord ~ x ~ fs => NonterminalLiteral(ord, x, fs)
     }


### PR DESCRIPTION
The following JS code throws a `ReferenceError` in ESMeta interpretation because of the wrong interpretation of `HasCallInTailPosition` for the function call `f ( )`.
```js
function f ( ) { }
( x => f ( ) ( x ) ) ( ) ;
```
It happens because of the wrong metalanguage parser for `this` nonterminal literals.
In the SDO, the expression `this |CallExpression|` should be parsed into a `ThisLiteral`, but it was parsed into a `NonterminalLiteral` as same as the expression `|CallExpression|`.
```
Static Semantics: HasCallInTailPosition (
    _call_: unknown,
): a Boolean

<emu-grammar>CallExpression : CallExpression Arguments</emu-grammar>
<emu-alg>
    1. If this |CallExpression| is _call_, return *true*.
    1. Return *false*.
</emu-alg>
```
This PR resolved this problem.