### PR TITLE
More precise lookup for string property of `AstNameTy`

### DIFF
--- a/src/main/resources/manuals/d711ba960cd12b76/tycheck-ignore.json
+++ b/src/main/resources/manuals/d711ba960cd12b76/tycheck-ignore.json
@@ -45,7 +45,6 @@
   "OptionalChain[9,0].ChainEvaluation",
   "OrdinaryFunctionCreate",
   "OrdinaryObject.OwnPropertyKeys",
-  "PerformEval",
   "ProxyCreate",
   "SerializeJSONObject",
   "SetFunctionLength",

--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -332,6 +332,15 @@ object TypeDomain extends state.Domain {
                 if (cfg.grammar.nameMap contains name) res ||= AstT(name)
                 else () // TODO warning(s"invalid access: $name of $ast")
           case Inf => res ||= AstT
+      case AstNameTy(names) =>
+        prop.str match
+          case Fin(ss) =>
+            for (s <- ss) s match
+              case "parent" => res ||= AstT
+              case name =>
+                if (cfg.grammar.nameMap contains name) res ||= AstT(name)
+                else () // TODO warning(s"invalid access: $name of $ast")
+          case Inf => res ||= AstT
       case _ => res ||= AstT
     // TODO if (!ast.isBottom)
     //   boundCheck(prop, MathT || StrT, t => s"invalid access: $t of $ast")


### PR DESCRIPTION
Previously, lookup of string property in AstNameTy did not work and just returned AstTopTy. For example, in es2022, there is a lookup of

  let body = script.ScriptBody

in [PerformEval](https://tc39.es/ecma262/2022/#sec-performeval)

<img width="321" alt="image" src="https://github.com/es-meta/esmeta/assets/70570804/10c18781-2099-45ed-86af-1a5d8f5a6b4d">


And according to the [spec](https://tc39.es/ecma262/#prod-ScriptBody), this should evaluate to Ast[StatementList] but did not, causing imprecision in the analysis.

There are six cases in es2022 when such lookup happens.
```
(Ast[CallMemberExpression],String["MemberExpression"])
(Ast[CallMemberExpression],String["Arguments"])
(Ast[CaseClause],String["Expression"])
(Ast[AsyncArrowHead],String["ArrowFormalParameters"])
(Ast[CallExpression, MemberExpression, OptionalChain],String["parent"])
(Ast[Script],String["ScriptBody"])
```
In all these cases except the fifth case, which is a lookup of "parent", I confirmed the type being more precise.

This commit fixes the issue.