### PR TITLE
Extend Unicode terminal parsing

### DIFF
--- a/src/main/scala/esmeta/error/ParseError.scala
+++ b/src/main/scala/esmeta/error/ParseError.scala
@@ -1,5 +1,7 @@
 package esmeta.error
 
+import esmeta.spec.Symbol
+
 sealed abstract class ParseError(msg: String)
   extends ESMetaError(msg, "ParseError")
 
@@ -11,6 +13,9 @@ case class WrongNumberOfParserParams(name: String, list: List[Boolean])
 
 case class ESValueParserFailed(str: String)
   extends ParseError(s"ESValueParser failed: $str")
+
+case class UnexpectedSymbol(symbol: Symbol)
+  extends ParseError(s"unexpected symbol: $symbol")
 
 case object UnexpectedParseResult
   extends ParseError(s"unexpected parsing result")

--- a/src/main/scala/esmeta/parser/ESParser.scala
+++ b/src/main/scala/esmeta/parser/ESParser.scala
@@ -175,10 +175,9 @@ case class ESParser(
         .reduce(_ | _)
       lazy val lookahead = ntl(symbol.toString, parser)
       prev <~ (if (contains) +lookahead else -lookahead)
-    case Empty               => prev
-    case NoLineTerminator    => prev <~ noLineTerminator
-    case CodePointAbbr(abbr) => ???
-    case UnicodeSet(cond)    => ???
+    case Empty            => prev
+    case NoLineTerminator => prev <~ noLineTerminator
+    case _                => throw UnexpectedSymbol(symbol)
 
   // a terminal lexer
   protected val TERMINAL: Lexer = grammar.prods.foldLeft[Parser[String]]("") {

--- a/src/main/scala/esmeta/parser/Lexer.scala
+++ b/src/main/scala/esmeta/parser/Lexer.scala
@@ -109,14 +109,15 @@ trait Lexer extends UnicodeParsers {
         .map(_.map(getSymbolParser(_, argsSet)).reduce(_ % _))
         .reduce(_ ||| _)
       "" <~ (if (b) guard else not)(parser)
-    case Empty            => EMPTY
-    case NoLineTerminator => strNoLineTerminator
+    case Empty               => EMPTY
+    case NoLineTerminator    => strNoLineTerminator
+    case CodePoint(cp, desc) => cp.toChar.toString.r
     case CodePointAbbr(abbr) =>
       abbrCPs.getOrElse(
         abbr,
         error(s"unknown code point abbreviation: <$abbr>"),
       )
-    case UnicodeSet(None)                                         => Unicode
+    case UnicodeSet(None)                                         => Any
     case UnicodeSet(Some("with the Unicode property “ID_Start”")) => IDStart
     case UnicodeSet(Some("with the Unicode property “ID_Continue”")) =>
       IDContinue

--- a/src/main/scala/esmeta/parser/Unicode.scala
+++ b/src/main/scala/esmeta/parser/Unicode.scala
@@ -4,7 +4,7 @@ import esmeta.*
 import esmeta.util.SystemUtils.*
 import io.circe.*, io.circe.syntax.*, io.circe.parser.*
 
-object CodePoint {
+object Unicode {
   val RECENT_VERSION = "14.0.0"
 
   lazy val IDStart = get("ID_Start")

--- a/src/main/scala/esmeta/parser/UnicodeParsers.scala
+++ b/src/main/scala/esmeta/parser/UnicodeParsers.scala
@@ -28,11 +28,11 @@ trait UnicodeParsers extends BasicParsers with EPackratParsers {
   val PS = "\u2029".r
 
   lazy val lines = "[\u000A\u000D\u2028\u2029]".r
-  lazy val Unicode = "(?s).".r
+  lazy val Any = "(?s).".r
   lazy val IDStart =
-    Unicode.filter(s => CodePoint.IDStart contains toCodePoint(s))
+    Any.filter(s => Unicode.IDStart contains toCodePoint(s))
   lazy val IDContinue =
-    Unicode.filter(s => CodePoint.IDContinue contains toCodePoint(s))
+    Any.filter(s => Unicode.IDContinue contains toCodePoint(s))
 
   protected def toCodePoint(str: String): Int =
     def check4B(i: Int): Boolean =

--- a/src/main/scala/esmeta/spec/Symbol.scala
+++ b/src/main/scala/esmeta/spec/Symbol.scala
@@ -68,6 +68,9 @@ case object Empty extends Symbol
 case object NoLineTerminator extends Symbol
 
 /** symbols for code point abbreviations */
+case class CodePoint(cp: Int, desc: String) extends Symbol
+
+/** symbols for code point abbreviations */
 case class CodePointAbbr(abbr: String) extends Symbol
 
 /** symbols for sets of unicode code points with a condition */

--- a/src/main/scala/esmeta/spec/util/JsonProtocol.scala
+++ b/src/main/scala/esmeta/spec/util/JsonProtocol.scala
@@ -50,6 +50,7 @@ object JsonProtocol extends BasicJsonProtocol {
     "cases" -> (_.as[Lookahead]),
     "empty" -> (_ => Right(Empty)),
     "nlt" -> (_ => Right(NoLineTerminator)),
+    "cp" -> (_.as[CodePoint]),
     "abbr" -> (_.as[CodePointAbbr]),
     "cpCond" -> (_.as[UnicodeSet]),
   )
@@ -62,6 +63,7 @@ object JsonProtocol extends BasicJsonProtocol {
     case symbol: Lookahead     => symbol.asJson
     case Empty                 => Json.obj("empty" -> Json.Null)
     case NoLineTerminator      => Json.obj("nlt" -> Json.Null)
+    case symbol: CodePoint     => symbol.asJson
     case symbol: CodePointAbbr => symbol.asJson
     case symbol: UnicodeSet    => symbol.asJson
   }
@@ -81,6 +83,8 @@ object JsonProtocol extends BasicJsonProtocol {
   given Encoder[ButOnlyIf] = deriveEncoder
   given Decoder[Lookahead] = deriveDecoder
   given Encoder[Lookahead] = deriveEncoder
+  given Decoder[CodePoint] = deriveDecoder
+  given Encoder[CodePoint] = deriveEncoder
   given Decoder[CodePointAbbr] = deriveDecoder
   given Encoder[CodePointAbbr] = deriveEncoder
   given Decoder[UnicodeSet] = deriveDecoder

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -81,7 +81,7 @@ trait Parsers extends LangParsers {
   /** grammar symbols */
   given symbol: Parser[Symbol] = {
     {
-      term | butnot | lookahead | butOnlyIf | nt | abbr | unicodeSet |
+      term | butnot | lookahead | butOnlyIf | nt | cp | abbr | unicodeSet |
       empty | nlt
     } ~ opt("?") ^^ { case s ~ o => if (o.isDefined) Optional(s) else s }
   }.named("spec.Symbol")
@@ -128,6 +128,15 @@ trait Parsers extends LangParsers {
   lazy val nlt: Parser[NoLineTerminator.type] = {
     "\\[no [\\|]?LineTerminator[\\|]? here\\]".r ^^^ NoLineTerminator
   }.named("spec.NoLineTerminator")
+
+  /** symbols for code point abbreviations */
+  lazy val cp: Parser[CodePoint] = {
+    lazy val unicode = "U[+]([1-9A-F]|10)?[0-9A-F]{4}".r
+    "<" ~> unicode ~ rep(word) <~ ">" ^^ {
+      case cp ~ desc =>
+        CodePoint(Integer.parseInt(cp.drop(2), 16), desc.mkString(" "))
+    }
+  }.named("spec.CodePoint")
 
   /** symbols for code point abbreviations */
   lazy val abbr: Parser[CodePointAbbr] = {

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -128,6 +128,8 @@ object Stringifier {
       case ButNot(base, cases) => app >> base >> " but not " >> cases
       case Empty               => app >> "[empty]"
       case NoLineTerminator    => app >> "[no LineTerminator here]"
+      case CodePoint(cp, desc) =>
+        app >> "<U+" >> cp >> (if (desc == "") "" else " " + desc) >> ">"
       case CodePointAbbr(abbr) => app >> "<" >> abbr >> ">"
       case Nonterminal(name, args) =>
         app >> name


### PR DESCRIPTION
For #147, I extended the Unicode terminal parsing algorithm by adding the `CodePoint` case for symbols in the spec.
Now, we support the following terminal symbols as well according to [The Unicode Standard, Version 15.0.0, Appendix A, Notational Conventions](https://www.unicode.org/versions/Unicode15.0.0/appA.pdf) and https://github.com/rbuckton/grammarkdown/issues/91:
```
<U+2212 MINUS SIGN>
```