### PR TITLE
Implement mapAlloc and property update checker

### DIFF
--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -16,4 +16,4 @@
   - yet: 463
   - unknown: 1543
 - tables: 89
-- type model: 58
+- type model: 59

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -521,7 +521,7 @@ trait AbsTransfer extends Optimized with PruneHelper {
                 v <- transfer(vexpr)
               } yield (k, v)
           })
-          lv <- id(_.allocMap(asite, tname, pairs))
+          lv <- id(_.allocMap(asite, tname, pairs, e))
         } yield lv
       case e @ EList(exprs) =>
         val asite = AllocSite(e.asite, cp.view)

--- a/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
+++ b/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
@@ -2,6 +2,7 @@ package esmeta.analyzer
 
 import esmeta.ir.{Func => _, *}
 import esmeta.cfg.*
+import esmeta.analyzer.domain.AllocSite
 
 /** analysis points */
 sealed trait AnalysisPoint extends AnalyzerElem {
@@ -48,9 +49,23 @@ case class ReturnIfAbruptPoint(
   inline def func = cp.func
 }
 
+case class MapAllocPoint(cp: ControlPoint, emap: EMap) extends AnalysisPoint {
+  inline def view = cp.view
+  inline def func = cp.func
+}
+
 /** property lookup points */
 case class PropertyLookupPoint(
   kind: LookupKind,
+  cp: ControlPoint,
+  ref: Option[Ref],
+) extends AnalysisPoint {
+  inline def view = cp.view
+  inline def func = cp.func
+}
+
+/** property assign points */
+case class PropertyAssignPoint(
   cp: ControlPoint,
   ref: Option[Ref],
 ) extends AnalysisPoint {

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -317,7 +317,7 @@ object TypeAnalyzer {
     arity: Boolean = true,
     paramType: Boolean = true,
     returnType: Boolean = true,
-    uncheckedAbrupt: Boolean = false,
+    uncheckedAbrupt: Boolean = true,
     invalidAstProperty: Boolean = true,
     invalidStrProperty: Boolean = true,
     invalidNameProperty: Boolean = true,
@@ -326,5 +326,7 @@ object TypeAnalyzer {
     invalidListProperty: Boolean = true,
     invalidSymbolProperty: Boolean = true,
     invalidSubMapProperty: Boolean = true,
+    propertyUpdate: Boolean = true,
+    mapAlloc: Boolean = true,
   )
 }

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -250,7 +250,8 @@ class TypeAnalyzer(
     silent: Boolean = false,
   ): List[Func] =
     // find all possible initial analysis target functions
-    val allFuncs = cfg.funcs.filter(_.isParamTysDefined)
+    val allFuncs =
+      cfg.funcs.filter(f => f.isParamTysDefined && !f.isCloure && !f.isCont)
     target.fold(allFuncs)(pattern => {
       val funcs = allFuncs.filter(f => pattern.r.matches(f.name))
       if (!silent && funcs.isEmpty)

--- a/src/main/scala/esmeta/analyzer/TypeMismatch.scala
+++ b/src/main/scala/esmeta/analyzer/TypeMismatch.scala
@@ -4,6 +4,7 @@ import esmeta.cfg.*
 import esmeta.ir.{Func => _, *}
 import esmeta.ty.*
 import esmeta.util.*
+import esmeta.analyzer.domain.AllocSite
 
 /** specification type mismatches */
 sealed abstract class TypeMismatch(
@@ -38,7 +39,14 @@ case class UncheckedAbruptCompletionMismatch(
 
 /** invalid property mismatches */
 case class InvalidPropertyMismatch(
-  plp: PropertyLookupPoint,
+  plp: AnalysisPoint,
   base: TyElem,
   prop: ValueTy,
 ) extends TypeMismatch(plp)
+
+/** property type mismatches */
+case class PropertyTypeMismatch(
+  cp: AnalysisPoint,
+  expected: ValueTy,
+  actual: ValueTy,
+) extends TypeMismatch(cp)

--- a/src/main/scala/esmeta/analyzer/domain/state/BasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/BasicDomain.scala
@@ -136,7 +136,12 @@ object BasicDomain extends state.Domain {
       }
 
     /** property setter */
-    def update(base: AbsValue, prop: AbsValue, value: AbsValue): Elem =
+    def update(
+      base: AbsValue,
+      prop: AbsValue,
+      value: AbsValue,
+      ref: Option[Ref],
+    ): Elem =
       elem.bottomCheck(AbsValue)(base, prop, value) {
         elem.copy(heap = elem.heap.update(base.part, prop, value))
       }
@@ -240,6 +245,7 @@ object BasicDomain extends state.Domain {
       to: AllocSite,
       tname: String,
       pairs: Iterable[(AbsValue, AbsValue)],
+      e: EMap,
     ): (AbsValue, Elem) =
       val partV = AbsValue(to)
       elem.bottomCheck(AbsValue)(pairs.flatMap { case (k, v) => List(k, v) }) {

--- a/src/main/scala/esmeta/analyzer/domain/state/Domain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/Domain.scala
@@ -72,13 +72,18 @@ trait Domain extends domain.Domain[State] {
     /** setter with reference values */
     def update(refV: AbsRefValue, value: AbsValue): Elem = refV match
       case AbsRefId(x)            => update(x, value)
-      case AbsRefProp(base, prop) => update(base, prop, value)
+      case AbsRefProp(base, prop) => update(base, prop, value, refV.refElem)
 
     /** identifier setter */
     def update(x: Id, value: AbsValue): Elem
 
     /** property setter */
-    def update(base: AbsValue, prop: AbsValue, value: AbsValue): Elem
+    def update(
+      base: AbsValue,
+      prop: AbsValue,
+      value: AbsValue,
+      ref: Option[Ref],
+    ): Elem
 
     /** deletion with reference values */
     def delete(refV: AbsRefValue): Elem
@@ -129,6 +134,7 @@ trait Domain extends domain.Domain[State] {
       to: AllocSite,
       tname: String,
       pairs: Iterable[(AbsValue, AbsValue)],
+      e: EMap,
     ): (AbsValue, Elem)
 
     /** allocation of list with address partitions */

--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -113,7 +113,7 @@ object TypeDomain extends state.Domain {
         elem
 
     /** property setter */
-    def update(base: AbsValue, prop: AbsValue, value: AbsValue): Elem = elem
+    def update(base: AbsValue, prop: AbsValue, value: AbsValue, ref: Option[Ref]): Elem = elem
 
     /** deletion with reference values */
     def delete(refV: AbsRefValue): Elem = elem
@@ -178,6 +178,7 @@ object TypeDomain extends state.Domain {
       to: AllocSite,
       tname: String,
       pairs: Iterable[(AbsValue, AbsValue)],
+      emap: EMap,
     ): (AbsValue, Elem) =
       val value =
         if (tname == "Record") RecordT((for {

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -11,6 +11,12 @@ import esmeta.ty.util.{Stringifier => TyStringifier}
 import esmeta.util.*
 import esmeta.util.Appender.*
 import esmeta.util.BaseUtils.*
+import esmeta.ir.EMap
+import esmeta.ir.Prop
+import esmeta.ir.Global
+import esmeta.ir.Name
+import esmeta.ir.Temp
+import esmeta.ir.EStr
 
 /** stringifier for analyzer */
 class Stringifier(
@@ -94,6 +100,15 @@ class Stringifier(
         app >> " in " >> plp.func.name
         for (ref <- plp.ref) app >> ref
         app
+      case MapAllocPoint(cp: ControlPoint, emap: EMap) =>
+        app >> "map allocation " >> emap
+        app >> "in " >> cp.func.name
+      case pap: PropertyAssignPoint =>
+        app >> "property assignment to "
+        for (ref <- pap.ref)
+          import irStringifier.given
+          app >> ref
+        app >> " in " >> pap.func.name
 
   // control points
   given cpRule: Rule[ControlPoint] = (app, cp) =>
@@ -156,7 +171,10 @@ class Stringifier(
       case InvalidPropertyMismatch(plp, base, prop) =>
         app >> "[InvalidPropertyMismatch] " >> plp
         app :> "- lookup  : " >> prop >> " of " >> base
-
+      case PropertyTypeMismatch(cp, expected, actual) =>
+        app >> "[PropertyTypeMismatch] " >> cp
+        app :> "- expected: " >> expected
+        app :> "- actual  : " >> actual
   private val addLocRule: Rule[IRElem with LangEdge] = (app, elem) => {
     for {
       lang <- elem.langOpt

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -64,6 +64,13 @@ case class Func(
   lazy val isMethod: Boolean =
     irFunc.kind == FuncKind.ConcMeth || irFunc.kind == FuncKind.InternalMeth
 
+  /** check whether it is closure */
+  lazy val isCloure: Boolean =
+    irFunc.kind == FuncKind.Clo || irFunc.kind == FuncKind.BuiltinClo
+
+  lazy val isCont: Boolean =
+    irFunc.kind == FuncKind.Cont
+
   /** check whether it needs normal completion wrapping */
   lazy val isReturnComp: Boolean = irFunc.kind match
     case FuncKind.SynDirOp if irFunc.name.endsWith(".Evaluation") => true

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -318,13 +318,6 @@ object TyModel {
           "Extensible" -> BoolT,
           "Prototype" -> (NameT("Object") || NullT),
           "SubMap" -> SubMapT(StrT || SymbolT, NameT("PropertyDescriptor")),
-          "ErrorData" -> (AbsentT || UndefT),
-          "BooleanData" -> (AbsentT || BoolT),
-          "NumberData" -> (AbsentT || NumberT),
-          "SymbolData" -> (AbsentT || SymbolT),
-          "BigIntData" -> (AbsentT || BigIntT),
-          "DateValue" -> (AbsentT || NumberT),
-          "CleanupCallback" -> (AbsentT || NameT("JobCallbackRecord")),
         ),
       ),
       "OrdinaryObject" -> TyInfo(
@@ -498,11 +491,36 @@ object TyModel {
         ),
       ),
       "ArrayBufferObject" -> TyInfo(parent = Some("Object")),
-      "BooleanObject" -> TyInfo(parent = Some("OrdinaryObject")),
-      "BigIntObject" -> TyInfo(parent = Some("OrdinaryObject")),
-      "NumberObject" -> TyInfo(parent = Some("OrdinaryObject")),
-      "SymbolObject" -> TyInfo(parent = Some("OrdinaryObject")),
-
+      "BooleanObject" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "BooleanData" -> (AbsentT || BoolT),
+        ),
+      ),
+      "BigIntObject" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "BigIntData" -> (AbsentT || BigIntT),
+        ),
+      ),
+      "NumberObject" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "NumberData" -> (AbsentT || NumberT),
+        ),
+      ),
+      "SymbolObject" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "SymbolData" -> (AbsentT || SymbolT),
+        ),
+      ),
+      "ErrorObject" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "ErrorData" -> (AbsentT || UndefT),
+        ),
+      ),
       // special instances
       "ForInIteratorInstance" -> TyInfo(
         parent = Some("OrdinaryObject"),

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -494,31 +494,31 @@ object TyModel {
       "BooleanObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
-          "BooleanData" -> (AbsentT || BoolT),
+          "BooleanData" -> BoolT,
         ),
       ),
       "BigIntObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
-          "BigIntData" -> (AbsentT || BigIntT),
+          "BigIntData" -> BigIntT,
         ),
       ),
       "NumberObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
-          "NumberData" -> (AbsentT || NumberT),
+          "NumberData" -> NumberT,
         ),
       ),
       "SymbolObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
-          "SymbolData" -> (AbsentT || SymbolT),
+          "SymbolData" -> SymbolT,
         ),
       ),
       "ErrorObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
-          "ErrorData" -> (AbsentT || UndefT),
+          "ErrorData" -> UndefT,
         ),
       ),
       // special instances

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -86,6 +86,7 @@ case class TyModel(infos: Map[String, TyInfo] = Map()) {
   /** get types of property */
   def getPropOrElse(tname: String, p: String)(default: => ValueTy): ValueTy =
     if (tname == "IntrinsicsRecord" && p.startsWith("%") && p.endsWith("%"))
+      // can be  made more precise for %ThrowTypeError% which is function object(https://tc39.es/ecma262/2022/#table-well-known-intrinsic-objects)
       NameT("Object")
     else
       propMap
@@ -222,7 +223,7 @@ object TyModel {
           "GlobalObject" -> (UndefT || NameT("Object")),
           "GlobalEnv" -> NameT("GlobalEnvironmentRecord"),
           "TemplateMap" -> ListT(NameT("TemplatePair")),
-          "HostDefined" -> UndefT,
+          "HostDefined" -> AnyT,
         ),
       ),
       "TemplatePair" -> TyInfo(
@@ -317,6 +318,13 @@ object TyModel {
           "Extensible" -> BoolT,
           "Prototype" -> (NameT("Object") || NullT),
           "SubMap" -> SubMapT(StrT || SymbolT, NameT("PropertyDescriptor")),
+          "ErrorData" -> (AbsentT || UndefT),
+          "BooleanData" -> (AbsentT || BoolT),
+          "NumberData" -> (AbsentT || NumberT),
+          "SymbolData" -> (AbsentT || SymbolT),
+          "BigIntData" -> (AbsentT || BigIntT),
+          "DateValue" -> (AbsentT || NumberT),
+          "CleanupCallback" -> (AbsentT || NameT("JobCallbackRecord")),
         ),
       ),
       "OrdinaryObject" -> TyInfo(
@@ -327,6 +335,11 @@ object TyModel {
       ),
       "FunctionObject" -> TyInfo(
         parent = Some("OrdinaryObject"),
+        fields = Map(
+          "Errors" -> (AbsentT || ListT),
+          "Values" -> (AbsentT || ListT),
+          "Index" -> (AbsentT || MathT),
+        ),
       ),
       "ECMAScriptFunctionObject" -> TyInfo(
         parent = Some("FunctionObject"),
@@ -516,7 +529,7 @@ object TyModel {
       "PromiseReaction" -> TyInfo(
         fields = Map(
           "Capability" -> (NameT("PromiseCapabilityRecord") || UndefT),
-          "Ty" -> (FULFILL || REJECT),
+          "Type" -> (FULFILL || REJECT),
           "Handler" -> (NameT("JobCallbackRecord") || EMPTY),
         ),
       ),
@@ -723,7 +736,7 @@ object TyModel {
       "JobCallbackRecord" -> TyInfo(
         fields = Map(
           "Callback" -> NameT("FunctionObject"),
-          "HostDefined" -> UndefT,
+          "HostDefined" -> AnyT,
         ),
       ),
 
@@ -746,7 +759,7 @@ object TyModel {
         fields = Map(
           "Realm" -> (NameT("RealmRecord") || UndefT),
           "ECMAScriptCode" -> AstT("Script"),
-          "HostDefined" -> EMPTY,
+          "HostDefined" -> AnyT,
         ),
       ),
 
@@ -756,7 +769,7 @@ object TyModel {
           "Realm" -> NameT("RealmRecord"),
           "Environment" -> (NameT("ModuleEnvironmentRecord") || EMPTY),
           "Namespace" -> (NameT("ModuleNamespaceExoticObject") || EMPTY),
-          "HostDefined" -> UndefT,
+          "HostDefined" -> AnyT,
         ),
       ),
       "CyclicModuleRecord" -> TyInfo(


### PR DESCRIPTION
This PR adds new mismatch, `PropertyTypeMismatch` that checks for validy of property assignment in two `AnalysisPoint`, which are `MapAllocPoint` which stands for record allocation and `PropertyAssignPoint` for property update.

PropertyTypeMismatch in map allocation currently has 10 alarms, which are listed [here](https://gist.github.com/doehyunbaek/b8183112782dc3cb1f1c28283c346fe9).

PropertyTypeMismatch in property assignment currently has 23 alarms, which are listed [here](https://gist.github.com/doehyunbaek/73aaac1c9a289a011c276c95688ee684)

Performance: in my local dev machine, current [adv-ty-refine head](https://github.com/es-meta/esmeta/commit/8a66bce0a5d7bce2f5221cc1b3441ab0be785fc8) takes 38 seconds, and this pr's HEAD takes 38 seconds with config off, and 40 seconds with config on.