### PR TITLE
Fixed bugs in Spec parser for terminals (#145)

### DIFF
--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -88,7 +88,7 @@ trait Parsers extends LangParsers {
 
   /** terminals */
   lazy val term: Parser[Terminal] = {
-    "`[^`]+`|```".r ^^ {
+    "`[^`]+`|`[`]+`".r ^^ {
       case str =>
         Terminal(str.substring(1, str.length - 1))
     }


### PR DESCRIPTION
I fixed a bug in the `Spec` parser for terminals.
The PR https://github.com/tc39/ecma262/pull/2418 in ecma262 defines a new terminal: ` `` ` as follows:
```
      <emu-grammar type="definition">
        ClassSetReservedDoublePunctuator :: one of
          `&amp;&amp;` `!!` `##`
          `$$` `%%` `**`
          `++` `,,` `..`
          `::` `;;` `&lt;&lt;`
          `==` `&gt;&gt;` `??`
          `@@` `^^` `&grave;&grave;`
          `~~`
      </emu-grammar>
```
However, the current `Spec` parser for terminals only supports a single quote `` ` ``. So, I fixed this problem by extending the `Spec` parser to support one or more repetitions of `` ` ``.