### PR TITLE
Fix typo in tymodel and manual IR

### DIFF
--- a/src/main/resources/manuals/default/funcs/INTRINSICS.Function.prototype.toString.ir
+++ b/src/main/resources/manuals/default/funcs/INTRINSICS.Function.prototype.toString.ir
@@ -8,7 +8,7 @@ def <BUILTIN>:INTRINSICS.Function.prototype.toString(
 
   // 1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and ! HostHasSourceTextAvailable(_func_) is *true*, then
   //   1. Return ! CodePointsToString(_func_.[[SourceText]]).
-  if (&& (= (typeof func) @Object) (&& (! (= func.sourceText absent)) (= (typeof func.SourceText) @String))) {
+  if (&& (= (typeof func) @Object) (&& (! (= func.SourceText absent)) (= (typeof func.SourceText) @String))) {
     return func.SourceText
   } else {}
 

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -435,8 +435,8 @@ object TyModel {
           "ViewedArrayBuffer" -> NameT("ArrayBufferObject"),
           "ArrayLength" -> MathT,
           "ByteOffset" -> MathT,
-          "ContentTy" -> (NUMBER || BIGINT),
-          "TydArrayName" -> StrT,
+          "ContentType" -> (NUMBER || BIGINT),
+          "TypedArrayName" -> StrT,
         ),
       ),
       "ModuleNamespaceExoticObject" -> TyInfo(


### PR DESCRIPTION
This PR fixes following typos:
- IntegerIndexedExoticObject fields
- Function.prototype.toString IR

Type analysis result:
```
=== Affected by IntegerIndexedExoticObject changes
    def <BUILTIN>:INTRINSICS.get TypedArray.prototype[@@toStringTag](this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.get TypedArray.prototype[@@toStringTag](this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[Undefined]
+-> def <BUILTIN>:INTRINSICS.get TypedArray.prototype[@@toStringTag](this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[String | Undefined]

    def ValidateAtomicAccess(typedArray: Unknown["TypedArray"], requestIndex: Unknown): Unknown["EitherANormalCompletionContainingAnIntegerOrAnAbruptCompletion"]
--> def ValidateAtomicAccess(typedArray: Bot, requestIndex: Bot): Unknown["EitherANormalCompletionContainingAnIntegerOrAnAbruptCompletion"]
+-> def ValidateAtomicAccess(typedArray: ESValue, requestIndex: ESValue): Abrupt[throw]

    def ValidateIntegerTypedArray(typedArray: Unknown, waitable?: Boolean): Unknown["EitherANormalCompletionContainingEitherAnArrayBufferOrASharedArrayBuffer,OrAnAbruptCompletion"]
--> def ValidateIntegerTypedArray(typedArray: ESValue, waitable: Boolean): Abrupt
+-> def ValidateIntegerTypedArray(typedArray: ESValue, waitable: Boolean): Normal[ArrayBufferObject | Absent] | Abrupt

=== Affected by Function.prototype.toString IR change
    def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[String] | Abrupt[throw]
+-> def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[String | Absent] | Abrupt[throw]
```