### PR TITLE
Improve `InvalidPropertyMismatch` and reduce false alarms

### DIFF
--- a/src/main/resources/manuals/default/funcs/INTRINSICS.Function.prototype.toString.ir
+++ b/src/main/resources/manuals/default/funcs/INTRINSICS.Function.prototype.toString.ir
@@ -8,7 +8,7 @@ def <BUILTIN>:INTRINSICS.Function.prototype.toString(
 
   // 1. If Type(_func_) is Object and _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is a sequence of Unicode code points and ! HostHasSourceTextAvailable(_func_) is *true*, then
   //   1. Return ! CodePointsToString(_func_.[[SourceText]]).
-  if (&& (= (typeof func) @Object) (&& (! (= func.sourceText absent)) (= (typeof func.SourceText) @String))) {
+  if (&& (= (typeof func) @Object) (&& (! (= func.SourceText absent)) (= (typeof func.SourceText) @String))) {
     return func.SourceText
   } else {}
 

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -16,4 +16,4 @@
   - yet: 463
   - unknown: 1543
 - tables: 89
-- type model: 59
+- type model: 63

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -749,6 +749,20 @@ trait AbsTransfer extends Optimized with PruneHelper {
     v <- (bop, l.getSingle) match {
       case (BOp.And, One(Bool(false))) => pure(AVF)
       case (BOp.Or, One(Bool(true)))   => pure(AVT)
+      case (BOp.And, Many) =>
+        for {
+          st <- get
+          _ <- modify(prune(left, true))
+          r <- transfer(right)
+          _ <- put(st)
+        } yield r ⊔ AVF
+      case (BOp.Or, Many) =>
+        for {
+          st <- get
+          _ <- modify(prune(left, false))
+          r <- transfer(right)
+          _ <- put(st)
+        } yield r ⊔ AVT
       case _ =>
         for {
           r <- transfer(right)

--- a/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
+++ b/src/main/scala/esmeta/analyzer/AnalysisPoint.scala
@@ -63,7 +63,6 @@ case class MapAllocPoint(cp: ControlPoint, emap: EMap) extends AnalysisPoint {
 
 /** property lookup points */
 case class PropertyLookupPoint(
-  kind: LookupKind,
   cp: ControlPoint,
   ref: Option[Ref],
 ) extends AnalysisPoint {

--- a/src/main/scala/esmeta/analyzer/PruneHelper.scala
+++ b/src/main/scala/esmeta/analyzer/PruneHelper.scala
@@ -15,7 +15,7 @@ trait PruneHelper { this: AbsTransfer =>
   def prune(
     cond: Expr,
     positive: Boolean,
-  )(using cp: NodePoint[_]): Updater = cond match {
+  )(using cp: ControlPoint): Updater = cond match {
     case _ if !USE_REFINE => st => st
     // prune values
     case EBinary(BOp.Eq, ERef(ref: Local), target) =>

--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -430,13 +430,13 @@ object TypeDomain extends state.Domain {
     else {
       var res = ValueTy.Bot
       if (prop.str contains "length") res ||= MathT
-      if (!prop.math.isBottom) res ||= CodeUnitT
+      if (!prop.math.isBottom || !prop.number.isBottom) res ||= CodeUnitT
       // invalid access on string type
       if (!skipCheck)
         boundCheck(
           LookupKind.Str,
           prop,
-          MathT || StrT("length"),
+          MathT || NumberT || StrT("length"),
           (cp, t) =>
             val plp = PropertyLookupPoint(cp, ref)
             InvalidPropertyMismatch(plp, base, t),

--- a/src/main/scala/esmeta/analyzer/util/Stringifier.scala
+++ b/src/main/scala/esmeta/analyzer/util/Stringifier.scala
@@ -86,18 +86,7 @@ class Stringifier(
         app >> "(" >> (if (riaExpr.check) "?" else "!") >> ") "
         app >> "in " >> riap.func.name >> riaExpr
       case plp: PropertyLookupPoint =>
-        app >> "property lookup"
-        plp.kind match {
-          case LookupKind.Ast    => app >> "(ast)"
-          case LookupKind.Str    => app >> "(string)"
-          case LookupKind.Name   => app >> "(name)"
-          case LookupKind.Comp   => app >> "(comp)"
-          case LookupKind.Record => app >> "(record)"
-          case LookupKind.List   => app >> "(list)"
-          case LookupKind.Symbol => app >> "(symbol)"
-          case LookupKind.SubMap => app >> "(submap)"
-        }
-        app >> " in " >> plp.func.name
+        app >> "property lookup in " >> plp.func.name
         for (ref <- plp.ref) app >> ref
         app
       case MapAllocPoint(cp: ControlPoint, emap: EMap) =>

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -437,8 +437,8 @@ object TyModel {
           "ViewedArrayBuffer" -> NameT("ArrayBufferObject"),
           "ArrayLength" -> MathT,
           "ByteOffset" -> MathT,
-          "ContentTy" -> (NUMBER || BIGINT),
-          "TydArrayName" -> StrT,
+          "ContentType" -> (NUMBER || BIGINT),
+          "TypedArrayName" -> StrT,
         ),
       ),
       "ModuleNamespaceExoticObject" -> TyInfo(

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -318,6 +318,7 @@ object TyModel {
           "Extensible" -> BoolT,
           "Prototype" -> (NameT("Object") || NullT),
           "SubMap" -> SubMapT(StrT || SymbolT, NameT("PropertyDescriptor")),
+          "PrivateElements" -> ListT(NameT("PrivateElement")),
         ),
       ),
       "OrdinaryObject" -> TyInfo(
@@ -515,7 +516,31 @@ object TyModel {
           "SymbolData" -> SymbolT,
         ),
       ),
-      "ErrorObject" -> TyInfo(
+      "SetInstance" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "SetData" -> ListT(ESValueT),
+        ),
+      ),
+      "MapInstance" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "MapData" -> ListT(RecordT(Set("Key", "Value"))),
+        ),
+      ),
+      "WeakMapInstance" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "WeakMapData" -> ListT(RecordT(Set("Key", "Value"))),
+        ),
+      ),
+      "WeakSetInstance" -> TyInfo(
+        parent = Some("OrdinaryObject"),
+        fields = Map(
+          "WeakSetData" -> ListT(ESValueT),
+        ),
+      ),
+      "ErrorInstance" -> TyInfo(
         parent = Some("OrdinaryObject"),
         fields = Map(
           "ErrorData" -> UndefT,


### PR DESCRIPTION
before: 167 mismatches
after: 145 mismatches

This PR reduces false alarm by following fixes:
- Enable pruning in chained condition
- Improve TyModel
- Fix typo in manually inserted IR
and merge some mismatches catched in same lookup point.