### PR TITLE
Implement UncheckedAbruptCompletionMismatch

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -734,6 +734,8 @@ trait AbsTransfer extends Optimized with PruneHelper {
   )(using cp: ControlPoint): Result[AbsValue] = {
     val checkReturn: Result[Unit] =
       if (check) doReturn(riaExpr, value.abruptCompletion)
+      else if (!value.abruptCompletion.isBottom)
+        warning(s"unchecked abrupt completion: $value")
       else ()
     for (_ <- checkReturn) yield value.unwrapCompletion
   }

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -726,7 +726,7 @@ trait AbsTransfer extends Optimized with PruneHelper {
         sem.rpMap += retRp -> (oldRet ⊔ newRet)
         sem.worklist += retRp
 
-  // return if abrupt completion
+  /** return-if-abrupt completion */
   def returnIfAbrupt(
     riaExpr: EReturnIfAbrupt,
     value: AbsValue,

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -734,8 +734,6 @@ trait AbsTransfer extends Optimized with PruneHelper {
   )(using cp: ControlPoint): Result[AbsValue] = {
     val checkReturn: Result[Unit] =
       if (check) doReturn(riaExpr, value.abruptCompletion)
-      else if (!value.abruptCompletion.isBottom)
-        warning(s"unchecked abrupt completion: $value")
       else ()
     for (_ <- checkReturn) yield value.unwrapCompletion
   }

--- a/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
+++ b/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
@@ -39,6 +39,7 @@ case class InternalReturnPoint(
   inline def func = calleeRp.func
 }
 
+/** return-if-abrupt points */
 case class ReturnIfAbruptPoint(
   cp: ControlPoint,
   riaExpr: EReturnIfAbrupt,

--- a/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
+++ b/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
@@ -1,6 +1,6 @@
 package esmeta.analyzer
 
-import esmeta.ir.Return
+import esmeta.ir.{Func => _, *}
 import esmeta.cfg.*
 
 /** analysis points */
@@ -37,6 +37,14 @@ case class InternalReturnPoint(
 ) extends AnalysisPoint {
   inline def view = calleeRp.view
   inline def func = calleeRp.func
+}
+
+case class ReturnIfAbruptPoint(
+  cp: ControlPoint,
+  riaExpr: EReturnIfAbrupt,
+) extends AnalysisPoint {
+  inline def view = cp.view
+  inline def func = cp.func
 }
 
 /** control points */

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -73,9 +73,7 @@ class TypeAnalyzer(
         if (check) doReturn(riaExpr, value.abruptCompletion)
         else if (!value.abruptCompletion.isBottom)
           val riap = ReturnIfAbruptPoint(cp, riaExpr)
-          addMismatch(
-            UncheckedAbruptCompletionMismatch(riap, value.ty),
-          )
+          addMismatch(UncheckedAbruptCompletionMismatch(riap, value.ty))
         else ()
       for (_ <- checkReturn) yield value.unwrapCompletion
     }

--- a/src/main/scala/esmeta/analyzer/TypeMismatch.scala
+++ b/src/main/scala/esmeta/analyzer/TypeMismatch.scala
@@ -29,3 +29,9 @@ case class ArityMismatch(
   cp: CallPoint[Node],
   actual: Int,
 ) extends TypeMismatch(cp)
+
+/** unchecked abrupt completion mismatches */
+case class UncheckedAbruptCompletionMismatch(
+  riap: ReturnIfAbruptPoint,
+  actual: ValueTy,
+) extends TypeMismatch(riap)

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -75,6 +75,10 @@ class Stringifier(
         app >> " when " >> cp
       case InternalReturnPoint(irReturn, calleeRp) =>
         app >> "return statement in " >> calleeRp.func.name >> irReturn
+      case ReturnIfAbruptPoint(riap, riaExpr) =>
+        app >> "returnIfAbrupt"
+        app >> "(" >> (if (riaExpr.check) "?" else "!") >> ") "
+        app >> "in " >> riap.func.name >> riaExpr
 
   // control points
   given cpRule: Rule[ControlPoint] = (app, cp) =>
@@ -130,6 +134,9 @@ class Stringifier(
         given Rule[(Int, Int)] = arityRangeRule
         app >> "[ArityMismatch] " >> cp
         app :> "- expected: " >> cp.func.arity
+        app :> "- actual  : " >> actual
+      case UncheckedAbruptCompletionMismatch(riap, actual) =>
+        app >> "[UncheckedAbruptCompletionMismatch] " >> riap
         app :> "- actual  : " >> actual
 
   private val addLocRule: Rule[IRElem with LangEdge] = (app, elem) => {


### PR DESCRIPTION
This PR adds `UncheckedAbruptCompletionMismatch`. When `returnIfAbrupt` operates under the assumption that the completion record is not abrupt (noted by a `!` in shorthand form), but the value is abrupt, we refer to this scenario as an unchecked abrupt completion.

<details>
<summary>UncheckedAbruptCompletion mismatches (total 273)</summary>

```
* 273 type mismatches are detected.
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AddRestrictedFunctionProperties (step 3, 4:20-174)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AddRestrictedFunctionProperties (step 4, 5:20-177)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.DefineOwnProperty (step 2, 3:32-60)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.DefineOwnProperty (step 5, 9:31-85)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.DefineOwnProperty (step 7.a.i, 13:26-49)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.DefineOwnProperty (step 7.b.i.2, 17:28-72)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.DefineOwnProperty (step 7.b.ii.1, 19:28-51)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Delete (step 2, 3:32-60)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Delete (step 4.a, 6:24-47)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Get (step 2, 3:32-60)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Get (step 4.b, 8:23-40)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.GetOwnProperty (step 4, 5:32-60)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.GetOwnProperty (step 5.a, 7:40-57)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Set (step 2.b, 6:34-62)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArgumentsExoticObject.Set (step 3.b, 9:24-55)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArraySetLength (step 1.a, 3:23-75)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArraySetLength (step 11.a, 14:23-81)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArraySetLength (step 15, 21:33-91)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ArraySetLength (step 18.a, 31:35-125)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AssignmentRestElement[0,0].IteratorDestructuringAssignmentEvaluation (step 4.e.iv, 16:26-92)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AssignmentRestElement[0,0].IteratorDestructuringAssignmentEvaluation (step 4.e.iv, 16:59-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncConciseBody[0,0].EvaluateAsyncConciseBody (step 1, 2:39-72)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncConciseBody[0,0].EvaluateAsyncConciseBody (step 3.a, 5:22-101)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncFunctionBody[0,0].EvaluateAsyncFunctionBody (step 1, 2:39-72)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncFunctionBody[0,0].EvaluateAsyncFunctionBody (step 3.a, 5:22-101)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncModuleExecutionFulfilled (step 7.b, 12:28-109)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in AsyncModuleExecutionRejected (step 8.b, 14:28-104)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in BindingRestElement[0,0].IteratorBindingInitialization (step 4.f, 17:22-88)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in BindingRestElement[0,0].IteratorBindingInitialization (step 4.f, 17:55-74)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in BindingRestElement[1,0].IteratorBindingInitialization (step 3.f, 15:22-88)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in BindingRestElement[1,0].IteratorBindingInitialization (step 3.f, 15:55-74)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CanonicalNumericIndexString (step 2, 3:23-45)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CanonicalNumericIndexString (step 3, 4:25-40)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ClassTail[0,1].ClassDefinitionEvaluation (step 15.a, 54:39-117)
- actual  : Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ClassTail[0,3].ClassDefinitionEvaluation (step 15.a, 54:39-117)
- actual  : Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CopyDataProperties (step 2, 3:26-46)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CopyDataProperties (step 4.c.ii.2, 14:26-87)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateArrayFromList (step 3.a, 5:22-84)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateArrayFromList (step 3.a, 5:59-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateAsyncFromSyncIterator (step 3, 4:34-66)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateIterResultObject (step 2, 3:20-74)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateIterResultObject (step 3, 4:20-72)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateListFromArrayLike (step 6.a, 8:33-56)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateMappedArgumentsObject (step 15.b, 18:24-90)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateMappedArgumentsObject (step 15.b, 18:59-82)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateMappedArgumentsObject (step 16, 20:22-182)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateMethodProperty (step 3, 4:20-63)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CreateNonEnumerableDataPropertyOrThrow (step 3, 4:20-64)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CyclicModuleRecord.Evaluate (step 10.c.ii, 24:28-90)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in CyclicModuleRecord.Evaluate (step 6, 8:36-69)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[0,0].ArrayAccumulation (step 4, 6:31-109)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[0,0].ArrayAccumulation (step 4, 6:68-95)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[0,1].ArrayAccumulation (step 4, 6:31-109)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[0,1].ArrayAccumulation (step 4, 6:68-95)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[2,0].ArrayAccumulation (step 5, 7:31-109)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[2,0].ArrayAccumulation (step 5, 7:68-95)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[2,1].ArrayAccumulation (step 5, 7:31-109)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ElementList[2,1].ArrayAccumulation (step 5, 7:68-95)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in EvalDeclarationInstantiation (step 3.d.i.2.a, 15:25-55)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ExecuteAsyncModule (step 3, 4:38-71)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ForIn/OfHeadEvaluation (step 6.b, 15:29-52)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ForIn/OfHeadEvaluation (step 6.d, 17:36-64)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 4.a, 6:24-87)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 5.a, 8:24-93)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 6.a, 10:24-83)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 7.a, 12:24-83)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 8.a, 14:24-97)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FromPropertyDescriptor (step 9.a, 16:24-101)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 21.a, 42:39-70)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 21.c.i, 45:24-74)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 21.c.ii.1, 47:26-77)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 22.c.i, 55:24-78)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 22.d.i, 57:24-76)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 22.e, 58:22-68)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 27.c.i.2, 73:26-68)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 27.c.i.3, 74:26-69)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 34.b.i.1, 101:26-73)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in FunctionDeclarationInstantiation (step 34.b.ii.1, 103:26-72)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 11.a, 15:30-53)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 11.c, 17:24-190)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 11.e, 19:24-185)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 12, 21:22-61)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 13, 22:22-185)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in GetTemplateObject (step 14, 23:22-63)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array (step 5.c.i, 11:26-76)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array (step 5.d.i, 14:34-51)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array (step 5.e, 16:24-68)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array (step 6.d.i, 23:30-49)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array (step 6.d.iii, 25:26-77)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.from (step 12.a, 41:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.from (step 5.e.ii, 19:30-49)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.from (step 7, 33:33-52)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.of (step 7.b, 12:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.at (step 7, 10:32-51)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.concat (step 5.b.iv.1, 13:31-50)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.concat (step 5.b.iv.3.b, 17:63-82)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.concat (step 5.c.iii, 23:59-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.copyWithin (step 18.a, 24:33-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.copyWithin (step 18.b, 25:31-51)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.every (step 5.a, 7:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.fill (step 11.a, 13:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.filter (step 7.a, 9:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.filter (step 7.c.iii.1, 15:61-81)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.find (step 5.a, 7:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.findIndex (step 5.a, 7:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.forEach (step 5.a, 7:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.includes (step 10.a, 15:45-64)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.indexOf (step 10.a, 15:53-72)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.indexOf (step 10.b.i, 17:47-66)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.join (step 7.b, 10:44-63)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.lastIndexOf (step 8.a, 12:53-72)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.lastIndexOf (step 8.b.i, 14:47-66)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.map (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.pop (step 4.c, 10:31-51)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.push (step 5.a, 7:35-56)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reduce (step 8.b.i, 13:30-49)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reduce (step 9.a, 20:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reduceRight (step 8.b.i, 13:30-49)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reduceRight (step 9.a, 20:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reverse (step 5.b, 8:32-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.reverse (step 5.c, 9:32-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.shift (step 6.a, 10:30-49)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.shift (step 6.b, 11:28-51)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.shift (step 7, 20:51-76)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.slice (step 14.a, 16:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.slice (step 14.c.ii, 20:59-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.some (step 5.a, 7:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 14.a, 20:30-65)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 14.b.ii, 23:59-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 17.b.i, 30:32-73)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 17.b.ii, 31:30-63)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 17.d.i, 40:55-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 18.b.i, 45:32-77)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 18.b.ii, 46:30-67)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.splice (step 20.a, 55:35-54)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.toLocaleString (step 6.b, 10:52-71)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.unshift (step 4.c.i, 9:32-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.unshift (step 4.c.ii, 10:30-66)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Array.prototype.unshift (step 4.e.i, 21:37-52)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncFromSyncIteratorPrototype.next (step 3, 4:43-76)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncFromSyncIteratorPrototype.return (step 3, 4:43-76)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncFromSyncIteratorPrototype.throw (step 3, 4:43-76)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncGeneratorFunction.prototype.prototype.next (step 2, 3:41-74)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncGeneratorFunction.prototype.prototype.return (step 2, 3:41-74)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.AsyncGeneratorFunction.prototype.prototype.throw (step 2, 3:41-74)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.BigInt.prototype.toString (step 5, 6:40-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Date (step 5.j.i, 31:30-56)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Date.UTC (step 9.a, 11:28-54)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Function.prototype.bind (step 6.b.iii.1, 13:44-78)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.JSON.parse (step 11.c, 15:22-83)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.JSON.stringify (step 10, 39:20-85)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.JSON.stringify (step 4.b.ii.4.a, 15:34-53)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.JSON.stringify (step 4.b.ii.4.e, 19:63-78)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.JSON.stringify (step 6.a, 31:31-61)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Number.prototype.toFixed (step 10.a, 14:27-46)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Number.prototype.toPrecision (step 2, 3:52-67)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Number.prototype.toString (step 5, 6:40-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Object (step 3, 5:21-40)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Object.assign (step 3.a.i, 6:32-56)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Object.getOwnPropertyDescriptors (step 4.c, 8:60-123)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.Object.prototype.toString (step 3, 4:25-49)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.RegExp.prototype[@@match] (step 6.f.iii.2, 21:28-93)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.RegExp.prototype[@@match] (step 6.f.iii.2, 21:61-80)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.String.prototype.lastIndexOf (step 6, 7:77-108)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.String.prototype.replace (step 13.c, 22:37-133)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.String.raw (step 8.a, 10:33-60)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.from (step 12.a, 30:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.from (step 8, 25:33-53)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.of (step 6.b, 9:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.at (step 8, 11:21-52)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.at (step 8, 11:32-51)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.every (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.every (step 6.b, 9:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.fill (step 15.a, 17:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.fill (step 15.b, 18:24-57)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.filter (step 8.a, 10:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.filter (step 8.b, 11:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.find (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.find (step 6.b, 9:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.findIndex (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.findIndex (step 6.b, 9:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.forEach (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.forEach (step 6.b, 9:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.includes (step 11.a, 16:34-65)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.includes (step 11.a, 16:45-64)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.indexOf (step 11.a, 16:34-73)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.indexOf (step 11.a, 16:53-72)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.indexOf (step 11.b.i, 18:36-67)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.indexOf (step 11.b.i, 18:47-66)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.join (step 8.b, 11:33-64)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.join (step 8.b, 11:44-63)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.join (step 8.c, 12:102-123)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.lastIndexOf (step 9.a, 13:34-73)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.lastIndexOf (step 9.a, 13:53-72)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.lastIndexOf (step 9.b.i, 15:36-67)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.lastIndexOf (step 9.b.i, 15:47-66)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduce (step 10.a, 16:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduce (step 10.b, 17:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduce (step 9.a, 12:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduce (step 9.b, 13:37-53)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduceRight (step 10.a, 16:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduceRight (step 10.b, 17:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduceRight (step 9.a, 12:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reduceRight (step 9.b, 13:37-53)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.b, 9:32-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.c, 10:32-55)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.d, 11:36-56)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.e, 12:36-56)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.f, 13:24-66)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.reverse (step 6.g, 14:24-66)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.some (step 6.a, 8:28-47)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.TypedArray.prototype.some (step 6.b, 9:32-48)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.parseFloat (step 2, 3:35-71)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in INTRINSICS.parseInt (step 2, 3:23-59)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ImportCall[0,0].Evaluation (step 4, 5:41-74)
- actual  : Normal[PromiseCapabilityRecord] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ImportMeta[0,0].Evaluation (step 4.c.i, 9:26-95)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in InitializeBoundName (step 1.a, 3:24-74)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IntegerIndexedExoticObject.DefineOwnProperty (step 2, 12:21-66)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IntegerIndexedExoticObject.Delete (step 2, 6:21-47)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IntegerIndexedExoticObject.OwnPropertyKeys (step 2.a.i, 5:22-41)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in InternalizeJSONProperty (step 2.b.iii.1, 9:34-53)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 10, 15:44-82)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 10, 15:66-81)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 11, 16:101-142)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 12, 17:101-142)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 5, 7:67-105)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 5, 7:89-104)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 6, 8:67-105)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 6, 8:84-99)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 7.c, 12:21-47)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 8, 13:67-93)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 9, 14:44-82)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in IsLooselyEqual (step 9, 14:61-76)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in LiteralPropertyName[2,0].Evaluation (step 2, 3:21-38)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in LiteralPropertyName[2,0].PropName (step 2, 3:19-36)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeConstructor (step 5.b, 12:22-200)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeConstructor (step 6, 13:20-197)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeDay (step 2, 3:28-57)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeDay (step 3, 4:28-58)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeDay (step 4, 5:29-58)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeTime (step 2, 3:28-57)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeTime (step 3, 4:28-56)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeTime (step 4, 5:28-56)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in MakeTime (step 5, 6:32-59)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ModuleNamespaceExoticObject.DefineOwnProperty (step 1, 2:45-90)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ModuleNamespaceExoticObject.Delete (step 1.a, 3:23-49)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ModuleNamespaceExoticObject.Get (step 1.a, 3:23-58)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ModuleNamespaceExoticObject.HasProperty (step 1, 2:45-76)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ModuleNamespaceExoticObject.SetPrototypeOf (step 1, 2:21-54)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::bitwiseNOT (step 1, 2:34-48)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::leftShift (step 1, 2:30-44)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::leftShift (step 2, 3:30-45)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::signedRightShift (step 1, 2:30-44)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::signedRightShift (step 2, 3:30-45)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::unsignedRightShift (step 1, 2:30-45)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in Number::unsignedRightShift (step 2, 3:30-45)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in NumberBitwiseOp (step 1, 2:30-44)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in NumberBitwiseOp (step 2, 3:30-44)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in OrdinaryCallBindThis (step 6.b.i, 13:37-63)
- actual  : Normal[Object] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in OrdinaryCallBindThis (step 9, 17:22-61)
- actual  : Normal[ESValue] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in PrimaryExpression[10,0].Evaluation (step 3, 4:21-55)
- actual  : Normal[Object] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in PropertyDefinition[0,0].PropertyDefinitionEvaluation (step 5, 6:22-84)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in PropertyDefinition[2,0].PropertyDefinitionEvaluation (step 10, 20:22-83)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in RegExpAlloc (step 2, 3:24-166)
- actual  : Normal[Const[~unused~]] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in RegExpCreate (step 1, 2:29-52)
- actual  : Normal[Object] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in SerializeJSONProperty (step 9.a, 23:45-64)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in SpreadElement[0,0].ArrayAccumulation (step 4.d, 9:24-102)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in SpreadElement[0,0].ArrayAccumulation (step 4.d, 9:61-88)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in StringExoticObject.DefineOwnProperty (step 3, 6:21-66)
- actual  : Normal[Boolean] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in StringExoticObject.OwnPropertyKeys (step 5.a, 7:20-39)
- actual  : Normal[String] | Abrupt
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in TimeClip (step 3, 4:24-53)
- actual  : Normal[Math | Number[-INF, +INF]] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ToIndex (step 2.b, 6:31-56)
- actual  : Normal[Number] | Abrupt[throw]
[UncheckedAbruptCompletionMismatch] returnIfAbrupt (!) in ToPropertyKey (step 3, 5:19-36)
- actual  : Normal[String] | Abrupt
==========================================
```

</details>

<details>
<summary>List of functions where the mismatch occurs (total 142)</summary>
```
AddRestrictedFunctionProperties
ArgumentsExoticObject.DefineOwnProperty
ArgumentsExoticObject.Delete
ArgumentsExoticObject.Get
ArgumentsExoticObject.GetOwnProperty
ArgumentsExoticObject.Set
ArraySetLength
AssignmentRestElement[0,0].IteratorDestructuringAssignmentEvaluation
AsyncConciseBody[0,0].EvaluateAsyncConciseBody
AsyncFunctionBody[0,0].EvaluateAsyncFunctionBody
AsyncModuleExecutionFulfilled
AsyncModuleExecutionRejected
BindingRestElement[0,0].IteratorBindingInitialization
BindingRestElement[1,0].IteratorBindingInitialization
CanonicalNumericIndexString
ClassTail[0,1].ClassDefinitionEvaluation
ClassTail[0,3].ClassDefinitionEvaluation
CopyDataProperties
CreateArrayFromList
CreateAsyncFromSyncIterator
CreateIterResultObject
CreateListFromArrayLike
CreateMappedArgumentsObject
CreateMethodProperty
CreateNonEnumerableDataPropertyOrThrow
CyclicModuleRecord.Evaluate
ElementList[0,0].ArrayAccumulation
ElementList[0,1].ArrayAccumulation
ElementList[2,0].ArrayAccumulation
ElementList[2,1].ArrayAccumulation
EvalDeclarationInstantiation
ExecuteAsyncModule
ForIn/OfHeadEvaluation
FromPropertyDescriptor
FunctionDeclarationInstantiation
GetTemplateObject
INTRINSICS.Array
INTRINSICS.Array.from
INTRINSICS.Array.of
INTRINSICS.Array.prototype.at
INTRINSICS.Array.prototype.concat
INTRINSICS.Array.prototype.copyWithin
INTRINSICS.Array.prototype.every
INTRINSICS.Array.prototype.fill
INTRINSICS.Array.prototype.filter
INTRINSICS.Array.prototype.find
INTRINSICS.Array.prototype.findIndex
INTRINSICS.Array.prototype.forEach
INTRINSICS.Array.prototype.includes
INTRINSICS.Array.prototype.indexOf
INTRINSICS.Array.prototype.join
INTRINSICS.Array.prototype.lastIndexOf
INTRINSICS.Array.prototype.map
INTRINSICS.Array.prototype.pop
INTRINSICS.Array.prototype.push
INTRINSICS.Array.prototype.reduce
INTRINSICS.Array.prototype.reduceRight
INTRINSICS.Array.prototype.reverse
INTRINSICS.Array.prototype.shift
INTRINSICS.Array.prototype.slice
INTRINSICS.Array.prototype.some
INTRINSICS.Array.prototype.splice
INTRINSICS.Array.prototype.toLocaleString
INTRINSICS.Array.prototype.unshift
INTRINSICS.AsyncFromSyncIteratorPrototype.next
INTRINSICS.AsyncFromSyncIteratorPrototype.return
INTRINSICS.AsyncFromSyncIteratorPrototype.throw
INTRINSICS.AsyncGeneratorFunction.prototype.prototype.next
INTRINSICS.AsyncGeneratorFunction.prototype.prototype.return
INTRINSICS.AsyncGeneratorFunction.prototype.prototype.throw
INTRINSICS.BigInt.prototype.toString
INTRINSICS.Date
INTRINSICS.Date.UTC
INTRINSICS.Function.prototype.bind
INTRINSICS.JSON.parse
INTRINSICS.JSON.stringify
INTRINSICS.Number.prototype.toFixed
INTRINSICS.Number.prototype.toPrecision
INTRINSICS.Number.prototype.toString
INTRINSICS.Object
INTRINSICS.Object.assign
INTRINSICS.Object.getOwnPropertyDescriptors
INTRINSICS.Object.prototype.toString
INTRINSICS.RegExp.prototype[@@match]
INTRINSICS.String.prototype.lastIndexOf
INTRINSICS.String.prototype.replace
INTRINSICS.String.raw
INTRINSICS.TypedArray.from
INTRINSICS.TypedArray.of
INTRINSICS.TypedArray.prototype.at
INTRINSICS.TypedArray.prototype.every
INTRINSICS.TypedArray.prototype.fill
INTRINSICS.TypedArray.prototype.filter
INTRINSICS.TypedArray.prototype.find
INTRINSICS.TypedArray.prototype.findIndex
INTRINSICS.TypedArray.prototype.forEach
INTRINSICS.TypedArray.prototype.includes
INTRINSICS.TypedArray.prototype.indexOf
INTRINSICS.TypedArray.prototype.join
INTRINSICS.TypedArray.prototype.lastIndexOf
INTRINSICS.TypedArray.prototype.reduce
INTRINSICS.TypedArray.prototype.reduceRight
INTRINSICS.TypedArray.prototype.reverse
INTRINSICS.TypedArray.prototype.some
INTRINSICS.parseFloat
INTRINSICS.parseInt
ImportCall[0,0].Evaluation
ImportMeta[0,0].Evaluation
InitializeBoundName
IntegerIndexedExoticObject.DefineOwnProperty
IntegerIndexedExoticObject.Delete
IntegerIndexedExoticObject.OwnPropertyKeys
InternalizeJSONProperty
IsLooselyEqual
LiteralPropertyName[2,0].Evaluation
LiteralPropertyName[2,0].PropName
MakeConstructor
MakeDay
MakeTime
ModuleNamespaceExoticObject.DefineOwnProperty
ModuleNamespaceExoticObject.Delete
ModuleNamespaceExoticObject.Get
ModuleNamespaceExoticObject.HasProperty
ModuleNamespaceExoticObject.SetPrototypeOf
Number::bitwiseNOT
Number::leftShift
Number::signedRightShift
Number::unsignedRightShift
NumberBitwiseOp
OrdinaryCallBindThis
PrimaryExpression[10,0].Evaluation
PropertyDefinition[0,0].PropertyDefinitionEvaluation
PropertyDefinition[2,0].PropertyDefinitionEvaluation
RegExpAlloc
RegExpCreate
SerializeJSONProperty
SpreadElement[0,0].ArrayAccumulation
StringExoticObject.DefineOwnProperty
StringExoticObject.OwnPropertyKeys
TimeClip
ToIndex
ToPropertyKey
```


</details>
