### PR TITLE
Fix `getVersion` to handle tag properly

### DIFF
--- a/src/main/scala/esmeta/util/Git.scala
+++ b/src/main/scala/esmeta/util/Git.scala
@@ -46,7 +46,7 @@ abstract class Git(path: String, shortHashLength: Int = 16) { self =>
   /** get git commit version */
   def getVersion(target: String): Version =
     val name = executeCmd(s"git name-rev --name-only $target", path).trim
-    val hash = executeCmd(s"git rev-parse $target", path).trim
+    val hash = executeCmd(s"git rev-list -n 1 $target", path).trim
     Version(name, hash)
 
   /** get git commit hash for the current version */


### PR DESCRIPTION
Git tags are unique Git objects and thus have their own SHA1 hash. So the current implementation differentiates between a tag and the commit it points to. As a result, when `tycheck` using the `-extract:target=es2022` option, it's unable to correctly apply manual patches.

This PR changes git command for getting correct commit hash from the given target.
If this is intended, please feel free to close the pull request.