### PR TITLE
Implement `InvalidPopExpressionMismatch` checker 

### DIFF
--- a/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
+++ b/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
@@ -48,6 +48,15 @@ case class ReturnIfAbruptPoint(
   inline def func = cp.func
 }
 
+/** pop points */
+case class PopPoint(
+  cp: ControlPoint,
+  popExpr: EPop,
+) extends AnalysisPoint {
+  inline def view = cp.view
+  inline def func = cp.func
+}
+
 /** control points */
 sealed trait ControlPoint extends AnalysisPoint
 

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -74,7 +74,10 @@ class TypeAnalyzer(
             v <- transfer(list)
             pv <- id(_.pop(v, front))
           } yield {
-            if (config.invalidPop && v.ty.list.isBottom)
+            if (
+              config.invalidPop &&
+              (v.ty.list.isBottom || !(v.ty -- ListT).isBottom)
+            )
               val pp = PopPoint(cp, e)
               addMismatch(InvalidPopExpressionMismatch(pp, v.ty))
             pv

--- a/src/main/scala/esmeta/analyzer/TypeMismatch.scala
+++ b/src/main/scala/esmeta/analyzer/TypeMismatch.scala
@@ -35,3 +35,9 @@ case class UncheckedAbruptCompletionMismatch(
   riap: ReturnIfAbruptPoint,
   actual: ValueTy,
 ) extends TypeMismatch(riap)
+
+/** invalid pop expression mismatches */
+case class InvalidPopExpressionMismatch(
+  pp: PopPoint,
+  actual: ValueTy,
+) extends TypeMismatch(pp)

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -79,6 +79,8 @@ class Stringifier(
         app >> "returnIfAbrupt"
         app >> "(" >> (if (riaExpr.check) "?" else "!") >> ") "
         app >> "in " >> riap.func.name >> riaExpr
+      case PopPoint(cp, popExpr) =>
+        app >> "pop in " >> cp.func.name >> popExpr
 
   // control points
   given cpRule: Rule[ControlPoint] = (app, cp) =>
@@ -137,6 +139,9 @@ class Stringifier(
         app :> "- actual  : " >> actual
       case UncheckedAbruptCompletionMismatch(riap, actual) =>
         app >> "[UncheckedAbruptCompletionMismatch] " >> riap
+        app :> "- actual  : " >> actual
+      case InvalidPopExpressionMismatch(pp, actual) =>
+        app >> "[InvalidPopExpressionMismatch] " >> pp
         app :> "- actual  : " >> actual
 
   private val addLocRule: Rule[IRElem with LangEdge] = (app, elem) => {

--- a/src/main/scala/esmeta/ty/ListTy.scala
+++ b/src/main/scala/esmeta/ty/ListTy.scala
@@ -45,9 +45,11 @@ case class ListTy(elem: Option[ValueTy] = None)
     if (that.isBottom) this
     else
       (this.elem, that.elem) match
-        case (None, _)          => Bot
-        case (_, None)          => this
-        case (Some(l), Some(r)) => ListTy(Some(l -- r))
+        case (None, _) => Bot
+        case (_, None) => this
+        case (Some(l), Some(r)) =>
+          val ty = l -- r
+          if (ty.isBottom) Bot else ListTy(Some(ty))
 
   /** get single value */
   def getSingle: Flat[Nothing] = if (elem.isEmpty) Zero else Many

--- a/src/main/scala/esmeta/ty/ListTy.scala
+++ b/src/main/scala/esmeta/ty/ListTy.scala
@@ -45,11 +45,10 @@ case class ListTy(elem: Option[ValueTy] = None)
     if (that.isBottom) this
     else
       (this.elem, that.elem) match
-        case (None, _) => Bot
-        case (_, None) => this
-        case (Some(l), Some(r)) =>
-          val ty = l -- r
-          if (ty.isBottom) Bot else ListTy(Some(ty))
+        case (None, _)                    => Bot
+        case (_, None)                    => this
+        case (Some(l), Some(r)) if l <= r => Bot
+        case (Some(l), Some(r))           => ListTy(Some(l -- r))
 
   /** get single value */
   def getSingle: Flat[Nothing] = if (elem.isEmpty) Zero else Many


### PR DESCRIPTION
The `InvalidPopExpressionMismatch` occurs when the operand of pop expression does not contain `listTy` or contain non-`listTy` types.

Type analysis log with mismatches:
```
* 2 type mismatches are detected.
[InvalidPopExpressionMismatch] pop in GeneratorYield (step 8, 11:14 - 12:128)
- actual  : Absent
[InvalidPopExpressionMismatch] pop in INTRINSICS.ForInIteratorPrototype.next
- actual  : List[String] | Undefined
```

and fix `ListTy` for better prune type operation

### Detailed analysis
#### GeneratorYield: TyModel improvement
In our compiler, we manually introduce certain steps (internally labeled as ReturnToResumeStep). Therefore, in the GeneratorYield IR, a pop instruction with the genContext.ReturnCont operand is inserted. However, in our TyModel, the ReturnCont property does not exist within the ExecutionContext. This mismatch can be resolved with improvement of TyModel.

#### INTRINSICS.ForInIteratorPrototype.next
Currently, this IR contains a 'yet' node. If we adjust the compiler to correctly handle this node and also enhance our TyModel, we should be able to resolve this mismatch.