### PR TITLE
Refactor `ESValueParser`

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -133,8 +133,6 @@
   "LengthOfArrayLike",
   "LexicalBinding[0,1].Evaluation",
   "LexicalBinding[1,0].Evaluation",
-  "LiteralPropertyName[2,0].Evaluation",
-  "LiteralPropertyName[2,0].PropName",
   "LogicalANDExpression[1,0].Evaluation",
   "LogicalORExpression[1,0].Evaluation",
   "MemberExpression[1,0].Evaluation",

--- a/src/main/scala/esmeta/analyzer/domain/obj/ObjBasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/obj/ObjBasicDomain.scala
@@ -367,7 +367,7 @@ trait ObjBasicDomainDecl { self: Self =>
           KeyWiseList(if (intSorted) {
             (for {
               case Str(s) <- props
-              d = ESValueParser.str2Number(s)
+              d = ESValueParser.str2number(s).double
               if toStringHelper(d) == s
               i = d.toLong
               if d == i

--- a/src/main/scala/esmeta/analyzer/domain/value/ValueBasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/ValueBasicDomain.scala
@@ -344,8 +344,8 @@ trait ValueBasicDomainDecl { self: Self =>
           case _              => Bot
         )
         for (Str(s) <- elem.str) newV ⊔= (cop match
-          case ToNumber => apply(Number(ESValueParser.str2Number(s)))
-          case ToBigInt => apply(ESValueParser.str2bigInt(s))
+          case ToNumber => apply(ESValueParser.str2number(s))
+          case ToBigInt => apply(ESValueParser.str2bigint(s))
           case _: ToStr => apply(Str(s))
           case _        => Bot
         )
@@ -451,7 +451,7 @@ trait ValueBasicDomainDecl { self: Self =>
       def isArrayIndex: Elem = elem.getSingle match
         case Zero => Bot
         case One(Str(s)) =>
-          val d = ESValueParser.str2Number(s)
+          val d = ESValueParser.str2number(s).double
           val ds = toStringHelper(d)
           val UPPER = (1L << 32) - 1
           val l = d.toLong

--- a/src/main/scala/esmeta/analyzer/domain/value/ValueTypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/ValueTypeDomain.scala
@@ -404,14 +404,16 @@ trait ValueTypeDomainDecl { self: Self =>
         else
           method match
             case "SV" | "TRV" | "StringValue" => StrT
-            case "IdentifierCodePoints"       => StrT
-            case "MV" | "NumericValue" =>
+            // TODO handle `list of code points` type
+            case "IdentifierCodePoints" => StrT
+            case "MV" =>
               elem.ty.astValue.getNames match
                 case Fin(set) =>
                   if (set subsetOf posIntMVTyNames) PosIntT
                   else if (set subsetOf nonNegIntMVTyNames) NonNegIntT
                   else MathT
                 case Inf => MathT
+            case "NumericValue"          => NumericT
             case "TV"                    => StrT // XXX ignore UndefT case
             case "BodyText" | "FlagText" => StrT
             case "Contains"              => BoolT

--- a/src/main/scala/esmeta/parser/ESParser.scala
+++ b/src/main/scala/esmeta/parser/ESParser.scala
@@ -45,7 +45,7 @@ case class ESParser(
         // TODO handle in a more general way for indirect left-recursion
         if (name == "CoalesceExpressionHead") handleLR
         else getParser(prod)
-      else (args: List[Boolean]) => nt(name, lexers(name, 0))
+      else (args: List[Boolean]) => nt(name, lexers(name, 0 /* TODO args */ ))
     name -> parser
   }).toMap
 
@@ -158,7 +158,7 @@ case class ESParser(
     case symbol: NtBase =>
       lazy val parser = symbol match
         case Nonterminal(name, args) =>
-          if (lexNames contains name) nt(name, lexers(name, 0))
+          if (lexNames contains name) nt(name, lexers(name, 0 /* TODO args */ ))
           else parsers(name)(toBools(argsSet, args))
         case ButNot(base, cases) =>
           val name = s"$base \\ ${cases.mkString("(", ", ", ")")}"

--- a/src/main/scala/esmeta/parser/ESValueParser.scala
+++ b/src/main/scala/esmeta/parser/ESValueParser.scala
@@ -416,14 +416,14 @@ object ESValueParser extends UnicodeParsers with RegexParsers {
     lazy val HexEscapeSequence: S = "x" % TRV.HexDigit % TRV.HexDigit
     lazy val UnicodeEscapeSequence: S =
       "u" % TRV.Hex4Digits |
-      "u{" % TRV.CodePoint <~ "}"
+      "u{" % TRV.CodePoint % "}"
     lazy val Hex4Digits: S =
       TRV.HexDigit % TRV.HexDigit % TRV.HexDigit % TRV.HexDigit
     lazy val HexDigit: S = Predef.HexDigit
     lazy val LineContinuation: S = "\\" % LineTerminatorSequence
     lazy val LineTerminatorSequence: S =
-      Predef.cr ^^^ "\u000a" |
       Predef.cr ~> Predef.lf |
+      Predef.cr ^^^ "\u000a" |
       Predef.lf |
       Predef.ls |
       Predef.ps

--- a/src/main/scala/esmeta/parser/ESValueParser.scala
+++ b/src/main/scala/esmeta/parser/ESValueParser.scala
@@ -1,8 +1,10 @@
 package esmeta.parser
 
+import esmeta.error.*
 import esmeta.es.*
 import esmeta.state.{BigInt => BigIntV, *}
-import esmeta.error.*
+import esmeta.util.BaseUtils.*
+import scala.annotation.switch
 import scala.util.matching.Regex
 import scala.util.parsing.combinator.*
 import scala.util.parsing.input.*
@@ -12,45 +14,437 @@ object ESValueParser extends UnicodeParsers with RegexParsers {
   case class Data() extends DataType { def next = this }
   def defaultData = Data()
 
-  // parsing
-  def parseIdentifier(str: String): String =
-    get("SV.IdentifierName", SV.IdentifierName, str)
-  def parseString(str: String): String =
-    get("SV.StringLiteral", SV.StringLiteral, str)
-  def parseNumber(str: String): SimpleValue =
-    get("NumericValue.NumericLiteral", NumericValue.NumericLiteral, str)
-  def parseTVNoSubstitutionTemplate(str: String): SimpleValue =
-    tv(get("TV.NoSubstitutionTemplate", TV.NoSubstitutionTemplate, str))
-  def parseTRVNoSubstitutionTemplate(str: String): String =
-    getOrElse("TRV.NoSubstitutionTemplate", TRV.NoSubstitutionTemplate, str, "")
-  def parseTVTemplateHead(str: String): SimpleValue =
-    tv(get("TV.TemplateHead", TV.TemplateHead, str))
-  def parseTRVTemplateHead(str: String): String =
-    get("TRV.TemplateHead", TRV.TemplateHead, str)
-  def parseTVTemplateMiddle(str: String): SimpleValue =
-    tv(get("TV.TemplateMiddle", TV.TemplateMiddle, str))
-  def parseTRVTemplateMiddle(str: String): String =
-    get("TRV.TemplateMiddle", TRV.TemplateMiddle, str)
-  def parseTVTemplateTail(str: String): SimpleValue =
-    tv(get("TV.TemplateTail", TV.TemplateTail, str))
-  def parseTRVTemplateTail(str: String): String =
-    get("TRV.TemplateTail", TRV.TemplateTail, str)
-  def str2Number(str: String): Double =
-    parseAll(DoubleMV.StringNumericLiteral, str) match {
-      case Success(0, _) if str.trim.startsWith("-") => -0.0
-      case Success(n, _)                             => n.toDouble
-      case _                                         => Double.NaN
-    }
-  def str2bigInt(str: String): SimpleValue =
-    parseAll(BigIntMV.StringNumericLiteralForBigInt, str) match {
-      case Success(b, _) => BigIntV(b)
-      case _             => Undef
-    }
+  // not skip white spaces
+  override def skipWhitespace = false
+
+  // Math parsers
+  type M = Parser[Math]
+
+  // Number parsers
+  type N = Parser[Number]
+
+  // String parsers
+  type S = Parser[String]
+  extension (x0: S) {
+    inline def rep: S = x0.* ^^ { _.mkString }
+    inline def rep1: S = x0.+ ^^ { _.mkString }
+    inline def opt: S = x0.? ^^ { _.getOrElse("") }
+    inline def %(x1: => S): S = x0 ~ x1 ^^ { case x ~ y => x + y }
+    inline def not: S = Predef.SourceCharacter.filter(parseAll(x0, _).isEmpty)
+  }
+
+  def str2number(str: String): Number = optional {
+    StringNumericValue.of("StringNumericLiteral")(str)
+  }.getOrElse(Number(Double.NaN))
+  def str2bigint(str: String): BigIntV | Undef = optional {
+    MV.of("StringIntegerLiteral")(str).toBigInt
+  }.getOrElse(Undef)
+
+  // predefined parsers
+  object Predef {
+    lazy val lf = toParser(LF)
+    lazy val cr = toParser(CR)
+    lazy val ls = toParser(LS)
+    lazy val ps = toParser(PS)
+    lazy val SourceCharacter: S = "(?s).".r
+    lazy val WhiteSpace: S = toParser(WhiteSpaceCPs)
+    lazy val LineTerminator: S = toParser(LineTerminatorCPs)
+    lazy val LineTerminatorSequence: S = lf | cr <~ not(lf) | ls | ps | cr % lf
+    lazy val LineContinuation: S = "\\" % LineTerminatorSequence
+    lazy val StrWhiteSpaceChar: S = toParser(StrWhiteSpaceCharCPs)
+    lazy val StrWhiteSpace: S = StrWhiteSpaceChar.rep1
+    lazy val SignedInteger: S = "[+-]?[0-9]+".r
+    lazy val BinaryIntegerLiteral: S = "0[bB][01]+".r
+    lazy val OctalIntegerLiteral: S = "0[oO][0-7]+".r
+    lazy val HexIntegerLiteral: S = "0[xX][0-9a-fA-F]+".r
+    lazy val NonDecimalIntegerLiteral: S =
+      BinaryIntegerLiteral | OctalIntegerLiteral | HexIntegerLiteral
+    lazy val StrIntegerLiteral: S = SignedInteger | NonDecimalIntegerLiteral
+    lazy val LegacyOctalEscapeSequence: S =
+      "0" <~ guard("8" | "9") |
+      NonZeroOctalDigit <~ not(OctalDigit) |
+      ZeroToThree % OctalDigit <~ not(OctalDigit) |
+      FourToSeven % OctalDigit |
+      ZeroToThree % OctalDigit % OctalDigit
+    lazy val NonZeroOctalDigit: S = "[1-7]".r
+    lazy val OctalDigit: S = "[0-7]".r
+    lazy val ZeroToThree: S = "[0-3]".r
+    lazy val FourToSeven: S = "[4-7]".r
+    lazy val NonOctalDecimalEscapeSequence: S = "[89]".r
+    lazy val SingleEscapeCharacter: S = "[btnvfrn'\"\\\\]".r
+    lazy val DecimalDigit: S = "[0-9]".r
+    lazy val EscapeCharacter: S =
+      SingleEscapeCharacter | DecimalDigit | "x" | "u"
+    lazy val HexDigit: S = "[0-9a-fA-F]".r
+    lazy val HexDigits: S = "[0-9a-fA-F]+".r
+    lazy val NotEscapeSequence: S =
+      "0" % DecimalDigit |
+      DecimalDigit.filter(_ != "0") |
+      "x" <~ not(HexDigit) |
+      "x" % HexDigit <~ not(HexDigit) |
+      "u" % HexDigit <~ not(HexDigit) |
+      "u" % HexDigit % HexDigit <~ not(HexDigit) |
+      "u" % HexDigit % HexDigit % HexDigit <~ not(HexDigit) |
+      "u" <~ not(HexDigit) <~ not("{") |
+      "u{" <~ not(HexDigit) |
+      "u{" % NotCodePoint <~ not(HexDigit) |
+      "u{" % CodePoint <~ not(HexDigit) <~ not("}")
+    lazy val CodePoint: S =
+      HexDigits.filter { s => Math(s).toInt <= 0x10ffff }
+    lazy val NotCodePoint: S =
+      HexDigits.filter { s => Math(s).toInt > 0x10ffff }
+  }
+
+  // ---------------------------------------------------------------------------
+  // StringValue of |IdentifierName| and |PrivateIdentifier|
+  // (https://tc39.es/ecma262/#sec-numericvalue)
+  // ---------------------------------------------------------------------------
+  object StringValue {
+    val of: Map[String, String => Str] = from("StringValue")(
+      "IdentifierName \\ (ReservedWord)" -> (IdentifierName ^^ { Str(_) }),
+      "IdentifierName" -> (IdentifierName ^^ { Str(_) }),
+      "PrivateIdentifier" -> (PrivateIdentifier ^^ { Str(_) }),
+    )
+
+    lazy val IdentifierName: S =
+      IdentifierStart % IdentifierPart.rep
+    lazy val IdentifierStart: S =
+      IDStart |
+      "$" |
+      "_" |
+      "\\" ~> SV.UnicodeEscapeSequence
+    lazy val IdentifierPart: S =
+      IDContinue |
+      "$" |
+      "\\" ~> SV.UnicodeEscapeSequence
+    lazy val PrivateIdentifier: S = "#" % IdentifierName
+  }
+
+  // ---------------------------------------------------------------------------
+  // Numeric Value of |NumericLiteral|
+  // (https://tc39.es/ecma262/#sec-numericvalue)
+  // ---------------------------------------------------------------------------
+  object NumericValue {
+    val of: Map[String, String => Numeric] = Map(
+      "NumericLiteral" -> { s =>
+        (s.take(2): @switch) match
+          case "0b" | "0B" => toNumeric(s.drop(2), 2)
+          case "0o" | "0O" => toNumeric(s.drop(2), 8)
+          case "0x" | "0X" => toNumeric(s.drop(2), 16)
+          case _ =>
+            if (isOctalString(s)) toNumeric(s, 8)
+            else toNumeric(s, 10)
+      },
+    )
+
+    // convert to a numeric value with a base
+    private def toNumeric(s: String, base: Int): Numeric =
+      if (s.endsWith("n")) BigIntV(BigInt(s.dropRight(1), base))
+      else if (base == 10) Number(Math(s).toDouble)
+      else Number(Math.from(s, base).toDouble)
+  }
+
+  // ---------------------------------------------------------------------------
+  // MV
+  // ---------------------------------------------------------------------------
+  object MV {
+    val of = Map[String, String => Math](
+      // https://tc39.es/ecma262/#sec-static-semantics-mv
+      "NumericLiteral" -> { s =>
+        val ss = noSuffix(s)
+        handleNonDecimal(ss).getOrElse(handleLegacyOctal(ss))
+      },
+      "DecimalBigIntegerLiteral" -> { s => Math(noSuffix(s)) },
+      "NonDecimalIntegerLiteral" -> { handleNonDecimal(_).get },
+      "DecimalLiteral" -> { s => Math(s) },
+      "DecimalIntegerLiteral" -> { s => Math(s) },
+      "DecimalDigits" -> { s => Math(s) },
+      "DecimalDigit" -> { s => Math(s) },
+      "NonZeroDigit" -> { s => Math(s) },
+      "ExponentPart" -> { s => Math(s.tail) },
+      "SignedInteger" -> { s => Math(s) },
+      "BinaryIntegerLiteral" -> { s => Math.fromBinary(s.drop(2)) },
+      "BinaryDigits" -> { s => Math.fromBinary(noSep(s)) },
+      "BinaryDigit" -> { s => Math(s) },
+      "OctalIntegerLiteral" -> { s => Math.fromOctal(s.drop(2)) },
+      "OctalDigits" -> { s => Math.fromOctal(noSep(s)) },
+      "LegacyOctalIntegerLiteral" -> { s => Math.fromOctal(s) },
+      "NonOctalDecimalIntegerLiteral" -> { s => Math(s) },
+      "LegacyOctalLikeDecimalIntegerLiteral" -> { s => Math(s) },
+      "OctalDigit" -> { s => Math(s) },
+      "HexIntegerLiteral" -> { s => Math.fromHex(s.drop(2)) },
+      "HexDigits" -> { s => Math.fromHex(noSep(s)) },
+      "HexDigit" -> { s => Math.fromHex(s) },
+
+      // https://tc39.es/ecma262/#sec-string-literals-static-semantics-mv
+      "LegacyOctalEscapeSequence" -> { s => Math.fromOctal(s) },
+      "NonZeroOctalDigit" -> { s => Math(s) },
+      "ZeroToThree" -> { s => Math(s) },
+      "FourToSeven" -> { s => Math(s) },
+      "NonOctalDecimalEscapeSequence" -> { s => Math(s) },
+      "HexEscapeSequence" -> { s => Math.fromHex(s.tail) },
+      "Hex4Digits" -> { s => Math.fromHex(s) },
+    ) ++ from("MV")(
+      // https://tc39.es/ecma262/#sec-runtime-semantics-mv-for-stringintegerliteral
+      "StringIntegerLiteral" -> StringIntegerLiteral,
+    )
+
+    lazy val HexDigit: M =
+      "[0-9a-fA-F]".r ^^ { case s => Math.fromHex(s) }
+    lazy val HexDigits: M =
+      "[0-9a-fA-F]+".r ^^ { case s => Math.fromHex(noSep(s)) }
+    lazy val Hex4Digits: M =
+      "[0-9a-fA-F]{4}".r ^^ { case s => Math.fromHex(s) }
+    lazy val StringIntegerLiteral: M =
+      import Predef.{StrWhiteSpace, StrIntegerLiteral}
+      opt(StrWhiteSpace) ~> {
+        StrIntegerLiteral ^^ { s => handleNonDecimal(s).getOrElse(Math(s)) }
+      } <~ opt(StrWhiteSpace) |
+      opt(StrWhiteSpace) ^^^ Math(0)
+    lazy val CodePoint: M = MV.HexDigits.filter { _.toInt <= 0x10ffff }
+    lazy val NotCodePoint: M = MV.HexDigits.filter { _.toInt > 0x10ffff }
+    lazy val NonDecimalIntegerLiteral: M =
+      Predef.BinaryIntegerLiteral ^^ { s => Math.fromBinary(s.drop(2)) } |
+      Predef.OctalIntegerLiteral ^^ { s => Math.fromOctal(s.drop(2)) } |
+      Predef.HexIntegerLiteral ^^ { s => Math.fromHex(s.drop(2)) }
+
+    // remove numeric literal separator
+    private def noSep(s: String): String = s.replace("_", "")
+
+    // remove suffix "n" from a string
+    private inline def noSuffix(s: String): String =
+      if (s.endsWith("n")) s.dropRight(1) else s
+
+    // handle non-decimal integer literals
+    private inline def handleNonDecimal(s: String): Option[Math] =
+      (s.take(2): @switch) match
+        case "0b" | "0B" => Some(Math.fromBinary(noSuffix(s.drop(2))))
+        case "0o" | "0O" => Some(Math.fromOctal(noSuffix(s.drop(2))))
+        case "0x" | "0X" => Some(Math.fromHex(noSuffix(s.drop(2))))
+        case _           => None
+
+    // handle legacy octal integer literals
+    private inline def handleLegacyOctal(s: String): Math =
+      if (isOctalString(s)) Math.fromOctal(s) else Math(s)
+  }
+
+  // ---------------------------------------------------------------------------
+  // StringNumericValue of |StringNumericLiteral|
+  // (https://tc39.es/ecma262/#sec-runtime-semantics-stringnumericvalue)
+  // ---------------------------------------------------------------------------
+  object StringNumericValue {
+    val of: Map[String, String => Number] = from("StringNumericValue")(
+      "StringNumericLiteral" -> StringNumericLiteral,
+      "StrNumericLiteral" -> StrNumericLiteral,
+      "StrDecimalLiteral" -> StrDecimalLiteral,
+      "StrUnsignedDecimalLiteral" -> StrUnsignedDecimalLiteral,
+    )
+
+    lazy val StringNumericLiteral: N =
+      import Predef.StrWhiteSpace
+      opt(StrWhiteSpace) ~> {
+        StringNumericValue.StrNumericLiteral
+      } <~ opt(StrWhiteSpace) |
+      opt(Predef.StrWhiteSpace) ^^^ Number(0)
+    lazy val StrNumericLiteral: N =
+      StringNumericValue.StrDecimalLiteral |
+      MV.NonDecimalIntegerLiteral ^^ { n => Number(n.toDouble) }
+    lazy val StrDecimalLiteral: N =
+      "[-+]?".r ~ StringNumericValue.StrUnsignedDecimalLiteral ^^ {
+        case s ~ Number(n) => if (s == "-") Number(-n) else Number(n)
+      }
+    lazy val StrUnsignedDecimalLiteral: N =
+      "Infinity" ^^^ Number(Double.PositiveInfinity) |
+      "[.eE0-9]+".r ^^ { s => Number(Math(s).toDouble) }
+  }
+
+  // ---------------------------------------------------------------------------
+  // SV of |StringLiteral|
+  // (https://tc39.es/ecma262/#sec-static-semantics-sv)
+  // ---------------------------------------------------------------------------
+  object SV {
+    val of: Map[String, String => Str] = from("SV")(
+      "StringLiteral" -> (StringLiteral ^^ { Str(_) }),
+    )
+
+    lazy val StringLiteral: S =
+      "\"" ~> SV.DoubleStringCharacters.opt <~ "\"" |
+      "'" ~> SV.SingleStringCharacters.opt <~ "'"
+    lazy val DoubleStringCharacters: S = SV.DoubleStringCharacter.rep1
+    lazy val SingleStringCharacters: S = SV.SingleStringCharacter.rep1
+    lazy val DoubleStringCharacter: S =
+      ("\"" | "\\" | Predef.LineTerminator).not |
+      Predef.ls |
+      Predef.ps |
+      "\\" ~> SV.EscapeSequence |
+      Predef.LineContinuation ^^^ ""
+    lazy val SingleStringCharacter: S =
+      ("'" | "\\" | Predef.LineTerminator).not |
+      Predef.ls |
+      Predef.ps |
+      "\\" ~> SV.EscapeSequence |
+      Predef.LineContinuation ^^^ ""
+    lazy val EscapeSequence: S =
+      SV.CharacterEscapeSequence |
+      "0" ^^^ "\u0000" |
+      Predef.LegacyOctalEscapeSequence ^^ { s => cp2str(Math.fromOctal(s)) } |
+      Predef.NonOctalDecimalEscapeSequence |
+      SV.HexEscapeSequence |
+      SV.UnicodeEscapeSequence
+    lazy val CharacterEscapeSequence: S =
+      Predef.SingleEscapeCharacter ^^ {
+        case "b" => "\u0008"
+        case "t" => "\u0009"
+        case "n" => "\u000a"
+        case "v" => "\u000b"
+        case "f" => "\u000c"
+        case "r" => "\u000d"
+        case s   => s
+      } |
+      SV.NonEscapeCharacter
+    lazy val NonEscapeCharacter: S =
+      (Predef.EscapeCharacter | Predef.LineTerminator).not
+    lazy val HexEscapeSequence: S =
+      "x" ~> MV.HexDigit ~ MV.HexDigit ^^ {
+        case x ~ y => Character.toChars(16 * x.toInt + y.toInt).mkString
+      }
+    lazy val Hex4Digits: S =
+      MV.Hex4Digits ^^ { case x => Character.toChars(x.toInt).mkString }
+    lazy val UnicodeEscapeSequence: S =
+      "u" ~> SV.Hex4Digits |||
+      "u{" ~> MV.CodePoint <~ "}" ^^ { case n => cp2str(n) }
+    lazy val TemplateEscapeSequence: S =
+      SV.CharacterEscapeSequence |
+      "0" <~ not(Predef.DecimalDigit) ^^^ "\u0000" |
+      SV.HexEscapeSequence |
+      SV.UnicodeEscapeSequence
+
+    // convert a code point to a string
+    private def cp2str(cp: Math): String = cp2str(cp.toInt)
+
+    // convert a code point to a string
+    private def cp2str(cp: Int): String = Character.toChars(cp).mkString
+  }
+
+  // ---------------------------------------------------------------------------
+  // TV of |NoSubstitutionTemplate|, |TemplateHead|, |TemplateMiddle|, and
+  // |TemplateTail|
+  // (https://tc39.es/ecma262/#sec-static-semantics-tv)
+  // ---------------------------------------------------------------------------
+  object TV {
+    val of: Map[String, String => (Str | Undef)] = from("TV")(
+      "NoSubstitutionTemplate" -> NoSubstitutionTemplate,
+      "TemplateHead" -> TemplateHead,
+      "TemplateMiddle" -> TemplateMiddle,
+      "TemplateTail" -> TemplateTail,
+    ).map { case (x, p) => x -> ((s: String) => handleUndef(p(s))) }
+
+    case object ReturnUndef extends Throwable
+    lazy val NoSubstitutionTemplate: S =
+      "`" ~> TV.TemplateCharacters.opt <~ "`"
+    lazy val TemplateHead: S =
+      "`" ~> TV.TemplateCharacters.opt <~ "${"
+    lazy val TemplateMiddle: S =
+      "}" ~> TV.TemplateCharacters.opt <~ "${"
+    lazy val TemplateTail: S =
+      "}" ~> TV.TemplateCharacters.opt <~ "`"
+    lazy val TemplateCharacter: S =
+      "$" <~ not("{") |
+      "\\" ~> SV.TemplateEscapeSequence |
+      "\\" ~> Predef.NotEscapeSequence ^^^ { throw ReturnUndef } |
+      TV.LineContinuation |
+      TRV.LineTerminatorSequence |
+      ("`" | "\\" | "$" | Predef.LineTerminator).not
+    lazy val TemplateCharacters: S =
+      TV.TemplateCharacter.rep1
+    lazy val LineContinuation: S =
+      "\\" ~ Predef.LineTerminatorSequence ^^^ ""
+
+    private def handleUndef(str: => String): Str | Undef =
+      try Str(str)
+      catch case TV.ReturnUndef => Undef
+  }
+
+  // ---------------------------------------------------------------------------
+  // TRV of |NoSubstitutionTemplate|, |TemplateHead|, |TemplateMiddle|, and
+  // |TemplateTail|
+  // (https://tc39.es/ecma262/#sec-static-semantics-trv)
+  // ---------------------------------------------------------------------------
+  object TRV {
+    val of: Map[String, String => Str] = from("TRV")(
+      "NoSubstitutionTemplate" -> NoSubstitutionTemplate,
+      "TemplateHead" -> TemplateHead,
+      "TemplateMiddle" -> TemplateMiddle,
+      "TemplateTail" -> TemplateTail,
+    ).map { case (x, p) => x -> ((s: String) => Str(p(s))) }
+    lazy val NoSubstitutionTemplate: S =
+      "`" ~> TRV.TemplateCharacters.opt <~ "`"
+    lazy val TemplateHead: S =
+      "`" ~> TRV.TemplateCharacters.opt <~ "${"
+    lazy val TemplateMiddle: S =
+      "}" ~> TRV.TemplateCharacters.opt <~ "${"
+    lazy val TemplateTail: S =
+      "}" ~> TRV.TemplateCharacters.opt <~ "`"
+    lazy val TemplateCharacters: S = TRV.TemplateCharacter.rep1
+    lazy val TemplateCharacter: S =
+      "$" <~ not("{") |
+      "\\" % TRV.TemplateEscapeSequence |
+      "\\" % TRV.NotEscapeSequence |
+      TRV.LineContinuation |
+      TRV.LineTerminatorSequence |
+      ("`" | "\\" | "$" | Predef.LineTerminator).not
+    lazy val TemplateEscapeSequence: S =
+      TRV.CharacterEscapeSequence |
+      "0" ^^^ "\u0030" |
+      TRV.HexEscapeSequence |
+      TRV.UnicodeEscapeSequence
+    lazy val NotEscapeSequence: S =
+      "0" % TRV.DecimalDigit |
+      TRV.DecimalDigit.filter(_ != "0") |
+      "x" <~ not(HexDigit) |
+      "x" % TRV.HexDigit <~ not(Predef.HexDigit) |
+      "u" <~ not(Predef.HexDigit) <~ not("{") |
+      "u" % TRV.HexDigit <~ not(Predef.HexDigit) |
+      "u" % TRV.HexDigit % TRV.HexDigit <~ not(Predef.HexDigit) |
+      "u" % TRV.HexDigit % TRV.HexDigit % TRV.HexDigit <~ not(Predef.HexDigit) |
+      "u{" <~ not(Predef.HexDigit) |
+      "u{" % TRV.NotCodePoint <~ not(Predef.HexDigit) |
+      "u{" % TRV.CodePoint <~ not(Predef.HexDigit) <~ not("}")
+    lazy val DecimalDigit: S = "[0-9]".r
+    lazy val CharacterEscapeSequence: S =
+      SV.NonEscapeCharacter |
+      TRV.SingleEscapeCharacter
+    lazy val SingleEscapeCharacter: S = Predef.SingleEscapeCharacter
+    lazy val HexEscapeSequence: S = "x" % TRV.HexDigit % TRV.HexDigit
+    lazy val UnicodeEscapeSequence: S =
+      "u" % TRV.Hex4Digits |
+      "u{" % TRV.CodePoint <~ "}"
+    lazy val Hex4Digits: S =
+      TRV.HexDigit % TRV.HexDigit % TRV.HexDigit % TRV.HexDigit
+    lazy val HexDigit: S = Predef.HexDigit
+    lazy val LineContinuation: S = "\\" % LineTerminatorSequence
+    lazy val LineTerminatorSequence: S =
+      Predef.cr ^^^ "\u000a" |
+      Predef.cr ~> Predef.lf |
+      Predef.lf |
+      Predef.ls |
+      Predef.ps
+    lazy val CodePoint: S = Predef.CodePoint
+    lazy val NotCodePoint: S = Predef.NotCodePoint
+  }
+
+  private def from[T](sdoName: String)(
+    pair: (String, Parser[T])*,
+  ): Map[String, String => T] = (for {
+    (name, parser) <- pair
+  } yield name -> (s => get(s"$sdoName.$name", parser, s))).toMap
+
   private def get[T](name: String, rule: Parser[T], str: String): T =
     parseAll(rule, str) match {
       case Success(res, _) => res
       case f => throw ESValueParserFailed(name + "\n" + f.toString)
     }
+
   private def getOrElse[T](
     name: String,
     rule: Parser[T],
@@ -60,567 +454,7 @@ object ESValueParser extends UnicodeParsers with RegexParsers {
     case Success(res, _) => res
     case _               => default
   }
-  private def tv(str: => String): SimpleValue =
-    try { Str(str) }
-    catch { case TV.ReturnUndef => Undef }
 
-  // String Value
-  object SV {
-    lazy val IdentifierName: S = (
-      seq(
-        SV.IdentifierStart,
-        rep(SV.IdentifierPart) ^^ { case l => l.foldLeft("")(_ + _) },
-      ),
-    )
-    lazy val IdentifierStart: S = (
-      IDStart |||
-        "$" |||
-        "_" |||
-        "\\" ~> SV.UnicodeEscapeSequence
-    )
-    lazy val IdentifierPart: S = (
-      IDContinue |||
-        "$" |||
-        "\\" ~> SV.UnicodeEscapeSequence |||
-        Predef.ZWNJ |||
-        Predef.ZWJ
-    )
-    lazy val StringLiteral: S = (
-      // The SV of StringLiteral::"" is the empty code unit sequence.
-      "\"\"" ^^^ "" |||
-        // The SV of StringLiteral::'' is the empty code unit sequence.
-        "''" ^^^ "" |||
-        // The SV of StringLiteral::"DoubleStringCharacters" is the SV of DoubleStringCharacters.
-        "\"" ~> SV.DoubleStringCharacters <~ "\"" |||
-        // The SV of StringLiteral::'SingleStringCharacters' is the SV of SingleStringCharacters.
-        "'" ~> SV.SingleStringCharacters <~ "'"
-    )
-    lazy val DoubleStringCharacters: S = (
-      // The SV of DoubleStringCharacters::DoubleStringCharacter is a sequence of up to two code units that is the SV of DoubleStringCharacter.
-      SV.DoubleStringCharacter |||
-        // The SV of DoubleStringCharacters::DoubleStringCharacterDoubleStringCharacters is a sequence of up to two code units that is the SV of DoubleStringCharacter followed by the code units of the SV of DoubleStringCharacters in order.
-        seq(SV.DoubleStringCharacter, SV.DoubleStringCharacters)
-    )
-    lazy val SingleStringCharacters: S = (
-      // The SV of SingleStringCharacters::SingleStringCharacter is a sequence of up to two code units that is the SV of SingleStringCharacter.
-      SV.SingleStringCharacter |||
-        // The SV of SingleStringCharacters::SingleStringCharacterSingleStringCharacters is a sequence of up to two code units that is the SV of SingleStringCharacter followed by the code units of the SV of SingleStringCharacters in order.
-        seq(SV.SingleStringCharacter, SV.SingleStringCharacters)
-    )
-    lazy val DoubleStringCharacter: S = (
-      // The SV of DoubleStringCharacter::SourceCharacterbut not one of " or \ or LineTerminator is the UTF16Encoding of the code point value of SourceCharacter.
-      notChars("\"" | "\\" | Predef.LineTerminator) |||
-        // The SV of DoubleStringCharacter::<LS> is the code unit 0x2028 (LINE SEPARATOR).
-        Predef.LS |||
-        // The SV of DoubleStringCharacter::<PS> is the code unit 0x2029 (PARAGRAPH SEPARATOR)
-        Predef.PS |||
-        // The SV of DoubleStringCharacter::\EscapeSequence is the SV of the EscapeSequence.
-        "\\" ~> SV.EscapeSequence |||
-        // The SV of DoubleStringCharacter::LineContinuation is the empty code unit sequence.
-        Predef.LineContinuation ^^^ ""
-    )
-    lazy val SingleStringCharacter: S = (
-      // The SV of SingleStringCharacter::SourceCharacterbut not one of ' or \ or LineTerminator is the UTF16Encoding of the code point value of SourceCharacter.
-      notChars("'" | "\\" | Predef.LineTerminator) |||
-        // The SV of SingleStringCharacter::<LS> is the code unit 0x2028 (LINE SEPARATOR).
-        Predef.LS |||
-        // The SV of SingleStringCharacter::<PS> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
-        Predef.PS |||
-        // The SV of SingleStringCharacter::\EscapeSequence is the SV of the EscapeSequence.
-        "\\" ~> SV.EscapeSequence |||
-        // The SV of SingleStringCharacter::LineContinuation is the empty code unit sequence.
-        Predef.LineContinuation ^^^ ""
-    )
-    lazy val EscapeSequence: S = (
-      // The SV of EscapeSequence::CharacterEscapeSequence is the SV of the CharacterEscapeSequence.
-      SV.CharacterEscapeSequence |||
-        // The SV of EscapeSequence::0 is the code unit 0x0000 (NULL).
-        "0" ^^^ "\u0000" |||
-        // The SV of EscapeSequence::HexEscapeSequence is the SV of the HexEscapeSequence.
-        SV.HexEscapeSequence |||
-        // The SV of EscapeSequence::UnicodeEscapeSequence is the SV of the UnicodeEscapeSequence.
-        SV.UnicodeEscapeSequence
-    )
-    lazy val CharacterEscapeSequence: S = (
-      // The SV of CharacterEscapeSequence::SingleEscapeCharacter is the code unit whose value is determined by the SingleEscapeCharacter according to Table 34.
-      Predef.SingleEscapeCharacter ^^ {
-        case "b" => "\u0008"
-        case "t" => "\u0009"
-        case "n" => "\u000a"
-        case "v" => "\u000b"
-        case "f" => "\u000c"
-        case "r" => "\u000d"
-        case s   => s
-      } |||
-        // The SV of CharacterEscapeSequence::NonEscapeCharacter is the SV of the NonEscapeCharacter.
-        SV.NonEscapeCharacter
-    )
-    lazy val NonEscapeCharacter: S = (
-      // The SV of NonEscapeCharacter::SourceCharacterbut not one of EscapeCharacter or LineTerminator is the UTF16Encoding of the code point value of SourceCharacter.
-      notChars(Predef.EscapeCharacter | Predef.LineTerminator),
-    )
-    lazy val HexEscapeSequence: S = (
-      // The SV of HexEscapeSequence::xHexDigitHexDigit is the code unit whose value is (16 times the MV of the first HexDigit) plus the MV of the second HexDigit.
-      "x" ~> DoubleMV.HexDigit ~ DoubleMV.HexDigit ^^ {
-        case x ~ y => Character.toChars(16 * x.toInt + y.toInt).mkString
-      }
-    )
-    lazy val UnicodeEscapeSequence: S = (
-      // The SV of UnicodeEscapeSequence::uHex4Digits is the SV of Hex4Digits.
-      "u" ~> SV.Hex4Digits |||
-        // The SV of UnicodeEscapeSequence::u{CodePoint} is the UTF16Encoding of the MV of CodePoint(HexDigits).
-        "u{" ~> DoubleMV.CodePoint <~ "}" ^^ {
-          case n => Character.toChars(n.toInt).mkString
-        }
-    )
-    lazy val Hex4Digits: S = (
-      // The SV of Hex4Digits::HexDigitHexDigitHexDigitHexDigit is the code unit whose value is (0x1000 times the MV of the first HexDigit) plus (0x100 times the MV of the second HexDigit) plus (0x10 times the MV of the third HexDigit) plus the MV of the fourth HexDigit.
-      DoubleMV.HexDigit ~ DoubleMV.HexDigit ~ DoubleMV.HexDigit ~ DoubleMV.HexDigit ^^ {
-        case a ~ b ~ c ~ d =>
-          Character
-            .toChars(
-              a.toInt * 0x1000 +
-              b.toInt * 0x100 +
-              c.toInt * 0x10 +
-              d.toInt * 0x1,
-            )
-            .mkString
-      }
-    )
-  }
-
-  // Numeric Value
-  object NumericValue {
-    lazy val NumericLiteral: V = (
-      DoubleMV.DecimalLiteral ^^ { Number(_) } |||
-        NumericValue.DecimalBigIntegerLiteral |||
-        DoubleMV.NonDecimalIntegerLiteral ^^ { Number(_) } |||
-        BigIntMV.NonDecimalIntegerLiteral <~ Predef.BigIntLiteralSuffix ^^ {
-          BigIntV(_)
-        }
-    )
-
-    lazy val DecimalBigIntegerLiteral: V =
-      ("0" ||| Predef.NonZeroDigit ~ opt(Predef.DecimalDigits) ^^ {
-        case x ~ y => x + y.getOrElse("")
-      }) <~ Predef.BigIntLiteralSuffix ^^ { s => BigIntV(BigInt(s)) }
-  }
-
-  // Mathematical Value
-  object DoubleMV
-    extends MV[Double](0, 1, _.toDouble, _.toDouble, _ + _, _ * _, _ < _)
-  object BigIntMV
-    extends MV[BigInt](0, 1, BigInt(_), BigInt(_), _ + _, _ * _, _ < _)
-  case class MV[T](
-    zero: T,
-    one: T,
-    fromInt: Int => T,
-    fromString: String => T,
-    add: (T, T) => T,
-    mul: (T, T) => T,
-    lt: (T, T) => Boolean,
-  ) {
-    type D = Parser[T]
-    lazy val DecimalLiteral: D = Predef.DecimalLiteral ^^ fromString
-    lazy val NonDecimalIntegerLiteral: D = (
-      this.BinaryIntegerLiteral |||
-        this.OctalIntegerLiteral |||
-        this.HexIntegerLiteral
-    )
-    lazy val NonZeroDigit: D = Predef.NonZeroDigit ^^ fromString
-    lazy val DecimalDigits: D = Predef.DecimalDigits ^^ fromString
-    lazy val BinaryIntegerLiteral: D = ("0b" | "0B") ~> this.BinaryDigits
-    lazy val BinaryDigits: D = rep1("0" | "1") ^^ {
-      case list =>
-        list.foldLeft(zero) {
-          case (x, s) => add(mul(x, fromInt(2)), fromString(s))
-        }
-    }
-    lazy val OctalIntegerLiteral: D = ("0o" | "0O") ~> this.OctalDigits
-    lazy val OctalDigits: D = rep1("[0-7]".r) ^^ {
-      case list =>
-        list.foldLeft(zero) {
-          case (x, s) => add(mul(x, fromInt(8)), fromString(s))
-        }
-    }
-    lazy val HexIntegerLiteral: D = ("0x" | "0X") ~> this.HexDigits
-    lazy val HexDigits: D = rep1(HexDigit) ^^ {
-      case list =>
-        list.foldLeft(zero) {
-          case (x, y) => add(mul(x, fromInt(16)), y)
-        }
-    }
-    lazy val StringNumericLiteral: D = (
-      opt(Predef.StrWhiteSpace) ^^^ zero |||
-        opt(Predef.StrWhiteSpace) ~> this.StrNumericLiteral <~ opt(
-          Predef.StrWhiteSpace,
-        )
-    )
-    lazy val StrNumericLiteral: D = (
-      this.StrDecimalLiteral |||
-        this.NonDecimalIntegerLiteral
-    )
-    lazy val StrDecimalLiteral: D = Predef.StrDecimalLiteral ^^ fromString
-    lazy val StringNumericLiteralForBigInt: D = (
-      opt(Predef.StrWhiteSpace) ^^^ zero |||
-        opt(Predef.StrWhiteSpace) ~> this.StrNumericLiteralForBigInt <~ opt(
-          Predef.StrWhiteSpace,
-        )
-    )
-    lazy val StrNumericLiteralForBigInt: D = (
-      this.StrDecimalLiteralForBigInt |||
-        this.NonDecimalIntegerLiteral
-    )
-    lazy val StrDecimalLiteralForBigInt: D =
-      Predef.StrDecimalLiteralForBigInt ^^ fromString
-    lazy val CodePoint: D =
-      this.HexDigits.filter(d => !lt(fromInt(0x10ffff), d))
-    lazy val HexDigit: D = "[0-9a-fA-F]".r ^^ {
-      case s =>
-        val ch = s.head
-        fromInt({
-          if (ch.isUpper) ch - 'A' + 10
-          else if (ch.isLower) ch - 'a' + 10
-          else ch - '0'
-        })
-    }
-  }
-
-  // Template Value
-  object TV {
-    // handle NotEscapeSequence
-    case object ReturnUndef extends Throwable
-    lazy val NoSubstitutionTemplate: S = (
-      // The TV of NoSubstitutionTemplate::`` is the empty code unit sequence.
-      "``" ^^^ "" |||
-        // The TV of NoSubstitutionTemplate::`TemplateCharacters` is the TV of TemplateCharacters.
-        "`" ~> TV.TemplateCharacters <~ "`"
-    )
-    lazy val TemplateHead: S = (
-      // The TV of TemplateHead::`${ is the empty code unit sequence.
-      "`${" ^^^ "" |||
-        // The TV of TemplateHead::`TemplateCharacters${ is the TV of TemplateCharacters.
-        "`" ~> TV.TemplateCharacters <~ "${"
-    )
-    lazy val TemplateMiddle: S = (
-      // The TV of TemplateMiddle::}${ is the empty code unit sequence.
-      "}${" ^^^ "" |||
-        // The TV of TemplateMiddle::}TemplateCharacters${ is the TV of TemplateCharacters.
-        "}" ~> TV.TemplateCharacters <~ "${"
-    )
-    lazy val TemplateTail: S = (
-      // The TV of TemplateTail::}TemplateCharacters` is the TV of TemplateCharacters.
-      "}" ~> TV.TemplateCharacters <~ "`" |||
-        // The TV of TemplateTail::}` is the empty code unit sequence.
-        "}`" ^^^ ""
-    )
-    lazy val TemplateCharacter: S = (
-      // The TV of TemplateCharacter::SourceCharacterbut not one of ` or \ or $ or LineTerminator is the UTF16Encoding of the code point value of SourceCharacter.
-      notChars("`" | "\\" | "$" | Predef.LineTerminator) |||
-        // The TV of TemplateCharacter::$ is the code unit 0x0024 (DOLLAR SIGN).
-        "$" <~ not("{") |||
-        // The TV of TemplateCharacter::\EscapeSequence is the SV of EscapeSequence.
-        "\\" ~> SV.EscapeSequence |||
-        // The TV of TemplateCharacter::\NotEscapeSequence is undefined.
-        "\\" ~> Predef.NotEscapeSequence ^^^ {
-          throw ReturnUndef
-        } |||
-        // The TV of TemplateCharacter::LineContinuation is the TV of LineContinuation.
-        TV.LineContinuation |||
-        // The TV of TemplateCharacter::LineTerminatorSequence is the TRV of LineTerminatorSequence.
-        TRV.LineTerminatorSequence
-    )
-    lazy val TemplateCharacters: S = (
-      // The TV of TemplateCharacters::TemplateCharacter is the TV of TemplateCharacter.
-      TV.TemplateCharacter |||
-        // Otherwise, it is a sequence consisting of the code units of the TV of TemplateCharacter followed by the code units of the TV of TemplateCharacters.
-        seq(TemplateCharacter, TemplateCharacters)
-    )
-    lazy val LineContinuation: S = (
-      // The TV of LineContinuation::\LineTerminatorSequence is the empty code unit sequence.
-      "\\" ~ Predef.LineTerminatorSequence ^^^ ""
-    )
-  }
-
-  // Template Raw Value
-  object TRV {
-    lazy val CharacterEscapeSequence: S = (
-      // The TRV of CharacterEscapeSequence::NonEscapeCharacter is the SV of the NonEscapeCharacter.
-      SV.NonEscapeCharacter |||
-        // The TRV of CharacterEscapeSequence::SingleEscapeCharacter is the TRV of the SingleEscapeCharacter.
-        TRV.SingleEscapeCharacter
-    )
-    lazy val DecimalDigit: S = (
-      // The TRV of DecimalDigit::one of0123456789 is the SV of the SourceCharacter that is that single code point.
-      "[0-9]".r
-    )
-    lazy val EscapeSequence: S = (
-      // The TRV of EscapeSequence::CharacterEscapeSequence is the TRV of the CharacterEscapeSequence.
-      TRV.CharacterEscapeSequence |||
-        // The TRV of EscapeSequence::0 is the code unit 0x0030 (DIGIT ZERO).
-        "0" <~ not(Predef.DecimalDigit) |||
-        // The TRV of EscapeSequence::HexEscapeSequence is the TRV of the HexEscapeSequence.
-        TRV.HexEscapeSequence |||
-        // The TRV of EscapeSequence::UnicodeEscapeSequence is the TRV of the UnicodeEscapeSequence.
-        TRV.UnicodeEscapeSequence
-    )
-    lazy val Hex4Digits: S = (
-      // The TRV of Hex4Digits::HexDigitHexDigitHexDigitHexDigit is the sequence consisting of the TRV of the first HexDigit followed by the TRV of the second HexDigit followed by the TRV of the third HexDigit followed by the TRV of the fourth HexDigit.
-      seq(
-        TRV.HexDigit,
-        TRV.HexDigit,
-        TRV.HexDigit,
-        TRV.HexDigit,
-      ),
-    )
-    lazy val NotCodePoint: S = Predef.NotCodePoint
-    lazy val CodePoint: S = Predef.CodePoint
-    lazy val HexDigits: S = (
-      // The TRV of HexDigits::HexDigit is the TRV of HexDigit.
-      TRV.HexDigit |||
-        // The TRV of HexDigits::HexDigitsHexDigit is the sequence consisting of TRV of HexDigits followed by TRV of HexDigit.
-        seq(TRV.HexDigit, TRV.HexDigits)
-    )
-    lazy val HexEscapeSequence: S = (
-      // The TRV of HexEscapeSequence::xHexDigitHexDigit is the sequence consisting of the code unit 0x0078 (LATIN SMALL LETTER X) followed by TRV of the first HexDigit followed by the TRV of the second HexDigit.
-      seq(
-        "x",
-        TRV.HexDigit,
-        TRV.HexDigit,
-      ),
-    )
-    lazy val LineContinuation: S = (
-      // The TRV of LineContinuation::\LineTerminatorSequence is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of LineTerminatorSequence.
-      seq(
-        "\\",
-        LineTerminatorSequence,
-      ),
-    )
-    lazy val LineTerminatorSequence: S = (
-      // The TRV of LineTerminatorSequence::<CR> is the code unit 0x000A (LINE FEED).
-      Predef.CR ^^^ "\u000a" |||
-        // The TRV of LineTerminatorSequence::<CR><LF> is the sequence consisting of the code unit 0x000A (LINE FEED).
-        Predef.CR ~> Predef.LF |||
-        // The TRV of LineTerminatorSequence::<LF> is the code unit 0x000A (LINE FEED).
-        Predef.LF |||
-        // The TRV of LineTerminatorSequence::<LS> is the code unit 0x2028 (LINE SEPARATOR).
-        Predef.LS |||
-        // The TRV of LineTerminatorSequence::<PS> is the code unit 0x2029 (PARAGRAPH SEPARATOR).
-        Predef.PS
-    )
-    lazy val NoSubstitutionTemplate: S = (
-      // The TRV of NoSubstitutionTemplate::`TemplateCharacters` is the TRV of TemplateCharacters.
-      "`" ~> TRV.TemplateCharacters <~ "`" |||
-        // The TRV of NoSubstitutionTemplate::`` is the empty code unit sequence.
-        "``" ^^^ ""
-    )
-    lazy val NotEscapeSequence: S = (
-      // The TRV of NotEscapeSequence::0DecimalDigit is the sequence consisting of the code unit 0x0030 (DIGIT ZERO) followed by the code units of the TRV of DecimalDigit.
-      seq("0", TRV.DecimalDigit) |||
-        // The TRV of NotEscapeSequence::DecimalDigit not 0 is the code units of the TRV of DecimalDigit.
-        TRV.DecimalDigit.filter(_ != "0") |||
-        // The TRV of NotEscapeSequence::uHexDigitHexDigitHexDigit[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of the first HexDigit followed by the code units of the TRV of the second HexDigit followed by the code units of the TRV of the third HexDigit.
-        seq("u", TRV.HexDigit, TRV.HexDigit, TRV.HexDigit) <~ not(
-          Predef.HexDigit,
-        ) |||
-        // The TRV of NotEscapeSequence::uHexDigitHexDigit[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of the first HexDigit followed by the code units of the TRV of the second HexDigit.
-        seq("u", TRV.HexDigit, TRV.HexDigit) <~ not(Predef.HexDigit) |||
-        // The TRV of NotEscapeSequence::uHexDigit[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code units of the TRV of HexDigit.
-        seq("u", TRV.HexDigit) <~ not(Predef.HexDigit) |||
-        // The TRV of NotEscapeSequence::u[lookahead ∉ HexDigit][lookahead ≠ {] is the code unit 0x0075 (LATIN SMALL LETTER U).
-        "u" <~ not(Predef.HexDigit) <~ not("{") |||
-        // The TRV of NotEscapeSequence::u{CodePoint[lookahead ∉ HexDigit][lookahead ≠ }] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by the code units of the TRV of CodePoint.
-        seq("u{", TRV.CodePoint) <~ not(Predef.HexDigit) <~ not("}") |||
-        // The TRV of NotEscapeSequence::u{NotCodePoint[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by the code units of the TRV of NotCodePoint.
-        seq("u{", TRV.NotCodePoint) <~ not(Predef.HexDigit) |||
-        // The TRV of NotEscapeSequence::u{[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET).
-        "u{" <~ not(Predef.HexDigit) |||
-        // The TRV of NotEscapeSequence::xHexDigit[lookahead ∉ HexDigit] is the sequence consisting of the code unit 0x0078 (LATIN SMALL LETTER X) followed by the code units of the TRV of HexDigit.
-        seq("x", TRV.HexDigit) <~ not(HexDigit) |||
-        // The TRV of NotEscapeSequence::x[lookahead ∉ HexDigit] is the code unit 0x0078 (LATIN SMALL LETTER X).
-        "x" <~ not(HexDigit)
-    )
-    lazy val SingleEscapeCharacter: S = (
-      // The TRV of SingleEscapeCharacter::one of'"\bfnrtv is the SV of the SourceCharacter that is that single code point.
-      Predef.SingleEscapeCharacter
-    )
-    lazy val TemplateCharacter: S = (
-      // The TRV of TemplateCharacter::$ is the code unit 0x0024 (DOLLAR SIGN).
-      "$" <~ not("{") |||
-        // The TRV of TemplateCharacter::LineContinuation is the TRV of LineContinuation.
-        TRV.LineContinuation |||
-        // The TRV of TemplateCharacter::LineTerminatorSequence is the TRV of LineTerminatorSequence.
-        TRV.LineTerminatorSequence |||
-        // The TRV of TemplateCharacter::SourceCharacterbut not one of ` or \ or $ or LineTerminator is the UTF16Encoding of the code point value of SourceCharacter.
-        notChars("`" | "\\" | "$" | Predef.LineTerminator) |||
-        // The TRV of TemplateCharacter::\EscapeSequence is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of EscapeSequence.
-        seq("\\", TRV.EscapeSequence) |||
-        // The TRV of TemplateCharacter::\NotEscapeSequence is the sequence consisting of the code unit 0x005C (REVERSE SOLIDUS) followed by the code units of TRV of NotEscapeSequence.
-        seq("\\", TRV.NotEscapeSequence)
-    )
-    lazy val TemplateCharacters: S = (
-      // The TRV of TemplateCharacters::TemplateCharacter is the TRV of TemplateCharacter.
-      TRV.TemplateCharacter |||
-        // The TRV of TemplateCharacters::TemplateCharacterTemplateCharacters is a sequence consisting of the code units of the TRV of TemplateCharacter followed by the code units of the TRV of TemplateCharacters.
-        seq(TRV.TemplateCharacter, TRV.TemplateCharacters)
-    )
-    lazy val TemplateHead: S = (
-      // The TRV of TemplateHead::`${ is the empty code unit sequence.
-      "`${" ^^^ "" |||
-        // The TRV of TemplateHead::`TemplateCharacters${ is the TRV of TemplateCharacters.
-        "`" ~> TRV.TemplateCharacters <~ "${"
-    )
-    lazy val TemplateMiddle: S = (
-      // The TRV of TemplateMiddle::}${ is the empty code unit sequence.
-      "}${" ^^^ "" |||
-        // The TRV of TemplateMiddle::}TemplateCharacters${ is the TRV of TemplateCharacters.
-        "}" ~> TRV.TemplateCharacters <~ "${"
-    )
-    lazy val TemplateTail: S = (
-      // The TRV of TemplateTail::}TemplateCharacters` is the TRV of TemplateCharacters.
-      "}" ~> TRV.TemplateCharacters <~ "`" |||
-        // The TRV of TemplateTail::}` is the empty code unit sequence.
-        "}`" ^^^ ""
-    )
-    lazy val UnicodeEscapeSequence: S = (
-      // The TRV of UnicodeEscapeSequence::uHex4Digits is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by TRV of Hex4Digits.
-      seq("u", TRV.Hex4Digits) |||
-        // The TRV of UnicodeEscapeSequence::u{CodePoint} is the sequence consisting of the code unit 0x0075 (LATIN SMALL LETTER U) followed by the code unit 0x007B (LEFT CURLY BRACKET) followed by TRV of CodePoint followed by the code unit 0x007D (RIGHT CURLY BRACKET).
-        seq("u{", TRV.CodePoint, "}")
-    )
-    lazy val HexDigit: S = (
-      // The TRV of a HexDigit is the SV of the SourceCharacter that is that HexDigit.
-      Predef.HexDigit
-    )
-  }
-
-  // types
-  type S = Parser[String]
-  type V = Parser[SimpleValue]
-
-  // predefined parsers
-  object Predef {
-    lazy val SourceCharacter: S = "(?s).".r
-    lazy val ZWNJ: Parser[String] = "\u200C"
-    lazy val ZWJ: Parser[String] = "\u200D"
-    lazy val ZWNBSP: Parser[String] = "\uFEFF"
-    lazy val TAB: Parser[String] = "\u0009"
-    lazy val VT: Parser[String] = "\u000B"
-    lazy val FF: Parser[String] = "\u000C"
-    lazy val SP: Parser[String] = "\u0020"
-    lazy val NBSP: Parser[String] = "\u00A0"
-    lazy val USP: Parser[String] =
-      "[\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000]".r
-    lazy val LF: S = "\u000A"
-    lazy val CR: S = "\u000D"
-    lazy val LS: S = "\u2028"
-    lazy val PS: S = "\u2029"
-    lazy val WhiteSpace: Parser[String] =
-      TAB | VT | FF | SP | NBSP | ZWNBSP | USP
-    lazy val LineTerminator: S = LF | CR | LS | PS
-    lazy val LineTerminatorSequence: Parser[String] =
-      LF | CR <~ not(LF) | LS | PS | seq(CR, LF)
-    lazy val LineContinuation: S = "\\" ~> LineTerminatorSequence
-    lazy val SingleEscapeCharacter: S = """['"\\bfnrtv]""".r
-    lazy val EscapeCharacter: S = (
-      SingleEscapeCharacter |||
-        DecimalDigit |||
-        "x" |||
-        "u"
-    )
-    lazy val NotEscapeSequence: S = (
-      seq("0", DecimalDigit) |||
-        DecimalDigit.filter(_ != "0") |||
-        "x" <~ not(HexDigit) |||
-        seq("x", HexDigit <~ not(HexDigit)) |||
-        "u" <~ not(HexDigit | "{") |||
-        seq("u", HexDigit <~ not(HexDigit)) |||
-        seq("u", HexDigit, HexDigit <~ not(HexDigit)) |||
-        seq("u", HexDigit, HexDigit, HexDigit <~ not(HexDigit)) |||
-        "u{" <~ not(HexDigit) |||
-        seq("u{", NotCodePoint <~ not(HexDigit)) |||
-        seq("u{", CodePoint <~ not(HexDigit | "}"))
-    )
-    lazy val DecimalLiteral: S = (
-      seq(
-        DecimalIntegerLiteral,
-        ".",
-        sOpt(DecimalDigits),
-        sOpt(ExponentPart),
-      ) |||
-        seq(".", DecimalDigits, sOpt(ExponentPart)) |||
-        seq(DecimalIntegerLiteral, sOpt(ExponentPart))
-    )
-    lazy val StrDecimalLiteral: S = (
-      StrUnsignedDecimalLiteral |||
-        seq("+", StrUnsignedDecimalLiteral) |||
-        seq("-", StrUnsignedDecimalLiteral)
-    )
-    lazy val StrDecimalLiteralForBigInt: S = (
-      DecimalDigits |||
-        seq("+", DecimalDigits) |||
-        seq("-", DecimalDigits)
-    )
-    lazy val StrUnsignedDecimalLiteral: S = (
-      "Infinity" ^^^ "1e10000" |||
-        seq(DecimalDigits, ".", sOpt(DecimalDigits), sOpt(ExponentPart)) |||
-        seq(".", DecimalDigits, sOpt(ExponentPart)) |||
-        seq(DecimalDigits, sOpt(ExponentPart))
-    )
-    lazy val DecimalIntegerLiteral: S = (
-      "0" |||
-        seq(NonZeroDigit, sOpt(DecimalDigits))
-    )
-    lazy val DecimalDigits: S = (
-      DecimalDigit |||
-        seq(DecimalDigit, DecimalDigits)
-    )
-    lazy val DecimalDigit: S = "[0-9]".r
-    lazy val NonZeroDigit: S = "[1-9]".r
-    lazy val ExponentPart: S = (
-      seq(ExponentIndicator, SignedInteger),
-    )
-    lazy val ExponentIndicator: S = "[eE]".r
-    lazy val SignedInteger: S = (
-      DecimalDigits |||
-        seq("+", DecimalDigits) |||
-        seq("-", DecimalDigits)
-    )
-    lazy val StrWhiteSpace: S = (
-      seq(StrWhiteSpaceChar, sOpt(StrWhiteSpace)),
-    )
-    lazy val StrWhiteSpaceChar: S = (
-      WhiteSpace |||
-        LineTerminator
-    )
-    lazy val HexDigits: S = seq(HexDigit, sOpt(HexDigits))
-    lazy val HexDigit: S = "[0-9a-fA-F]".r
-    lazy val CodePoint: S = HexDigits.filter {
-      case s => parseAll(DoubleMV.HexDigits, s).get <= 0x10ffff
-    }
-    lazy val NotCodePoint: S = HexDigits.filter {
-      case s => parseAll(DoubleMV.HexDigits, s).get > 0x10ffff
-    }
-    lazy val BigIntLiteralSuffix: S = "n"
-  }
-
-  // sequences
-  def sOpt(s: => S): S = opt(s) ^^ {
-    case Some(s) => s
-    case None    => ""
-  }
-  def seq(x0: S, x1: => S): S = x0 ~ x1 ^^ { case x ~ y => x + y }
-  def seq(x0: S, x1: => S, x2: => S): S = x0 ~ x1 ~ x2 ^^ {
-    case x ~ y ~ z => x + y + z
-  }
-  def seq(x0: S, x1: => S, x2: => S, x3: => S): S = x0 ~ x1 ~ x2 ~ x3 ^^ {
-    case x ~ y ~ z ~ a => x + y + z + a
-  }
-
-  // filtering out source characters
-  def notChars(cond: S): S =
-    Predef.SourceCharacter.filter(s => parseAll(cond, s).isEmpty)
-
-  // not skip white spaces
-  override def skipWhitespace = false
+  private def isOctalString(s: String): Boolean =
+    s.startsWith("0") && s.forall(c => '0' <= c && c < '8')
 }

--- a/src/main/scala/esmeta/parser/Lexer.scala
+++ b/src/main/scala/esmeta/parser/Lexer.scala
@@ -33,11 +33,6 @@ trait Lexer extends UnicodeParsers {
     )
   }
 
-  // special code points
-  lazy val WhiteSpaceCPs = USP ++ Set(TAB, VT, FF, SP, NBSP, ZWNBSP)
-  lazy val LineTerminatorCPs = Set(LF, CR, LS, PS)
-  lazy val NoLineTerminatorCPs = WhiteSpaceCPs -- LineTerminatorCPs
-
   // special lexers
   lazy val WhiteSpace = toParser(WhiteSpaceCPs)
   lazy val LineTerminator = toParser(LineTerminatorCPs)
@@ -64,6 +59,10 @@ trait Lexer extends UnicodeParsers {
     argsSet = getArgs(prod.lhs.params, args)
     lexer = getLexer(prod, argsSet)
   } yield (name, argsBit) -> lexer).toMap
+
+  // get lexers
+  def getLexer(name: String, args: List[Boolean]): Lexer =
+    lexers(name, toBit(args))
 
   lazy val lexNames = lexers.keySet.map(_._1)
 

--- a/src/main/scala/esmeta/parser/UnicodeParsers.scala
+++ b/src/main/scala/esmeta/parser/UnicodeParsers.scala
@@ -16,7 +16,7 @@ trait UnicodeParsers extends BasicParsers with EPackratParsers {
   val VT = 0x000b
   val FF = 0x000c
   val ZWNBSP = 0xfeff
-  // TODO automatically extract category "Zs"
+  // TODO automatically extract category "Space_Separator (Zs)"
   val USP = Set(
     0x0020, 0x00a0, 0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005,
     0x2006, 0x2007, 0x2008, 0x2009, 0x200a, 0x202f, 0x205f, 0x3000,

--- a/src/main/scala/esmeta/parser/UnicodeParsers.scala
+++ b/src/main/scala/esmeta/parser/UnicodeParsers.scala
@@ -11,17 +11,15 @@ import scala.util.matching.Regex
 trait UnicodeParsers extends BasicParsers with EPackratParsers {
   val ZWNJ = 0x200c
   val ZWJ = 0x200d
-  val ZWNBSP = 0xfeff
   // white spaces
   val TAB = 0x0009
   val VT = 0x000b
   val FF = 0x000c
-  val SP = 0x0020
-  val NBSP = 0x00a0
+  val ZWNBSP = 0xfeff
   // TODO automatically extract category "Zs"
   val USP = Set(
-    0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007,
-    0x2008, 0x2009, 0x200a, 0x202f, 0x205f, 0x3000,
+    0x0020, 0x00a0, 0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005,
+    0x2006, 0x2007, 0x2008, 0x2009, 0x200a, 0x202f, 0x205f, 0x3000,
   )
   // line terminators
   val LF = 0x000a
@@ -33,6 +31,12 @@ trait UnicodeParsers extends BasicParsers with EPackratParsers {
   lazy val Any = "(?s).".r
   lazy val IDStart = toParser(Unicode.IDStart)
   lazy val IDContinue = toParser(Unicode.IDContinue)
+
+  // special code points
+  lazy val WhiteSpaceCPs = USP ++ Set(TAB, VT, FF, ZWNBSP)
+  lazy val LineTerminatorCPs = Set(LF, CR, LS, PS)
+  lazy val NoLineTerminatorCPs = WhiteSpaceCPs -- LineTerminatorCPs
+  lazy val StrWhiteSpaceCharCPs = WhiteSpaceCPs ++ LineTerminatorCPs
 
   protected inline def toCodePoint(s: String): Int = s.codePoints.toArray.head
 
@@ -46,12 +50,10 @@ trait UnicodeParsers extends BasicParsers with EPackratParsers {
   val abbrCPs: Map[String, Set[Int]] = Map(
     "ZWNJ" -> ZWNJ,
     "ZWJ" -> ZWJ,
-    "ZWNBSP" -> ZWNBSP,
     "TAB" -> TAB,
     "VT" -> VT,
     "FF" -> FF,
-    "SP" -> SP,
-    "NBSP" -> NBSP,
+    "ZWNBSP" -> ZWNBSP,
     "LF" -> LF,
     "CR" -> CR,
     "LS" -> LS,

--- a/src/main/scala/esmeta/state/Obj.scala
+++ b/src/main/scala/esmeta/state/Obj.scala
@@ -70,7 +70,7 @@ case class MapObj(
     } else
       (for {
         case (Str(s), _) <- props.toVector
-        d = ESValueParser.str2Number(s)
+        d = ESValueParser.str2number(s).double
         if toStringHelper(d) == s
         i = d.toLong // should handle unsigned integer
         if d == i

--- a/src/main/scala/esmeta/state/Value.scala
+++ b/src/main/scala/esmeta/state/Value.scala
@@ -122,7 +122,10 @@ object Math {
   inline def apply(n: Double): Math = Math(BigDecimal(n, UNLIMITED))
   inline def apply(n: scala.math.BigInt): Math = Math(BigDecimal(n, UNLIMITED))
   inline def apply(s: String): Math = Math(BigDecimal(s, UNLIMITED))
-  inline def fromHex(s: String): Math = apply(scala.math.BigInt(s, 16))
+  inline def from(s: String, b: Int): Math = apply(scala.math.BigInt(s, b))
+  inline def fromBinary(s: String): Math = from(s, 2)
+  inline def fromOctal(s: String): Math = from(s, 8)
+  inline def fromHex(s: String): Math = from(s, 16)
 
   extension (m: Math) {
     def +(n: Math): Math = Math(m.decimal + n.decimal)

--- a/src/main/scala/esmeta/ty/package.scala
+++ b/src/main/scala/esmeta/ty/package.scala
@@ -109,6 +109,7 @@ lazy val PosInfinityT: ValueTy = ValueTy(infinity = InfinityTy.Pos)
 def InfinityT(ps: Boolean*): ValueTy =
   if (ps.isEmpty) ValueTy.Bot
   else ValueTy(infinity = InfinityTy(ps.toSet))
+lazy val NumericT: ValueTy = NumberT || BigIntT
 lazy val NumberT: ValueTy = ValueTy(number = NumberTy.Top)
 lazy val NumberIntT: ValueTy = ValueTy(number = NumberTy.Int)
 def NumberT(ns: Number*): ValueTy =


### PR DESCRIPTION
We refactored `ESValueParser` to support the latest changes and fix minor bugs related to the return types of `NumericValue`.