### PR TITLE
Support `verbose` option for `test262-test` command.

### DIFF
--- a/.completion
+++ b/.completion
@@ -21,7 +21,7 @@ _esmeta_completions() {
   parseOpt="-parse:debug"
   evalOpt="-eval:timeout -eval:tycheck -eval:multiple -eval:log"
   webOpt="-web:port"
-  test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log -test262-test:concurrent"
+  test262testOpt="-test262-test:target -test262-test:progress -test262-test:coverage -test262-test:timeout -test262-test:with-yet -test262-test:log -test262-test:concurrent -test262-test:verbose"
   injectOpt="-inject:defs -inject:out -inject:log"
   mutateOpt="-mutate:out -mutate:mutator -mutate:untilValid"
   analyzeOpt="-analyze:repl"

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -39,6 +39,7 @@ case object Test262Test extends Phase[CFG, Summary] {
       config.coverage,
       config.timeLimit,
       config.concurrent,
+      config.verbose,
     )
 
     // if summary has failed test case, throws an exception
@@ -84,6 +85,11 @@ case object Test262Test extends Phase[CFG, Summary] {
       BoolOption(c => c.concurrent = true),
       "turn on concurrent mode.",
     ),
+    (
+      "verbose",
+      BoolOption(c => c.verbose = true),
+      "turn on verbose mode.",
+    ),
   )
   case class Config(
     var target: Option[String] = None,
@@ -93,5 +99,6 @@ case object Test262Test extends Phase[CFG, Summary] {
     var withYet: Boolean = false,
     var log: Boolean = false,
     var concurrent: Boolean = false,
+    var verbose: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/test262/Test262.scala
+++ b/src/main/scala/esmeta/test262/Test262.scala
@@ -75,6 +75,7 @@ case class Test262(
     useProgress: Boolean = false,
     useErrorHandler: Boolean = true,
     concurrent: Boolean = false,
+    verbose: Boolean = false,
   ): ProgressBar[Test] = ProgressBar(
     msg = s"Run Test262 $name tests",
     iterable = targetTests,
@@ -82,9 +83,14 @@ case class Test262(
     getName = (test, _) => test.relName,
     errorHandler = (e, summary, name) =>
       if (useErrorHandler) e match
-        case NotSupported(reasons) => summary.notSupported.add(name, reasons)
-        case _: TimeoutException   => summary.timeout.add(name)
-        case e: Throwable          => summary.fail.add(name, getMessage(e))
+        case NotSupported(reasons) =>
+          summary.notSupported.add(name, reasons)
+        case _: TimeoutException =>
+          if (verbose) println(s"[TIMEOUT] $name")
+          summary.timeout.add(name)
+        case e: Throwable =>
+          if (verbose) println(s"[FAIL   ] $name")
+          summary.fail.add(name, getMessage(e))
       else throw e,
     verbose = useProgress,
     concurrent = concurrent,
@@ -98,6 +104,7 @@ case class Test262(
     useCoverage: Boolean = false,
     timeLimit: Option[Int] = None, // default: no limit
     concurrent: Boolean = false,
+    verbose: Boolean = false,
   ): Summary = {
     // extract tests from paths
     val tests: List[Test] = getTests(paths.toList)
@@ -116,6 +123,7 @@ case class Test262(
       useProgress = useProgress,
       useErrorHandler = multiple,
       concurrent = concurrent,
+      verbose = verbose,
     )
 
     // coverage with time limit


### PR DESCRIPTION
With the `-test262-test:verbose` option, the `test262-test` command immediately prints all failed or timeout test cases.