### PR TITLE
Fix lifespan count and get detail-log on range-tycheck

### DIFF
--- a/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
+++ b/src/main/scala/esmeta/phase/RangeFingerprintDiff.scala
@@ -158,7 +158,7 @@ def getLifespans(
   lifespans ++ finalState.alive.map { (fingerprint, firstAppear) =>
     Lifespan(
       fingerprint,
-      (firstAppear, finalState.generation - 1),
+      (firstAppear, finalState.generation),
     )
   }.toList
 }

--- a/src/main/scala/esmeta/phase/RangeTypeCheck.scala
+++ b/src/main/scala/esmeta/phase/RangeTypeCheck.scala
@@ -39,7 +39,7 @@ case object RangeTypeCheck extends Phase[Unit, Unit] {
       print(s"[${idx + 1}/${targetLen}]: $name (hash: $hash)")
       try {
         val result = executeCmd(
-          s"""esmeta tycheck -silent -extract:target="$hash" -tycheck:log -tycheck:logdir="${logdir}" -tycheck:level=${config.level}""",
+          s"""esmeta tycheck -silent -extract:target="$hash" -tycheck:detail-log -tycheck:logdir="${logdir}" -tycheck:level=${config.level}""",
         )
       } catch {
         case e => print(" - failed " + e)


### PR DESCRIPTION
This PR changes below:
- fix lifespan count of fingerprint which lasts until the end of the range
- print detail-log for debugging