### PR TITLE
Dump cfg functions in dot/pdf format concurrently

### DIFF
--- a/src/main/scala/esmeta/cfg/CFG.scala
+++ b/src/main/scala/esmeta/cfg/CFG.scala
@@ -76,6 +76,7 @@ case class CFG(
       iterable = funcs,
       getName = (x, _) => x.name,
       detail = false,
+      concurrent = true,
     )
     for (func <- progress)
       val path = s"$baseDir/${func.normalizedName}"


### PR DESCRIPTION
Now: 1m 47s (in M1 Pro, 16GB)
```sh
➜  esmeta git:(dev) ✗ esmeta build-cfg -build-cfg:log -build-cfg:dot -build-cfg:pdf -extract:target=es2022 -silent
- Dump CFG functions... (total: 2,688)
[########################################] 100.00% (2,688/2,688) [00:01]
- Dumped CFG functions into /Users/flow/flow/esmeta/logs/cfg/func .
- Dump CFG functions in DOT/PDF formats... (total: 2,688)
[########################################] 100.00% (2,688/2,688) [01:47]
```
Before: Sorry! It's still working on it!
```sh
➜  esmeta git:(dev) ✗ esmeta build-cfg -build-cfg:log -build-cfg:dot -build-cfg:pdf -extract:target=es2022 -silent
- Dump CFG functions... (total: 2,688)
[########################################] 100.00% (2,688/2,688) [00:01]
- Dumped CFG functions into /Users/flow/flow/esmeta/logs/cfg/func .
- Dump CFG functions in DOT/PDF formats... (total: 2,688)
[###################                     ] 48.44% (1,302/2,688) [04:10]
```