### PR TITLE
Fix for missing optional parameters state in getLocals

### DIFF
--- a/src/main/scala/esmeta/analyzer/TypeSemantics.scala
+++ b/src/main/scala/esmeta/analyzer/TypeSemantics.scala
@@ -76,10 +76,10 @@ class TypeSemantics(
     // construct local type environment
     (for (((param, arg), idx) <- (params zip argsWithOptional).zipWithIndex)
       yield {
-        val argTy = removeAbsentTy(arg.ty)
         val expected = param.ty.ty match
           case _: UnknownTy => arg
           case paramTy: ValueTy =>
+            val argTy = removeAbsentTy(arg.ty)
             if (method && idx == 0) () /* ignore `this` for method-like calls */
             else if (!(argTy <= paramTy))
               val key = (callerNp, calleeRp, idx, param)


### PR DESCRIPTION
The `getLocals` function can be used even if some optional parameters are not provided. However, if some optional arguments are missing, the `params zip args` does not consider the value of unprovided optional parameter, where an `AbsentTop` value is expected.

This PR fixes this by ensuring `AbsentTop` is provided for value of missing optional arguments.

### Reproduction

If you want to get quick reproduction, run following REPL command:
```
esmeta tycheck -tycheck:repl -tycheck:target=CreateArrayFromList
```
The `ArrayCreate` function is called at the first instruction. This function requires a 'length' as its first parameter and optionally a 'proto' as the second parameter. However, when `CreateArrayFromList` calls `ArrayCreate`, it doesn't provide this second argument. Consequently, at the entry point, `ArrayCreate` is unable to find 'proto' in its state due to the fact that `params zip args` doesn't provide any value for missing arguments.

This absence of 'proto' leads to a condition `(= proto absent)` in `ArrayCreate` resulting in 'Bot'. This 'Bot' result in turn prevents the addition of any subsequent block (i.e., 'then' or 'else' blocks) into worklist. As a result, the analysis is not fully completed and terminates prematurely.