### PR TITLE
Implement priority flag

### DIFF
--- a/.completion
+++ b/.completion
@@ -17,7 +17,7 @@ _esmeta_completions() {
   extractOpt="-extract:target -extract:log -extract:eval -extract:repl"
   compileOpt="-compile:log -compile:log-with-loc"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
-  tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:tysens"
+  tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:priority -tycheck:tysens"
   parseOpt="-parse:debug"
   evalOpt="-eval:timeout -eval:tycheck -eval:multiple -eval:log"
   webOpt="-web:port"

--- a/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
+++ b/src/main/scala/esmeta/analyzer/TypeAnalyzer.scala
@@ -368,19 +368,42 @@ object TypeAnalyzer {
   /** configuration for type checking */
   case class Config(
     // type checkers
-    arity: Boolean = true,
-    paramType: Boolean = true,
-    returnType: Boolean = true,
-    uncheckedAbrupt: Boolean = true,
-    invalidAstProperty: Boolean = true,
-    invalidStrProperty: Boolean = true,
-    invalidNameProperty: Boolean = true,
-    invalidCompProperty: Boolean = true,
-    invalidRecordProperty: Boolean = true,
-    invalidListProperty: Boolean = true,
-    invalidSymbolProperty: Boolean = true,
-    invalidSubMapProperty: Boolean = true,
-    propertyUpdate: Boolean = true,
-    mapAlloc: Boolean = true,
-  )
+    arityPriority: Int = 1,
+    paramTypePriority: Int = 1,
+    returnTypePriority: Int = 1,
+    uncheckedAbruptPriority: Int = 1,
+    invalidAstPropertyPriority: Int = 1,
+    invalidStrPropertyPriority: Int = 1,
+    invalidNamePropertyPriority: Int = 1,
+    invalidCompPropertyPriority: Int = 1,
+    invalidRecordPropertyPriority: Int = 1,
+    invalidListPropertyPriority: Int = 1,
+    invalidSymbolPropertyPriority: Int = 1,
+    invalidSubMapPropertyPriority: Int = 1,
+    propertyUpdatePriority: Int = 1,
+    mapAllocPriority: Int = 1,
+  ) {
+    def arity: Boolean = arityPriority <= PRIORITY_FLAG
+    def paramType: Boolean = paramTypePriority <= PRIORITY_FLAG
+    def returnType: Boolean = returnTypePriority <= PRIORITY_FLAG
+    def uncheckedAbrupt: Boolean = uncheckedAbruptPriority <= PRIORITY_FLAG
+    def invalidAstProperty: Boolean =
+      invalidAstPropertyPriority <= PRIORITY_FLAG
+    def invalidStrProperty: Boolean =
+      invalidStrPropertyPriority <= PRIORITY_FLAG
+    def invalidNameProperty: Boolean =
+      invalidNamePropertyPriority <= PRIORITY_FLAG
+    def invalidCompProperty: Boolean =
+      invalidCompPropertyPriority <= PRIORITY_FLAG
+    def invalidRecordProperty: Boolean =
+      invalidRecordPropertyPriority <= PRIORITY_FLAG
+    def invalidListProperty: Boolean =
+      invalidListPropertyPriority <= PRIORITY_FLAG
+    def invalidSymbolProperty: Boolean =
+      invalidSymbolPropertyPriority <= PRIORITY_FLAG
+    def invalidSubMapProperty: Boolean =
+      invalidSubMapPropertyPriority <= PRIORITY_FLAG
+    def propertyUpdate: Boolean = propertyUpdatePriority <= PRIORITY_FLAG
+    def mapAlloc: Boolean = mapAllocPriority <= PRIORITY_FLAG
+  }
 }

--- a/src/main/scala/esmeta/analyzer/package.scala
+++ b/src/main/scala/esmeta/analyzer/package.scala
@@ -114,6 +114,9 @@ var YET_THROW: Boolean = false
 /** use condition-based refinement */
 var USE_REFINE: Boolean = false
 
+/** priority */
+var PRIORITY_FLAG: Int = 1
+
 // -----------------------------------------------------------------------------
 // shortcuts
 // -----------------------------------------------------------------------------

--- a/src/main/scala/esmeta/phase/TypeCheck.scala
+++ b/src/main/scala/esmeta/phase/TypeCheck.scala
@@ -62,6 +62,11 @@ case object TypeCheck extends Phase[CFG, AbsSemantics] {
       "turn on logging mode.",
     ),
     (
+      "priority",
+      NumOption((c, n) => PRIORITY_FLAG = n),
+      "turn on all type mismatches with a priority higher(1 is highest) than or equal.",
+    ),
+    (
       "tysens",
       BoolOption(c => TY_SENS = true),
       "turn on type sensitivity.",


### PR DESCRIPTION
Implemented priority flag. 1 is highest.

Enable by `-tycheck:priority={pr}`, and all features labeled p1, p2, ... pr should be turned on. 