### PR TITLE
Refine on field existence condition

### DIFF
--- a/src/main/resources/manuals/default/ty-model.json
+++ b/src/main/resources/manuals/default/ty-model.json
@@ -600,7 +600,7 @@
       }
     },
     "BoundFunctionExoticObject" : {
-      "parent" : "Object",
+      "parent" : "FunctionObject",
       "methods" : {
         "Call" : "BoundFunctionExoticObject.Call",
         "Construct" : "BoundFunctionExoticObject.Construct"

--- a/src/main/scala/esmeta/analyzer/PruneHelper.scala
+++ b/src/main/scala/esmeta/analyzer/PruneHelper.scala
@@ -27,6 +27,14 @@ trait PruneHelper { this: AbsTransfer =>
         prunedV = lv.pruneValue(r, positive)
         _ <- modify(_.update(l, prunedV))
       } yield ()
+    // prune types with field existence
+    case EBinary(BOp.Eq, ERef(Prop(ref: Local, EStr(field))), EAbsent()) =>
+      for {
+        l <- transfer(ref)
+        lv <- transfer(l)
+        prunedV = lv.pruneObject(field, positive)
+        _ <- modify(_.update(l, prunedV))
+      } yield ()
     // prune fields
     case EBinary(BOp.Eq, ERef(Prop(ref: Local, EStr(field))), target) =>
       for {

--- a/src/main/scala/esmeta/analyzer/PruneHelper.scala
+++ b/src/main/scala/esmeta/analyzer/PruneHelper.scala
@@ -32,7 +32,7 @@ trait PruneHelper { this: AbsTransfer =>
       for {
         l <- transfer(ref)
         lv <- transfer(l)
-        prunedV = lv.pruneObject(field, positive)
+        prunedV = lv.pruneAbsentField(field, positive)
         _ <- modify(_.update(l, prunedV))
       } yield ()
     // prune fields

--- a/src/main/scala/esmeta/analyzer/domain/value/BasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/BasicDomain.scala
@@ -449,7 +449,7 @@ object BasicDomain extends value.Domain {
     def pruneField(field: String, r: Elem, positive: Boolean): Elem = elem
     def pruneType(r: Elem, positive: Boolean): Elem = elem
     def pruneTypeCheck(r: Elem, positive: Boolean): Elem = elem
-    def pruneObject(field: String, positive: Boolean): Elem = elem
+    def pruneAbsentField(field: String, positive: Boolean): Elem = elem
 
     /** completion helpers */
     def wrapCompletion: Elem = wrapCompletion("normal")

--- a/src/main/scala/esmeta/analyzer/domain/value/BasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/BasicDomain.scala
@@ -449,6 +449,7 @@ object BasicDomain extends value.Domain {
     def pruneField(field: String, r: Elem, positive: Boolean): Elem = elem
     def pruneType(r: Elem, positive: Boolean): Elem = elem
     def pruneTypeCheck(r: Elem, positive: Boolean): Elem = elem
+    def pruneObject(field: String, positive: Boolean): Elem = elem
 
     /** completion helpers */
     def wrapCompletion: Elem = wrapCompletion("normal")

--- a/src/main/scala/esmeta/analyzer/domain/value/Domain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/Domain.scala
@@ -148,7 +148,7 @@ trait Domain extends domain.Domain[AValue] {
     def pruneField(field: String, r: Elem, positive: Boolean): Elem
     def pruneType(r: Elem, positive: Boolean): Elem
     def pruneTypeCheck(r: Elem, positive: Boolean): Elem
-    def pruneObject(field: String, positive: Boolean): Elem
+    def pruneAbsentField(field: String, positive: Boolean): Elem
 
     /** single check */
     def isSingle: Boolean = elem.getSingle match

--- a/src/main/scala/esmeta/analyzer/domain/value/Domain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/Domain.scala
@@ -148,6 +148,7 @@ trait Domain extends domain.Domain[AValue] {
     def pruneField(field: String, r: Elem, positive: Boolean): Elem
     def pruneType(r: Elem, positive: Boolean): Elem
     def pruneTypeCheck(r: Elem, positive: Boolean): Elem
+    def pruneObject(field: String, positive: Boolean): Elem
 
     /** single check */
     def isSingle: Boolean = elem.getSingle match

--- a/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
@@ -281,6 +281,14 @@ object TypeDomain extends value.Domain {
       if (positive) Elem(NameT(tname))
       else elem -- Elem(NameT(tname))
     }).getOrElse(elem)
+    def pruneObject(field: String, positive: Boolean): Elem =
+      val subTys = (for {
+        name <- elem.ty.name.set
+      } yield cfg.tyModel.getSubTypes(name, field)).toList.flatten
+      val normalized = Elem(subTys.foldLeft(ValueTy.Bot) {
+        case (res, name) => res ⊔ NameT(name)
+      })
+      if (positive) elem else elem ⊓ normalized
 
     /** completion helpers */
     def wrapCompletion: Elem =

--- a/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
@@ -239,6 +239,14 @@ object TypeDomain extends value.Domain {
       if (positive) elem ⊓ r
       else if (r.isSingle) elem -- r
       else elem
+    def pruneAbsentField(field: String, positive: Boolean): Elem =
+      val subTys = (for {
+        name <- elem.ty.name.set
+      } yield cfg.tyModel.getSubTypes(name, field)).toList.flatten
+      val normalized = Elem(subTys.foldLeft(ValueTy.Bot) {
+        case (res, name) => res ⊔ NameT(name)
+      })
+      if (positive) elem else elem ⊓ normalized
     def pruneField(field: String, r: Elem, positive: Boolean): Elem =
       field match
         case "Value" =>
@@ -281,14 +289,6 @@ object TypeDomain extends value.Domain {
       if (positive) Elem(NameT(tname))
       else elem -- Elem(NameT(tname))
     }).getOrElse(elem)
-    def pruneAbsentField(field: String, positive: Boolean): Elem =
-      val subTys = (for {
-        name <- elem.ty.name.set
-      } yield cfg.tyModel.getSubTypes(name, field)).toList.flatten
-      val normalized = Elem(subTys.foldLeft(ValueTy.Bot) {
-        case (res, name) => res ⊔ NameT(name)
-      })
-      if (positive) elem else elem ⊓ normalized
 
     /** completion helpers */
     def wrapCompletion: Elem =

--- a/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/TypeDomain.scala
@@ -281,7 +281,7 @@ object TypeDomain extends value.Domain {
       if (positive) Elem(NameT(tname))
       else elem -- Elem(NameT(tname))
     }).getOrElse(elem)
-    def pruneObject(field: String, positive: Boolean): Elem =
+    def pruneAbsentField(field: String, positive: Boolean): Elem =
       val subTys = (for {
         name <- elem.ty.name.set
       } yield cfg.tyModel.getSubTypes(name, field)).toList.flatten

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -136,6 +136,19 @@ case class TyModel(infos: Map[String, TyInfo] = Map()) {
   private def getSamePropMap(name: String): PropMap =
     infos.get(name).map(_.props).getOrElse(Map())
 
+  /** get subtypes with field existence */
+  def getSubTypes(name: String, key: String): List[String] = {
+    val exist = getSamePropMap(name).contains(key)
+    if (exist) List(name)
+    else
+      directSubTys.get(name).fold(List()) {
+        case children =>
+          children
+            .flatMap(child => getSubTypes(child, key))
+            .toList
+      }
+  }
+
   /** get property map from ancestors */
   private def getLowerPropMap(name: String): PropMap =
     directSubTys.get(name) match

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -137,17 +137,15 @@ case class TyModel(infos: Map[String, TyInfo] = Map()) {
     infos.get(name).map(_.props).getOrElse(Map())
 
   /** get subtypes with field existence */
-  def getSubTypes(name: String, key: String): List[String] = {
-    val exist = getSamePropMap(name).contains(key)
-    if (exist) List(name)
-    else
-      directSubTys.get(name).fold(List()) {
-        case children =>
-          children
-            .flatMap(child => getSubTypes(child, key))
-            .toList
-      }
-  }
+  lazy val getSubTypes: ((String, String)) => List[String] =
+    cached((name, key) =>
+      val exist = getSamePropMap(name).contains(key)
+      if (exist) List(name)
+      else
+        directSubTys
+          .get(name)
+          .fold(Nil)(_.flatMap(child => getSubTypes(child, key)).toList),
+    )
 
   /** get property map from ancestors */
   private def getLowerPropMap(name: String): PropMap =


### PR DESCRIPTION
This PR includes:
- Refinement(pruning) on field existence condition.
- Fix [BoundFunctionExoticObject](https://tc39.es/ecma262/2022/#sec-bound-function-exotic-objects) TyModel.

The result of this PR:
```
iter: 70,202 → 70,098 (-104)
analyzed-nodes: 16,307/20,020 (81.45%) → 16,313/20,020 (81.48%)
```

diff of analyze/types:
```
    def <BUILTIN>:INTRINSICS.BigInt.prototype.valueOf(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.BigInt.prototype.valueOf(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[BigInt | Undefined] | Abrupt[throw]
+-> def <BUILTIN>:INTRINSICS.BigInt.prototype.valueOf(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[BigInt] | Abrupt[throw]
 --------------------------------------------------------------------------------
    def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[String | Absent] | Abrupt[throw]
+-> def <BUILTIN>:INTRINSICS.Function.prototype.toString(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[String] | Abrupt[throw]
 --------------------------------------------------------------------------------
    def <BUILTIN>:INTRINSICS.get DataView.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.get DataView.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[ArrayBufferObject | Undefined] | Abrupt[throw]
+-> def <BUILTIN>:INTRINSICS.get DataView.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[ArrayBufferObject] | Abrupt[throw]
 --------------------------------------------------------------------------------
    def <BUILTIN>:INTRINSICS.get TypedArray.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Unknown
--> def <BUILTIN>:INTRINSICS.get TypedArray.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[ArrayBufferObject | Undefined] | Abrupt[throw]
+-> def <BUILTIN>:INTRINSICS.get TypedArray.prototype.buffer(this: ESValue, ArgumentsList: List[ESValue], NewTarget: Object | Undefined): Normal[ArrayBufferObject] | Abrupt[throw]
 --------------------------------------------------------------------------------
    def IsArray(argument: Unknown): Normal[Boolean] | Abrupt
--> def IsArray(argument?: ESValue): Normal[Boolean] | Abrupt[throw]
+-> def IsArray(argument: ESValue): Normal[Boolean] | Abrupt[throw]
 --------------------------------------------------------------------------------
    def thisBigIntValue(value: Unknown): Unknown
--> def thisBigIntValue(value: ESValue): Abrupt[throw] | BigInt | Absent
+-> def thisBigIntValue(value: ESValue): Abrupt[throw] | BigInt
 --------------------------------------------------------------------------------
```

Due to the pruning involving the field existence check, many values that previously contained Absent or Undefined have been refined.