### PR TITLE
Fix propRef of parser to pass test262

### DIFF
--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1072,7 +1072,9 @@ trait Parsers extends IndentParsers {
   }.named("lang.Reference")
 
   // property references
-  lazy val propRef: PL[PropertyReference] = opt("the value of") ~> {
+  lazy val propRef: PL[PropertyReference] = opt(
+    "the" ~ opt("String") ~ "value" ~ opt("of"),
+  ) ~> {
     baseRef ~ prop ~ rep(prop) ^^ {
       case base ~ p ~ ps =>
         ps.foldLeft(PropertyReference(base, p))(PropertyReference(_, _))


### PR DESCRIPTION
This PR includes:
- propRef fix of parser to pass test262

During testing with test262, we encountered an issue where the statement `"Let _rawValue_ be the String value _rawStrings_[_index_]."` was not parsing correctly. To alleviate this problem, we have made modification to `propRef` to address this issue.