### PR TITLE
Support `array-grouping` feature

### DIFF
--- a/src/main/resources/manuals/test262/supported-features.json
+++ b/src/main/resources/manuals/test262/supported-features.json
@@ -49,6 +49,7 @@
   "__proto__",
   "__setter__",
   "align-detached-buffer-semantics-with-web-reality",
+  "array-grouping",
   "arrow-function",
   "async-functions",
   "async-iteration",


### PR DESCRIPTION
We supported the [`array-grouping`](https://github.com/tc39/proposal-array-grouping) feature:
```yaml
- time: 3,016 ms [00:03]
- total: 28
  - not-supported (N): 2
    - metalanguage: 2
      - Let _cp_ be the code point whose numeric value is the numeric value of _first_.: 2
  - pass (P): 26
- pass-rate: P/P = 26/26 (100.00%)
```