### PR TITLE
Fix error in typing rules for EKeys

### DIFF
--- a/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/state/TypeDomain.scala
@@ -143,7 +143,7 @@ object TypeDomain extends state.Domain {
     ): (AbsValue, Elem) =
       val value =
         if (v.ty.subMap.isBottom) AbsValue.Bot
-        else AbsValue(StrT)
+        else AbsValue(ListT(StrT))
       (value, elem)
 
     /** list concatenation */


### PR DESCRIPTION
There is an error in typing rules related to `EKeys`.