### PR TITLE
Support `change-array-by-copy` feature

### DIFF
--- a/src/main/resources/manuals/test262/supported-features.json
+++ b/src/main/resources/manuals/test262/supported-features.json
@@ -55,6 +55,7 @@
   "async-functions",
   "async-iteration",
   "caller",
+  "change-array-by-copy",
   "class",
   "class-fields-private",
   "class-fields-private-in",

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -797,6 +797,7 @@ FieldDefinition[0,1].ClassFieldDefinitionEvaluation
 FieldDefinition[0,1].ComputedPropertyContains
 FieldDefinition[0,1].PrivateBoundIdentifiers
 FieldDefinition[0,1].PropName
+FindViaPredicate
 ForBinding[0,0].IsDestructuring
 ForBinding[1,0].IsDestructuring
 ForBodyEvaluation

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -5,12 +5,12 @@
     - numeric string: 17
     - syntactic: 195
   - extended productions for web: 29
-- algorithms: 2773 (88.42%)
-  - complete: 2452
-  - incomplete: 321
-- algorithm steps: 20530 (96.90%)
-  - complete: 19894
-  - incomplete: 636
+- algorithms: 2773 (88.46%)
+  - complete: 2453
+  - incomplete: 320
+- algorithm steps: 20530 (96.91%)
+  - complete: 19896
+  - incomplete: 634
 - types: 7330 (92.21%)
   - known: 6759
   - yet: 571

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -729,10 +729,26 @@ object Interpreter {
       case (Lt, Math(l), Math(r)) => Bool(l < r)
 
       // extended mathematical value operations
-      case (Lt, POS_INF, Math(r)) => Bool(false)
-      case (Lt, Math(r), POS_INF) => Bool(true)
-      case (Lt, NEG_INF, Math(r)) => Bool(true)
-      case (Lt, Math(r), NEG_INF) => Bool(false)
+      case (Add, POS_INF, Math(_))          => POS_INF
+      case (Add, Math(_), POS_INF)          => POS_INF
+      case (Add, NEG_INF, Math(_))          => NEG_INF
+      case (Add, Math(_), NEG_INF)          => NEG_INF
+      case (Sub, POS_INF, Math(_))          => POS_INF
+      case (Sub, Math(_), POS_INF)          => NEG_INF
+      case (Sub, NEG_INF, Math(_))          => NEG_INF
+      case (Sub, Math(_), NEG_INF)          => POS_INF
+      case (Mul, POS_INF, Math(r)) if r > 0 => POS_INF
+      case (Mul, POS_INF, Math(r)) if r < 0 => NEG_INF
+      case (Mul, Math(l), POS_INF) if l > 0 => POS_INF
+      case (Mul, Math(l), POS_INF) if l < 0 => NEG_INF
+      case (Mul, NEG_INF, Math(r)) if r > 0 => NEG_INF
+      case (Mul, NEG_INF, Math(r)) if r < 0 => POS_INF
+      case (Mul, Math(l), NEG_INF) if l > 0 => NEG_INF
+      case (Mul, Math(l), NEG_INF) if l < 0 => POS_INF
+      case (Lt, POS_INF, Math(_))           => Bool(false)
+      case (Lt, Math(_), POS_INF)           => Bool(true)
+      case (Lt, NEG_INF, Math(_))           => Bool(true)
+      case (Lt, Math(_), NEG_INF)           => Bool(false)
 
       // logical operations
       case (And, Bool(l), Bool(r)) => Bool(l && r)


### PR DESCRIPTION
We supported the [`change-array-by-copy`](https://github.com/tc39/proposal-change-array-by-copy) feature:
```yaml
- time: 7,100 ms [00:07]
- total: 118
  - not-supported (N): 45
    - feature: 33
      - TypedArray: 32
      - RegExp: 1
    - metalanguage: 12
      - Sort _items_ using an implementation-defined sequence of <emu-meta effects="user-code">calls to _SortCompare_</emu-meta>. If any such call returns an abrupt completion, stop before performing any further calls to _SortCompare_ and return that Completion Record.: 12
  - pass (P): 73
- pass-rate: P/P = 73/73 (100.00%)
```