### PR TITLE
Rewrap to completion if function returns completion record type

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsSemantics.scala
+++ b/src/main/scala/esmeta/analyzer/AbsSemantics.scala
@@ -208,6 +208,9 @@ class AbsSemantics(
   def doReturn(elem: Return, rp: ReturnPoint, origRet: AbsRet): Unit =
     val ReturnPoint(func, view) = rp
     val retRp = ReturnPoint(func, getEntryView(view))
+    // wrap completion by conditions specified in
+    // [5.2.3.5 Implicit Normal Completion]
+    // (https://tc39.es/ecma262/#sec-implicit-normal-completion)
     val newRet = if (func.isReturnComp) origRet.wrapCompletion else origRet
     if (!newRet.value.isBottom)
       val oldRet = this(retRp)

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -94,7 +94,10 @@ class AbsTransfer(sem: AbsSemantics) extends Optimized with PruneHelper {
       .map(ty => {
         if (!value.unwrapCompletion.isBottom) {
           val (newV, newSt) = st.setType(value.unwrapCompletion, ty)
-          value = newV ⊔ value.abruptCompletion
+          // wrap completion by conditions specified in
+          // [5.2.3.5 Implicit Normal Completion]
+          // (https://tc39.es/ecma262/#sec-implicit-normal-completion)
+          value = if (rp.func.isReturnComp) newV.wrapCompletion else newV
           st = newSt
         }
       })

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -119,9 +119,6 @@ class AbsTransfer(sem: AbsSemantics) extends Optimized with PruneHelper {
 
       val newSt = st.doReturn(
         callerSt,
-        // wrap completion by conditions specified in
-        // [5.2.3.5 Implicit Normal Completion]
-        // (https://tc39.es/ecma262/#sec-implicit-normal-completion)
         call.lhs -> value,
       )
 

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -83,7 +83,7 @@ private class TypeAnalyzer(
   // get view from a function
   def getView(func: Func): View = View()
 
-  // get return point
+  // get initial state of function
   def getState(func: Func): AbsState = func.params.foldLeft(AbsState.Empty) {
     case (st, Param(x, ty, opt, _)) =>
       var v = AbsValue(ty.ty)

--- a/src/main/scala/esmeta/analyzer/TypeSemantics.scala
+++ b/src/main/scala/esmeta/analyzer/TypeSemantics.scala
@@ -137,6 +137,9 @@ class TypeSemantics(
   /** update return points */
   override def doReturn(elem: Return, rp: ReturnPoint, origRet: AbsRet): Unit =
     val ReturnPoint(func, view) = rp
+    // wrap completion by conditions specified in
+    // [5.2.3.5 Implicit Normal Completion]
+    // (https://tc39.es/ecma262/#sec-implicit-normal-completion)
     val newRet = if (func.isReturnComp) origRet.wrapCompletion else origRet
     val givenTy = removeAbsentTy(newRet.value.ty)
     val expected = rp.func.retTy.ty match


### PR DESCRIPTION
The result type modified by `Interpreter.setTypeMap` needs to be rewrapped if the function returns completion record.
There are already many parts of our code do the same thing.
https://github.com/es-meta/esmeta/blob/a47e674b23ac53e5148722720e44e08e5e376707/src/main/scala/esmeta/analyzer/AbsTransfer.scala#L244
https://github.com/es-meta/esmeta/blob/a47e674b23ac53e5148722720e44e08e5e376707/src/main/scala/esmeta/interpreter/Interpreter.scala#L552
... and more.

And this PR adds/moves some comments related with `Implicit Normal Completion`.