### PR TITLE
Concurrent execution of Test262Test

### DIFF
--- a/.completion
+++ b/.completion
@@ -21,7 +21,7 @@ _esmeta_completions() {
   parseOpt="-parse:debug"
   evalOpt="-eval:timeout -eval:tycheck -eval:multiple -eval:log"
   webOpt="-web:port"
-  test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log"
+  test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log -test262-test:concurrent"
   injectOpt="-inject:defs -inject:out -inject:log"
   mutateOpt="-mutate:out -mutate:mutator -mutate:untilValid"
   analyzeOpt="-analyze:repl"

--- a/src/main/resources/manuals/default/test262/categorized.json
+++ b/src/main/resources/manuals/default/test262/categorized.json
@@ -297,7 +297,6 @@
   ],
   "wrong": [
     "built-ins/AsyncGeneratorPrototype/return/return-state-completed-broken-promise",
-    "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise",
-    "language/types/number/S8.5_A13_T2"
+    "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise"
   ]
 }

--- a/src/main/resources/manuals/default/test262/categorized.json
+++ b/src/main/resources/manuals/default/test262/categorized.json
@@ -297,6 +297,7 @@
   ],
   "wrong": [
     "built-ins/AsyncGeneratorPrototype/return/return-state-completed-broken-promise",
-    "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise"
+    "built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise",
+    "language/types/number/S8.5_A13_T2"
   ]
 }

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -26,6 +26,12 @@ case object Test262Test extends Phase[CFG, Summary] {
   ): Summary =
     // set test mode
     TEST_MODE = true
+    if (config.concurrent && config.progress)
+      // TODO: make progress bar stable in concurrent mode.
+      warn(
+        "progress bar may be unstable in concurrent mode. turning off progress bar",
+      )
+      config.progress = false
 
     // get target version of Test262
     val version = Test262.getVersion(config.target)
@@ -38,6 +44,7 @@ case object Test262Test extends Phase[CFG, Summary] {
       config.progress,
       config.coverage,
       config.timeLimit,
+      config.concurrent,
     )
 
     // if summary has failed test case, throws an exception
@@ -78,6 +85,11 @@ case object Test262Test extends Phase[CFG, Summary] {
       BoolOption(c => c.log = true),
       "turn on logging mode.",
     ),
+    (
+      "concurrent",
+      BoolOption(c => c.concurrent = true),
+      "turn on concurrent mode.",
+    ),
   )
   case class Config(
     var target: Option[String] = None,
@@ -86,5 +98,6 @@ case object Test262Test extends Phase[CFG, Summary] {
     var timeLimit: Option[Int] = None,
     var withYet: Boolean = false,
     var log: Boolean = false,
+    var concurrent: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -26,12 +26,6 @@ case object Test262Test extends Phase[CFG, Summary] {
   ): Summary =
     // set test mode
     TEST_MODE = true
-    if (config.concurrent && config.progress)
-      // TODO: make progress bar stable in concurrent mode.
-      warn(
-        "progress bar may be unstable in concurrent mode. turning off progress bar",
-      )
-      config.progress = false
 
     // get target version of Test262
     val version = Test262.getVersion(config.target)

--- a/src/main/scala/esmeta/test262/Test262.scala
+++ b/src/main/scala/esmeta/test262/Test262.scala
@@ -74,6 +74,7 @@ case class Test262(
     removed: Iterable[(Test, ReasonPath)] = Nil,
     useProgress: Boolean = false,
     useErrorHandler: Boolean = true,
+    concurrent: Boolean = false,
   ): ProgressBar[Test] = ProgressBar(
     msg = s"Run Test262 $name tests",
     iterable = targetTests,
@@ -86,6 +87,7 @@ case class Test262(
         case e: Throwable          => summary.fail.add(name, e.getMessage)
       else throw e,
     verbose = useProgress,
+    concurrent = concurrent,
   )
 
   /** interpreter test */
@@ -95,6 +97,7 @@ case class Test262(
     useProgress: Boolean = false,
     useCoverage: Boolean = false,
     timeLimit: Option[Int] = None, // default: no limit
+    concurrent: Boolean = false,
   ): Summary = {
     // extract tests from paths
     val tests: List[Test] = getTests(paths.toList)
@@ -112,6 +115,7 @@ case class Test262(
       removed = removed,
       useProgress = useProgress,
       useErrorHandler = multiple,
+      concurrent = concurrent,
     )
 
     // coverage with time limit

--- a/src/main/scala/esmeta/util/ProgressBar.scala
+++ b/src/main/scala/esmeta/util/ProgressBar.scala
@@ -52,7 +52,7 @@ case class ProgressBar[T](
 
   // foreach function
   override def foreach[U](f: T => U): Unit = {
-    val gcount = new AtomicInteger(baseSize)
+    val gcount = AtomicInteger(baseSize)
     val start = System.currentTimeMillis
     def updateTime: Unit =
       summary.time = Time(System.currentTimeMillis - start)

--- a/src/main/scala/esmeta/util/Summary.scala
+++ b/src/main/scala/esmeta/util/Summary.scala
@@ -110,7 +110,7 @@ object Summary {
 
   /** summary elements */
   case class Elem(
-    seq: BlockingQueue[String] = new LinkedBlockingQueue,
+    seq: BlockingQueue[String] = LinkedBlockingQueue(),
     map: TrieMap[Reason, Elem] = TrieMap(),
   ) {
 

--- a/src/main/scala/esmeta/util/Summary.scala
+++ b/src/main/scala/esmeta/util/Summary.scala
@@ -1,11 +1,13 @@
 package esmeta.util
 
 import esmeta.error.NotSupported.*
-import esmeta.util.SystemUtils.*
 import esmeta.util.Appender.Rule
-import scala.collection.mutable.{Map => MMap, ListBuffer}
+import esmeta.util.Summary.*
+import esmeta.util.SystemUtils.*
 import io.circe.*, io.circe.syntax.*, io.circe.parser.*
-import Summary.*
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue}
+import scala.collection.concurrent.TrieMap
+import scala.jdk.CollectionConverters.IterableHasAsScala
 
 case class Summary(
   notSupported: Elem = Elem(), // not yet supported elements
@@ -108,15 +110,15 @@ object Summary {
 
   /** summary elements */
   case class Elem(
-    seq: ListBuffer[String] = ListBuffer(),
-    map: MMap[Reason, Elem] = MMap(),
+    seq: BlockingQueue[String] = new LinkedBlockingQueue,
+    map: TrieMap[Reason, Elem] = TrieMap(),
   ) {
 
     /** all elements */
     def all: List[String] =
       val mapElems =
         for { (_, elem) <- map.toList; elem <- elem.all } yield elem
-      val seqElems = seq.toList
+      val seqElems = seq.asScala.toList
       seqElems ++ mapElems
 
     /** empty check */
@@ -130,7 +132,7 @@ object Summary {
     /** add data */
     def add(data: String, reason: Reason): Unit = add(data, List(reason))
     def add(data: String, reasons: ReasonPath = Nil): Unit = reasons match
-      case Nil => seq.append(data)
+      case Nil => seq.offer(data)
       case reason :: remain =>
         map.getOrElseUpdate(reason, Elem()).add(data, remain)
 
@@ -144,7 +146,7 @@ object Summary {
 
     /** conversion to JSON */
     def toJson: Json =
-      lazy val seqJson = Json.fromValues(seq.map(Json.fromString))
+      lazy val seqJson = Json.fromValues(seq.asScala.map(Json.fromString))
       if (map.isEmpty) seqJson
       else
         val mapValues = map.toList.map { case (r, e) => r -> e.toJson }


### PR DESCRIPTION
Support concurrent execution of Test262Test, this is mainly for performance reason.

For the Linux desktop with 12900F, this reduces test time of whole suite from  01:22:22 to 16:41, the benefit may vary between the systems.

Support serial extraction of ecma262 specification. This is mainly to help debugging as debugging concurrent execution of Extractor was a little bit confusing.