### PR TITLE
Supported `-extract:eval` to evaluate Extractor

### DIFF
--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test inject mutate analyze"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:repl"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl"
   compileOpt="-compile:log -compile:log-with-loc"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:ignore -tycheck:update-ignore -tycheck:log"

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -8,6 +8,7 @@ import esmeta.util.BaseUtils.*
 
 /** metalanguage parser */
 object Parser extends Parsers
+object ParserForEval extends Parsers { override def eval = true }
 trait Parsers extends IndentParsers {
   // shortcuts
   type P[T] = EPackratParser[T]

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -3,6 +3,7 @@ package esmeta.phase
 import esmeta.*
 import esmeta.extractor.Extractor
 import esmeta.lang.Step
+import esmeta.lang.util.ParserForEval.{getParseCount, getCacheCount}
 import esmeta.spec.*
 import esmeta.util.*
 import esmeta.util.BaseUtils.*
@@ -18,7 +19,11 @@ case object Extract extends Phase[Unit, Spec] {
     cmdConfig: CommandConfig,
     config: Config,
   ): Spec = if (!config.repl) {
-    val spec = Extractor(config.target)
+    lazy val spec = Extractor(config.target, config.eval)
+    if (config.eval)
+      time("extracting specification", spec)
+      println(f"- # of actual parsing: $getParseCount%,d")
+      println(f"- # of using cached result: $getCacheCount%,d")
     if (config.log) log(spec)
     spec
   } else {
@@ -100,6 +105,11 @@ case object Extract extends Phase[Unit, Spec] {
       "turn on logging mode.",
     ),
     (
+      "eval",
+      BoolOption(c => c.eval = true),
+      "evaluate the extractor.",
+    ),
+    (
       "repl",
       BoolOption(c => c.repl = true),
       "use a REPL for metalanguage parser.",
@@ -108,6 +118,7 @@ case object Extract extends Phase[Unit, Spec] {
   case class Config(
     var target: Option[String] = None,
     var log: Boolean = false,
+    var eval: Boolean = false,
     var repl: Boolean = false,
   )
 }


### PR DESCRIPTION
This PR supported `-extract:eval` option by extending `EPackrtParsers` with [`AtomicInteger`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/atomic/AtomicInteger.html).
```shell
$ esmeta extract -extract:eval -silent
# extracting specification... (6,013 ms)
# - # of actual parsing: 3,240,105
# - # of using cached result: 1,889,181
```