### PR TITLE
Allow whitespace separated evaluation of expression

### DIFF
--- a/src/main/scala/esmeta/analyzer/repl/command/CmdPrint.scala
+++ b/src/main/scala/esmeta/analyzer/repl/command/CmdPrint.scala
@@ -37,7 +37,8 @@ case object CmdPrint
             println(ret.state.getString(ret.value))
         }
       }
-      case s"-${`expr`}" :: str :: _ => {
+      case s"-${`expr`}" :: rest => {
+        val str = rest.mkString(" ")
         val sem = repl.sem
         val v = sem.transfer(cp, Expr.from(str))
         val st = cp match {


### PR DESCRIPTION
Before, in analyzer repl, commands such as this did not work
```console
analyzer> print -expr (< 0 len)
[ESMeta v0.2.0] [Parser (ir.Expr)] [1.3] failure: string matching regex '[_a-zA-Z][_a-zA-Z0-9]*' expected but end of source found

(<
  ^
```

This is because argparsing accepted only the first string and discarded the rest.

With this commit, the above command now works.

```console
analyzer> print -expr (< 0 len)
Bot
```