### PR TITLE
Supported multiple RHS conditions

### DIFF
--- a/src/main/scala/esmeta/mutator/synthesizer/RandomSynthesizer.scala
+++ b/src/main/scala/esmeta/mutator/synthesizer/RandomSynthesizer.scala
@@ -18,7 +18,7 @@ class RandomSynthesizer(
     val argsMap = (lhs.params zip args).toMap
     val pairs = for {
       (rhs, rhsIdx) <- rhsList.zipWithIndex
-      if rhs.condition.fold(true)(cond => argsMap(cond.name) == cond.pass)
+      if rhs.available(argsMap)
     } yield (rhs, rhsIdx)
     val (rhs, rhsIdx) = choose(pairs)
     val children = rhs.symbols.flatMap(synSymbol(argsMap))

--- a/src/main/scala/esmeta/mutator/synthesizer/SimpleSynthesizer.scala
+++ b/src/main/scala/esmeta/mutator/synthesizer/SimpleSynthesizer.scala
@@ -29,7 +29,7 @@ class SimpleSynthesizer(
       val argsMap = (lhs.params zip args).toMap
       val syns = for {
         (rhs, rhsIdx) <- rhsList.zipWithIndex
-        if rhs.condition.fold(true)(cond => argsMap(cond.name) == cond.pass)
+        if rhs.available(argsMap)
         children <- optional(rhs.symbols.flatMap(synSymbol(argsMap)))
         syn = Syntactic(name, args, rhsIdx, children)
       } yield syn

--- a/src/main/scala/esmeta/parser/Lexer.scala
+++ b/src/main/scala/esmeta/parser/Lexer.scala
@@ -82,13 +82,11 @@ trait Lexer extends UnicodeParsers {
 
   // get a parser for a right-hand side (RHS)
   protected def getRhsParser(rhs: Rhs, argsSet: Set[String]): Parser[String] =
-    rhs.condition match {
-      case Some(RhsCond(name, pass)) if (argsSet contains name) != pass => FAIL
-      case _ =>
-        rhs.symbols
-          .map(getSymbolParser(_, argsSet))
-          .reduce(_ % _)
-    }
+    if (rhs.available(argsSet))
+      rhs.symbols
+        .map(getSymbolParser(_, argsSet))
+        .reduce(_ % _)
+    else FAIL
 
   // get a parser for a symbol
   protected def getSymbolParser(

--- a/src/main/scala/esmeta/spec/Rhs.scala
+++ b/src/main/scala/esmeta/spec/Rhs.scala
@@ -7,7 +7,7 @@ import esmeta.util.BaseUtils.cached
 
 /** alternatives or right-hand-sides (RHSs) of productions */
 case class Rhs(
-  condition: Option[RhsCond],
+  conditions: List[RhsCond],
   symbols: List[Symbol],
   id: Option[String],
 ) extends SpecElem {
@@ -61,6 +61,15 @@ case class Rhs(
   /** get parameters from RHSs */
   def params: List[Param] =
     nts.map(nt => Param(nt.name, Type(AstT(nt.name))))
+
+  /** check whether the RHS is available */
+  def available(argsSet: Set[String]): Boolean = conditions.forall {
+    case RhsCond(name, pass) => (argsSet contains name) == pass
+  }
+
+  /** check whether the RHS is available */
+  def available(argsMap: Map[String, Boolean]): Boolean =
+    conditions.forall(cond => argsMap(cond.name) == cond.pass)
 }
 object Rhs extends Parser.From(Parser.rhs) {
 

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -41,7 +41,7 @@ trait Parsers extends LangParsers {
         val rs = for {
           r <- origRs
           s <- r.symbols
-        } yield Rhs(None, List(s), None)
+        } yield Rhs(Nil, List(s), None)
         Production(l, k, true, rs)
       case l ~ k ~ None ~ rs => Production(l, k, false, rs)
     }
@@ -64,18 +64,18 @@ trait Parsers extends LangParsers {
   /** production alternative right-hand-sides (RHSs) */
   given rhs: Parser[Rhs] = {
     lazy val rhsId: Parser[String] = "#" ~> "[-a-zA-Z0-9]+".r
-    opt(rhsCond) ~ rep1(symbol) ~ opt(rhsId) ^^ {
-      case c ~ ss ~ i =>
-        Rhs(c, ss, i)
+    opt(rhsConds) ~ rep1(symbol) ~ opt(rhsId) ^^ {
+      case cs ~ ss ~ i => Rhs(cs.getOrElse(Nil), ss, i)
     }
   }.named("spec.Rhs")
 
   /** RHS conditions */
+  given rhsConds: Parser[List[RhsCond]] = {
+    "[" ~> rep1sep(rhsCond, ",") <~ "]"
+  }.named("List[spec.RhsCond]")
+
   given rhsCond: Parser[RhsCond] = {
-    "[" ~> ("[+~]".r) ~ word <~ "]" ^^ {
-      case str ~ name =>
-        RhsCond(name, str == "+")
-    }
+    ("[+~]".r) ~ word ^^ { case str ~ name => RhsCond(name, str == "+") }
   }.named("spec.RhsCond")
 
   /** grammar symbols */

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -101,17 +101,20 @@ object Stringifier {
 
   // for production alternative right-hand-sides (RHSs)
   given rhsRule: Rule[Rhs] = (app, rhs) =>
-    val Rhs(condition, symbols, id) = rhs
+    val Rhs(conditions, symbols, id) = rhs
     given Rule[List[Symbol]] = iterableRule(sep = " ")
-    condition.foreach(app >> _ >> " ")
+    if (conditions.nonEmpty) app >> conditions >> " "
     app >> symbols
     id.foreach(app >> " #" >> _)
     app
 
   // for condidtions for RHSs
+  given rhsCondsRule: Rule[List[RhsCond]] = iterableRule("[", ", ", "]")
+
+  // for condidtions for RHSs
   given rhsCondRule: Rule[RhsCond] = (app, rhsCond) =>
     val RhsCond(name, pass) = rhsCond
-    app >> "[" >> (if (pass) "+" else "~") >> name >> "]"
+    app >> (if (pass) "+" else "~") >> name
 
   // for condidtions for symbols
   given symbolRule: Rule[Symbol] = (app, symbol) =>

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -80,14 +80,19 @@ class StringifyTinyTest extends SpecTest {
 
     // rhs conditions
     checkParseAndStringify("RhsCond", RhsCond)(
-      RhsCond("Hello", true) -> "[+Hello]",
-      RhsCond("Bye", false) -> "[~Bye]",
+      RhsCond("Hello", true) -> "+Hello",
+      RhsCond("Bye", false) -> "~Bye",
     )
 
     val rhsCond: RhsCond = RhsCond("Yield", true)
-    val rhs1: Rhs = Rhs(Some(rhsCond), symbols, None)
-    val rhs2: Rhs = Rhs(None, symbols, Some("this-is-id"))
-    val rhs3: Rhs = Rhs(None, List(Terminal("a")), None)
+    val rhs1: Rhs = Rhs(List(rhsCond), symbols, None)
+    val rhs2: Rhs = Rhs(Nil, symbols, Some("this-is-id"))
+    val rhs3: Rhs = Rhs(Nil, List(Terminal("a")), None)
+    val rhs4: Rhs = Rhs(
+      List(RhsCond("Hello", true), RhsCond("Bye", false)),
+      List(Terminal("a")),
+      None,
+    )
     val lhs1 = Lhs("Identifier", List("Yield", "Await", "In"))
     val lhs2 = Lhs("Identifier", Nil)
     val prod1 =
@@ -102,6 +107,7 @@ class StringifyTinyTest extends SpecTest {
       rhs1 -> "[+Yield] `{` `}`",
       rhs2 -> "`{` `}` #this-is-id",
       rhs3 -> "`a`",
+      rhs4 -> "[+Hello, ~Bye] `a`",
     )
 
     // lhs


### PR DESCRIPTION
Added this feature to resolve #133.
For example, the following RHS alternative
```
[+Hello, ~Bye] `a`
```
will be parsed as follows:
```scala
Rhs(
  List(RhsCond("Hello", true), RhsCond("Bye", false)),
  List(Terminal("a")),
  None,
)
```