### PR TITLE
Support direct use of modified named character notation

### DIFF
--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -133,9 +133,9 @@ trait Parsers extends LangParsers {
   lazy val cp: Parser[CodePoint] = {
     lazy val unicode = "U[+]([1-9A-F]|10)?[0-9A-F]{4}".r
     // https://www.unicode.org/reports/tr34/#UAX34-R1
-    "<" ~> unicode ~ (opt("(") ~> rep("[-A-Z0-9]+".r) <~ opt(")")) <~ ">" ^^ {
-      case cp ~ desc =>
-        CodePoint(Integer.parseInt(cp.drop(2), 16), desc.mkString(" "))
+    lazy val desc = rep1("[-A-Z0-9]+".r) ^^ { _.mkString(" ") }
+    "<" ~> unicode ~ opt(desc | "(" ~> desc <~ ")") <~ ">" ^^ {
+      case c ~ d => CodePoint(Integer.parseInt(c.drop(2), 16), d.getOrElse(""))
     }
   }.named("spec.CodePoint")
 
@@ -146,7 +146,7 @@ trait Parsers extends LangParsers {
 
   /** symbols for sets of unicode code points with a condition */
   lazy val unicodeSet: Parser[UnicodeSet] = {
-    ">" ~ ("any Unicode code point" | "any code point") ~> opt(".+".r) ^^ {
+    ">" ~ ("any" ~ opt("Unicode") ~ "code point") ~> opt(".+".r) ^^ {
       UnicodeSet(_)
     }
   }.named("spec.UnicodeSet")

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -132,7 +132,8 @@ trait Parsers extends LangParsers {
   /** symbols for code point abbreviations */
   lazy val cp: Parser[CodePoint] = {
     lazy val unicode = "U[+]([1-9A-F]|10)?[0-9A-F]{4}".r
-    "<" ~> unicode ~ rep(word) <~ ">" ^^ {
+    // https://www.unicode.org/reports/tr34/#UAX34-R1
+    "<" ~> unicode ~ (opt("(") ~> rep("[-A-Z0-9]+".r) <~ opt(")")) <~ ">" ^^ {
       case cp ~ desc =>
         CodePoint(Integer.parseInt(cp.drop(2), 16), desc.mkString(" "))
     }
@@ -145,7 +146,9 @@ trait Parsers extends LangParsers {
 
   /** symbols for sets of unicode code points with a condition */
   lazy val unicodeSet: Parser[UnicodeSet] = {
-    ">" ~ "any Unicode code point" ~> opt(".+".r) ^^ { UnicodeSet(_) }
+    ">" ~ ("any Unicode code point" | "any code point") ~> opt(".+".r) ^^ {
+      UnicodeSet(_)
+    }
   }.named("spec.UnicodeSet")
 
   /** lookahead symbol */


### PR DESCRIPTION
fixes #220 

- tag: es2023
```
- version: d048f32e861c2ed4a26f59a50d392918f26da3ba (es2023)
- grammar:
  - productions: 359
    - lexical: 147
    - numeric string: 17
    - syntactic: 195
  - extended productions for web: 28
- algorithms: 2654 (88.96%)
  - complete: 2361
  - incomplete: 293
- algorithm steps: 19535 (96.80%)
  - complete: 18909
  - incomplete: 626
- types: 6999 (93.28%)
  - known: 6529
  - yet: 470
  - unknown: 620
- tables: 89
- type model: 58
```

- branch: GH-2930
```
- version: 30dd718ed81baeedbc971a1e5d25ea32bc562f65
- grammar:
  - productions: 374
    - lexical: 162
    - numeric string: 17
    - syntactic: 195
  - extended productions for web: 29
- algorithms: 2774 (88.18%)
  - complete: 2446
  - incomplete: 328
- algorithm steps: 20511 (96.87%)
  - complete: 19870
  - incomplete: 641
- types: 7334 (91.79%)
  - known: 6732
  - yet: 602
  - unknown: 625
- tables: 90
- type model: 58
```