### PR TITLE
Add Proxy to supported feature

### DIFF
--- a/src/main/resources/manuals/d048f32e861c2ed4/bugfix.patch
+++ b/src/main/resources/manuals/d048f32e861c2ed4/bugfix.patch
@@ -1,5 +1,5 @@
 diff --git a/spec.html b/spec.html
-index 47ad886a..403c360d 100644
+index 47ad886a..361e0a0b 100644
 --- a/spec.html
 +++ b/spec.html
 @@ -34650,7 +34650,7 @@ THH:mm:ss.sss
@@ -47,3 +47,12 @@ index 47ad886a..403c360d 100644
          </emu-alg>
        </emu-clause>
  
+@@ -46497,7 +46497,7 @@ THH:mm:ss.sss
+             1. Let _p_ be _F_.[[RevocableProxy]].
+             1. If _p_ is *null*, return *undefined*.
+             1. Set _F_.[[RevocableProxy]] to *null*.
+-            1. Assert: _p_ is a Proxy object.
++            1. Assert: _p_ is a Proxy exotic object.
+             1. Set _p_.[[ProxyTarget]] to *null*.
+             1. Set _p_.[[ProxyHandler]] to *null*.
+             1. Return *undefined*.

--- a/src/main/resources/manuals/default/test262/supported-features.json
+++ b/src/main/resources/manuals/default/test262/supported-features.json
@@ -13,6 +13,7 @@
   "Promise.allSettled",
   "Promise.any",
   "Promise.prototype.finally",
+  "Proxy",
   "Reflect",
   "Reflect.construct",
   "Reflect.set",

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -2040,6 +2040,7 @@ ProxyExoticObject.GetOwnProperty
 ProxyExoticObject.GetPrototypeOf
 ProxyExoticObject.HasProperty
 ProxyExoticObject.IsExtensible
+ProxyExoticObject.OwnPropertyKeys
 ProxyExoticObject.PreventExtensions
 ProxyExoticObject.Set
 ProxyExoticObject.SetPrototypeOf

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -5,12 +5,12 @@
     - numeric string: 17
     - syntactic: 195
   - extended productions for web: 28
-- algorithms: 2656 (88.93%)
-  - complete: 2362
-  - incomplete: 294
-- algorithm steps: 19576 (96.78%)
-  - complete: 18946
-  - incomplete: 630
+- algorithms: 2656 (88.97%)
+  - complete: 2363
+  - incomplete: 293
+- algorithm steps: 19576 (96.79%)
+  - complete: 18947
+  - incomplete: 629
 - types: 7000 (91.49%)
   - known: 6404
   - yet: 596

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -466,6 +466,7 @@ class Compiler(
         EVariadic(VOp.Concat, exprs.map(compile(fb, _)))
       case ListConcatExpression(exprs) =>
         EListConcat(exprs.map(compile(fb, _)))
+      case ListCopyExpression(expr) => ECopy(compile(fb, expr))
       case RecordExpression("Completion Record", fields) =>
         val fmap = fields.toMap
         val fs @ List(ty, v, tgt) =

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -351,8 +351,8 @@ class Compiler(
       fb.addInst(INop()) // XXX add edge to lang element
     case SuspendStep(context, true) =>
       fb.addInst(IExpr(EPop(EGLOBAL_EXECUTION_STACK, true)))
-    case RemoveElemStep(expr, elem) =>
-      fb.addInst(IRemoveElem(compile(fb, expr), compile(fb, elem)))
+    case RemoveElemStep(elem, list) =>
+      fb.addInst(IRemoveElem(compile(fb, list), compile(fb, elem)))
     case RemoveFirstStep(expr) =>
       fb.addInst(IExpr(EPop(compile(fb, expr), true)))
     case RemoveContextStep(_, _) =>

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -13,6 +13,9 @@ case class StringConcatExpression(exprs: List[Expression]) extends Expression
 // list concatenation expressions
 case class ListConcatExpression(exprs: List[Expression]) extends Expression
 
+// list copy expressions
+case class ListCopyExpression(expr: Expression) extends Expression
+
 // record expressions
 case class RecordExpression(
   tname: String,

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -87,7 +87,7 @@ case class NoteStep(note: String) extends Step
 case class SuspendStep(context: Reference, remove: Boolean) extends Step
 
 // remove element steps
-case class RemoveElemStep(expr: Expression, elem: Expression) extends Step
+case class RemoveElemStep(elem: Expression, list: Expression) extends Step
 
 // remove firts element steps
 case class RemoveFirstStep(expr: Expression) extends Step

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -240,7 +240,7 @@ trait Parsers extends IndentParsers {
   // remove element step
   lazy val removeElemStep: PL[RemoveElemStep] =
     "remove" ~> expr ~ ("from" ~> expr) <~ end ^^ {
-      case e ~ v => RemoveElemStep(e, v)
+      case e ~ l => RemoveElemStep(e, l)
     }
 
   // remove first element step

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -348,6 +348,7 @@ trait Parsers extends IndentParsers {
   given expr: PL[Expression] = {
     stringConcatExpr |
     listConcatExpr |
+    listCopyExpr |
     recordExpr |
     lengthExpr |
     substrExpr |
@@ -382,6 +383,12 @@ trait Parsers extends IndentParsers {
   lazy val listConcatExpr: PL[ListConcatExpression] =
     "the list-concatenation of" ~> repsep(expr, sep("and")) ^^ {
       ListConcatExpression(_)
+    }
+
+  // list copy expressions
+  lazy val listCopyExpr: PL[ListCopyExpression] =
+    "a List whose elements are the elements of" ~> expr ^^ {
+      ListCopyExpression(_)
     }
 
   // record expressions

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -240,6 +240,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case ListConcatExpression(exprs) =>
         given Rule[List[Expression]] = listNamedSepRule(namedSep = "and")
         app >> "the list-concatenation of " >> exprs
+      case ListCopyExpression(expr) =>
+        app >> "a List whose elements are the elements of " >> expr
       case RecordExpression(ty, fields) =>
         given Rule[(FieldLiteral, Expression)] = {
           case (app, (field, expr)) =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -153,8 +153,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> First("suspend ") >> context
         if (remove) app >> " and remove it from the execution context stack"
         app >> "."
-      case RemoveElemStep(expr, elem) =>
-        app >> First("remove ") >> elem >> " from " >> expr >> "."
+      case RemoveElemStep(elem, list) =>
+        app >> First("remove ") >> elem >> " from " >> list >> "."
       case RemoveFirstStep(expr) =>
         app >> First("remove") >> " the first element from " >> expr >> "."
       case RemoveContextStep(removeCtxt, restoreCtxt) =>

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -78,7 +78,7 @@ trait UnitWalker extends BasicUnitWalker {
     case PushCtxtStep(ref)          => walk(ref)
     case NoteStep(note)             =>
     case SuspendStep(base, _)       => walk(base)
-    case RemoveElemStep(expr, elem) => walk(expr); walk(elem)
+    case RemoveElemStep(elem, list) => walk(elem); walk(list)
     case RemoveFirstStep(expr)      => walk(expr)
     case RemoveContextStep(remove, restore) =>
       walk(remove); walkOpt(restore, walk)

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -100,6 +100,8 @@ trait UnitWalker extends BasicUnitWalker {
       walkList(exprs, walk)
     case ListConcatExpression(exprs) =>
       walkList(exprs, walk)
+    case ListCopyExpression(expr) =>
+      walk(expr)
     case RecordExpression(ty, fields) =>
       walk(ty); walkList(fields, { case (f, e) => walk(f); walk(e) })
     case LengthExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -101,7 +101,7 @@ trait Walker extends BasicWalker {
     case PushCtxtStep(ref)       => PushCtxtStep(walk(ref))
     case NoteStep(note)          => NoteStep(note)
     case SuspendStep(base, r)    => SuspendStep(walk(base), r)
-    case RemoveElemStep(expr, elem) => RemoveElemStep(walk(expr), walk(elem))
+    case RemoveElemStep(elem, list) => RemoveElemStep(walk(elem), walk(list))
     case RemoveFirstStep(expr)      => RemoveFirstStep(walk(expr))
     case RemoveContextStep(remove, restore) =>
       RemoveContextStep(walk(remove), walkOpt(restore, walk))

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -133,6 +133,8 @@ trait Walker extends BasicWalker {
       StringConcatExpression(walkList(exprs, walk))
     case ListConcatExpression(exprs) =>
       ListConcatExpression(walkList(exprs, walk))
+    case ListCopyExpression(expr) =>
+      ListCopyExpression(walk(expr))
     case RecordExpression(ty, fields) =>
       lazy val newFields =
         walkList(fields, { case (f, e) => (walk(f), walk(e)) })

--- a/src/test/scala/esmeta/lang/JsonTinyTest.scala
+++ b/src/test/scala/esmeta/lang/JsonTinyTest.scala
@@ -139,6 +139,7 @@ class JsonTinyTest extends LangTest {
       listConcatExprOne -> "the list-concatenation of _x_",
       listConcatExprTwo -> "the list-concatenation of _x_ and _x_",
       listConcatExprThree -> "the list-concatenation of _x_, _x_, and _x_",
+      listCopyExpr -> "a List whose elements are the elements of _x_",
       recordEmptyExpr -> "Object { }",
       recordExpr -> "Object { [[Value]]: _x_ }",
       lengthExpr -> "the length of _x_",

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -115,6 +115,7 @@ object LangTest {
     ListConcatExpression(List(refExpr, refExpr))
   lazy val listConcatExprThree =
     ListConcatExpression(List(refExpr, refExpr, refExpr))
+  lazy val listCopyExpr = ListCopyExpression(refExpr)
   lazy val recordEmptyExpr =
     RecordExpression("Object", Nil)
   lazy val recordExpr =

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -138,6 +138,7 @@ class StringifyTinyTest extends LangTest {
       listConcatExprOne -> "the list-concatenation of _x_",
       listConcatExprTwo -> "the list-concatenation of _x_ and _x_",
       listConcatExprThree -> "the list-concatenation of _x_, _x_, and _x_",
+      listCopyExpr -> "a List whose elements are the elements of _x_",
       recordEmptyExpr -> "Object { }",
       recordExpr -> "Object { [[Value]]: _x_ }",
       lengthExpr -> "the length of _x_",


### PR DESCRIPTION
This PR includes:
- Add Proxy to supported feature
- Fix `bugfix.patch` according to the [update](https://github.com/tc39/ecma262/pull/2994) of ECMA262
- Add `listCopyExpr` for supporting following statement in [spec](https://262.ecma-international.org/14.0/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys):
  ```
  Let _uncheckedResultKeys_ be a List whose elements are the elements of _trapResult_.
  ```
- Fix `RemoveElemStep` to tackle Interpreter Error