### PR TITLE
Implement range-fingerprint-diff

### DIFF
--- a/.completion
+++ b/.completion
@@ -11,7 +11,7 @@ _esmeta_completions() {
   local cur prev opts lastc informats outformats datafiles
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  cmdList="help extract compile build-cfg tycheck range-tycheck parse eval web test262-test inject mutate analyze"
+  cmdList="help extract compile build-cfg tycheck range-tycheck range-fingerprint-diff parse eval web test262-test inject mutate analyze"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
   extractOpt="-extract:target -extract:log -extract:eval -extract:repl"
@@ -19,6 +19,7 @@ _esmeta_completions() {
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:level -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:silent -tycheck:log -tycheck:detail-log -tycheck:logdir -tycheck:tysens"
   rangetycheckOpt="-range-tycheck:yes -range-tycheck:level"
+  rangefingerprintdiffOpt=""
   parseOpt="-parse:debug"
   evalOpt="-eval:timeout -eval:tycheck -eval:multiple -eval:log"
   webOpt="-web:port"
@@ -60,6 +61,10 @@ _esmeta_completions() {
           ;;
         range-tycheck)
           COMPREPLY=($(compgen -W "${globalOpt} ${rangetycheckOpt}"))
+          return 0
+          ;;
+        range-fingerprint-diff)
+          COMPREPLY=($(compgen -W "${globalOpt} ${rangefingerprintdiffOpt}"))
           return 0
           ;;
         parse)

--- a/src/main/scala/esmeta/Command.scala
+++ b/src/main/scala/esmeta/Command.scala
@@ -119,6 +119,16 @@ case object CmdRangeTypeCheck
   override val targetName = "<commit>+"
 }
 
+case object CmdRangeFingerprintDiff
+  extends Command("range-fingerprint-diff", CmdBase >> RangeFingerprintDiff) {
+  val help =
+    "extracts statistics from fingerprint differences across multiple fingerprint sequence"
+  val examples = List(
+    "esmeta range-fingerprint-diff $ESMETA_HOME/logs/range-tycheck # extract statistics from logs/range-tycheck directory.",
+  )
+  override val targetName = "<dir>"
+}
+
 // -----------------------------------------------------------------------------
 // Interpreter & Double Debugger for ECMAScript
 // -----------------------------------------------------------------------------

--- a/src/main/scala/esmeta/ESMeta.scala
+++ b/src/main/scala/esmeta/ESMeta.scala
@@ -69,6 +69,7 @@ object ESMeta extends Git(BASE_DIR) {
     // Analysis of ECMA-262
     CmdTypeCheck,
     CmdRangeTypeCheck,
+    CmdRangeFingerprintDiff,
     // Interpreter & Double Debugger for ECMAScript
     CmdParse,
     CmdEval,
@@ -95,6 +96,7 @@ object ESMeta extends Git(BASE_DIR) {
     // Analysis of ECMA-262
     TypeCheck,
     RangeTypeCheck,
+    RangeFingerprintDiff,
     // Interpreter & Double Debugger for ECMAScript
     Parse,
     Eval,

--- a/src/main/scala/esmeta/analyzer/util/Fingerprint.scala
+++ b/src/main/scala/esmeta/analyzer/util/Fingerprint.scala
@@ -12,7 +12,7 @@ object Fingerprint {
   def apply(err: Iterable[TypeError]): List[String] =
     err.map(_.toFingerprint).map(normStr).toList
 
-  private def readFingerprintJson(path: String): Map[String, List[String]] =
+  def readFingerprintJson(path: String): Map[String, List[String]] =
     optional(readJson[Map[String, List[String]]](path))
       .getOrElse(throw ESMetaError(s"File not found: $path"))
 

--- a/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
+++ b/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
@@ -1,0 +1,50 @@
+package esmeta.phase
+
+import esmeta.*
+import esmeta.util.*
+import esmeta.util.SystemUtils.*
+import esmeta.analyzer.util.Fingerprint
+import java.io.File
+
+case object RangeFingerprintDiff extends Phase[Unit, Unit] {
+  val name = "range-fingerprint-diff"
+
+  val help =
+    "extracts statistics from fingerprint differences across multiple fingerprint sequence"
+
+  def apply(
+    unit: Unit,
+    cmdConfig: CommandConfig,
+    config: Config,
+  ): Unit =
+    val path = cmdConfig.targets.head
+    val fingerprints: List[String] = (
+      for {
+        file <- walkTree(path)
+        pathname = file.toString
+        if pathname.endsWith("fingerprints.json")
+      } yield pathname
+    ).toList.sorted
+    def makePairs[T](list: List[T]): List[(T, T)] =
+      list match {
+        case Nil          => Nil
+        case x :: Nil     => Nil
+        case x :: y :: xs => (x, y) :: makePairs(y :: xs)
+      }
+    val pairs = makePairs(fingerprints)
+    val diffs = pairs.map {
+      case (left, right) =>
+        (left, right, Fingerprint.getDiff(left, right))
+    }
+    println(
+      diffs
+        .map { (left, right, diff) =>
+          s"(${left.split('/').takeRight(2).head} - ${right.split('/').takeRight(2).head}) > added: ${diff.added.length} | removed: ${diff.removed.length} | preserved: ${diff.preserved.length}"
+        }
+        .mkString(LINE_SEP),
+    )
+
+  def defaultConfig: Config = Config()
+  val options: List[PhaseOption[Config]] = List()
+  case class Config()
+}

--- a/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
+++ b/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
@@ -5,22 +5,24 @@ import esmeta.util.*
 import esmeta.util.SystemUtils.*
 import esmeta.analyzer.util.Fingerprint
 import java.io.File
+import esmeta.analyzer.util.Fingerprint.FingerprintDiff
+import esmeta.util.BaseUtils.ratioSimpleString
 
 case object RangeFingerprintDiff extends Phase[Unit, Unit] {
   val name = "range-fingerprint-diff"
 
   val help =
-    "extracts statistics from fingerprint differences across multiple fingerprint sequence"
+    "extracts statistics from multiple fingerprint sequence"
 
   def apply(
     unit: Unit,
     cmdConfig: CommandConfig,
     config: Config,
   ): Unit =
-    val path = cmdConfig.targets.head
-    val fingerprints: List[String] = (
+    val dirPath = cmdConfig.targets.head
+    val paths: List[String] = (
       for {
-        file <- walkTree(path)
+        file <- walkTree(dirPath)
         pathname = file.toString
         if pathname.endsWith("fingerprints.json")
       } yield pathname
@@ -31,20 +33,132 @@ case object RangeFingerprintDiff extends Phase[Unit, Unit] {
         case x :: Nil     => Nil
         case x :: y :: xs => (x, y) :: makePairs(y :: xs)
       }
-    val pairs = makePairs(fingerprints)
+    val pairs = makePairs(paths)
     val diffs = pairs.map {
       case (left, right) =>
-        (left, right, Fingerprint.getDiff(left, right))
+        val leftVersion = left.split('/').takeRight(2).head
+        val rightVersion = right.split('/').takeRight(2).head
+        (leftVersion, rightVersion, Fingerprint.getDiff(left, right))
     }
-    println(
-      diffs
+    val initialFingerprint = Fingerprint.readFingerprintJson(paths.head)
+    val lifespans = getLifespans(
+      LifespanState(initialFingerprint.values.flatten.toList),
+      diffs.map(_._3),
+    )
+    val summary = {
+      (for {
+        path <- paths
+        fingerprint = Fingerprint.readFingerprintJson(path)
+        (tag, values) <- fingerprint.toSeq
+        value <- values
+      } yield (tag, value)).toSet.groupMap(_._1)(_._2)
+    }
+    dumpFile(
+      name = "difference in fingerprint between two revisions",
+      data = Yaml(
+        "count" -> diffs.map { (left, right, diff) =>
+          Map(
+            s"$left -> $right" -> Map(
+              "added" -> diff.added.length,
+              "removed" -> diff.removed.length,
+              "preserved" -> diff.preserved.length,
+            ),
+          )
+        },
+        "detail" -> diffs.map { (left, right, diff) =>
+          Map(
+            s"$left -> $right" -> Map(
+              "added" -> diff.added,
+              "removed" -> diff.removed,
+              "preserved" -> diff.preserved,
+            ),
+          )
+        },
+      ),
+      filename = s"$LOG_DIR/range-fingerprint-diff/diffs.yml",
+    )
+    dumpFile(
+      name =
+        "difference in fingerprint between two revisions (csv without detail)",
+      data = diffs
         .map { (left, right, diff) =>
-          s"(${left.split('/').takeRight(2).head} - ${right.split('/').takeRight(2).head}) > added: ${diff.added.length} | removed: ${diff.removed.length} | preserved: ${diff.preserved.length}"
+          List(
+            left,
+            right,
+            diff.added.length,
+            diff.removed.length,
+            diff.preserved.length,
+          ).mkString(",")
         }
         .mkString(LINE_SEP),
+      filename = s"$LOG_DIR/range-fingerprint-diff/diffs.csv",
+    )
+    dumpFile(
+      name = "lifespan of fingerprints",
+      data = lifespans
+        .map { lifespan =>
+          List(
+            lifespan.fingerprint,
+            paths(lifespan.appear._1),
+            paths(lifespan.appear._2),
+            (lifespan.appear._2 - lifespan.appear._1 + 1),
+          ).mkString("\t")
+        }
+        .mkString(LINE_SEP),
+      filename = s"$LOG_DIR/range-fingerprint-diff/lifespans.tsv",
+    )
+    dumpFile(
+      name = "summary of all fingerprints",
+      data = Yaml(
+        Map("total" -> summary.values.flatten.size) ++
+        (summary.map { (tag, values) =>
+          (tag -> s"${values.size} (${ratioSimpleString(values.size, summary.values.flatten.size)})")
+        }.toMap),
+      ),
+      filename = s"$LOG_DIR/range-fingerprint-diff/summary.yml",
     )
 
   def defaultConfig: Config = Config()
   val options: List[PhaseOption[Config]] = List()
   case class Config()
+}
+
+case class LifespanState(
+  alive: Map[String, Int],
+  generation: Int,
+)
+object LifespanState {
+  def apply(): LifespanState = LifespanState(alive = Map(), generation = 0)
+  def apply(list: List[String]): LifespanState =
+    LifespanState(alive = list.map(_ -> 0).toMap, generation = 0)
+}
+case class Lifespan(
+  fingerprint: String,
+  appear: (Int, Int),
+)
+def getLifespans(
+  state: LifespanState,
+  diffs: List[FingerprintDiff],
+): List[Lifespan] = {
+  val (finalState, lifespans) = diffs.foldLeft((state, List[Lifespan]())) {
+    case ((curr, lst), diff) => {
+      val spans = (for {
+        removed <- diff.removed
+        firstAppear <- curr.alive.get(removed)
+      } yield Lifespan(removed, (firstAppear, curr.generation)))
+      val next = LifespanState(
+        alive = curr.alive -- diff.removed ++ diff.added.map(
+          _ -> (curr.generation + 1),
+        ),
+        generation = curr.generation + 1,
+      )
+      (next, lst ++ spans)
+    }
+  }
+  lifespans ++ finalState.alive.map { (fingerprint, firstAppear) =>
+    Lifespan(
+      fingerprint,
+      (firstAppear, finalState.generation - 1),
+    )
+  }.toList
 }

--- a/src/main/scala/esmeta/util/Appender.scala
+++ b/src/main/scala/esmeta/util/Appender.scala
@@ -112,7 +112,11 @@ object Appender {
         given Rule[(String, Yaml)] = { case (a, (k, v)) => a >> k >> ":" >> v }
         app >> items
       case YList(items) =>
-        given Rule[Yaml] = { case (a, v) => a >> "- " >> v }
+        given Rule[Yaml] = {
+          case (a, v) =>
+            given Rule[Yaml] = yamlWithIndentRule(false)
+            a >> "- " >> v
+        }
         app >> items
       case YString(value) =>
         if (wrap) app >> " " >> value

--- a/src/main/scala/esmeta/util/Summary.scala
+++ b/src/main/scala/esmeta/util/Summary.scala
@@ -140,6 +140,7 @@ object Summary {
       data = toJson,
       filename = filename,
       noSpace = false,
+      silent = false,
     )
 
     /** conversion to JSON */

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -91,9 +91,10 @@ object SystemUtils {
     data: T,
     filename: String,
     noSpace: Boolean,
+    silent: Boolean,
   )(using encoder: Encoder[T]): Unit =
     dumpJson(data, filename, noSpace)
-    println(s"- Dumped $name into $filename in a JSON format.")
+    if (!silent) println(s"- Dumped $name into $filename in a JSON format.")
 
   /** get first filename */
   def getFirstFilename(cmdConfig: CommandConfig, msg: String): String =


### PR DESCRIPTION
This PR includes:
- simplifying fingerprint logics (remove `partitionFingerprints`)
- moving statistics in `analyze/fingerprint` to `analyze/summary.yml`
- introducing `range-fingerprint-diff` command, and this performs below:
	- extracting a difference between adjacent revision (see `range-fingerprint-diff/diffs.yml` log after executing command)
	- extracting lifespans of each fingerprints (see `range-fingerprint-diff/lifespans.tsv`)
	- extracting a summary of fingerprints that have occurred once throughout all revisions (see `range-fingerprint-diff/summary.yml`)

Here is an example of logs:	
![image](https://github.com/es-meta/esmeta/assets/49385012/73112673-4f4e-4835-b329-6d24b56052d9)
