### PR TITLE
Add PropertyKey support in PureValueTy parser

### DIFF
--- a/src/main/scala/esmeta/ty/util/Parser.scala
+++ b/src/main/scala/esmeta/ty/util/Parser.scala
@@ -72,6 +72,8 @@ trait Parsers extends BasicParsers {
     singleListTy ^^ { case l => PureValueTy(list = l) } |
     // symbol
     "Symbol" ^^^ PureValueTy(symbol = true) |
+    // Property key
+    "PropertyKey" ^^^ PureValueTy(str = Inf, symbol = true) |
     // AST value
     singleAstValueTy ^^ { case ast => PureValueTy(astValue = ast) } |
     // nt


### PR DESCRIPTION
This PR introduces `PropertyKey` type for precise analysis.
Without this feature, currently we encounter a ReturnTypeMismatch issue as shown below:
```
[ReturnTypeMismatch] ModuleNamespaceExoticObject.OwnPropertyKeys (step 3, 4:14-74)
- expected: Normal[List[Symbol | String]]
- actual  : Normal[List[PropertyKey | String]]
```
