### PR TITLE
Support more readable git versions

### DIFF
--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -1,4 +1,4 @@
-- version: tags/es2023-candidate-2023-04^0 (d048f32e861c2ed4a26f59a50d392918f26da3ba)
+- version: d048f32e861c2ed4a26f59a50d392918f26da3ba (es2023)
 - grammar:
   - productions: 359
     - lexical: 147

--- a/src/main/scala/esmeta/error/UtilError.scala
+++ b/src/main/scala/esmeta/error/UtilError.scala
@@ -2,3 +2,9 @@ package esmeta.error
 
 sealed abstract class UtilError(msg: String)
   extends ESMetaError(msg, "UtilError")
+
+case class InvalidGitVersion(msg: String)
+  extends UtilError(s"Invalid git version: $msg")
+
+case class GitTagMismatch(hash: String, tagName: String)
+  extends UtilError(s"Git tag mismatch: $hash != $tagName")

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -19,7 +19,7 @@ class StringifyTinyTest extends SpecTest {
     // -------------------------------------------------------------------------
     checkParseAndStringify("Summary", Summary)(
       Summary(
-        Some(Spec.Version("main", "2j3foijwo2")),
+        Some(Spec.Version("d048f32e861c2ed4a26f59a50d392918f26da3ba")),
         GrammarSummary(145, 16, 195, 28),
         AlgorithmSummary(2258, 365),
         StepSummary(18307, 754),
@@ -27,7 +27,7 @@ class StringifyTinyTest extends SpecTest {
         89,
         58,
       ) ->
-      s"""- version: main (2j3foijwo2)
+      s"""- version: d048f32e861c2ed4a26f59a50d392918f26da3ba (es2023)
          |- grammar:
          |  - productions: 356
          |    - lexical: 145

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -17,9 +17,11 @@ class StringifyTinyTest extends SpecTest {
     // -------------------------------------------------------------------------
     // Summary
     // -------------------------------------------------------------------------
+    val version =
+      Spec.Version("d048f32e861c2ed4a26f59a50d392918f26da3ba", Some("es2023"))
     checkParseAndStringify("Summary", Summary)(
       Summary(
-        Some(Spec.Version("d048f32e861c2ed4a26f59a50d392918f26da3ba")),
+        Some(version),
         GrammarSummary(145, 16, 195, 28),
         AlgorithmSummary(2258, 365),
         StepSummary(18307, 754),


### PR DESCRIPTION
The current `Git` helper utilized the following command to extract Git version name:
```bash
git name-rev --name-only <target>
```
It produced the following output for the `es2023` tag:
```bash
tags/es2023-candidate-2023-04^0
```

Instead, this PR proposes to use the following command to produce a more readable name for git versions:
```bash
git describe --tags --exact-match <target>
```
and it produces the following output for the `es2023` tag:
```bash
es2023
```