### PR TITLE
Replace `EIsArrayIndex` with `__IS_ARRAY_INDEX__` aux function

### DIFF
--- a/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
+++ b/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
@@ -1,0 +1,25 @@
+def <AUX>:__IS_ARRAY_INDEX__(
+  P: Symbol | String
+): Boolean = {
+  if (= (typeof P) @String) {
+    call %0 = clo<CanonicalNumericIndexString>(P)
+    if (= %0 undefined) {
+      return false
+    } else {
+      // IsIntegralNumber AO will be removed in ES2025
+      call %1 = clo<IsIntegralNumber>(%0)
+      if %1 {
+        %2 = ([math] %0)
+        if (&& (|| (< 0 %2) (= 0 %2)) (< %2 (- (** 2 32) 1))) {
+          return true
+        } else {
+          return false
+        }
+      } else {
+        return false
+      }
+    }
+  } else {
+    return false
+  }
+}

--- a/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
+++ b/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
@@ -1,25 +1,11 @@
 def <AUX>:__IS_ARRAY_INDEX__(
-  P: Symbol | String
+  P: ESValue
 ): Boolean = {
   if (= (typeof P) @String) {
-    call %0 = clo<CanonicalNumericIndexString>(P)
-    if (= %0 undefined) {
-      return false
-    } else {
-      // IsIntegralNumber AO will be removed in ES2025
-      call %1 = clo<IsIntegralNumber>(%0)
-      if %1 {
-        %2 = ([math] %0)
-        if (&& (|| (< 0 %2) (= 0 %2)) (< %2 (- (** 2 32) 1))) {
-          return true
-        } else {
-          return false
-        }
-      } else {
-        return false
-      }
-    }
-  } else {
-    return false
-  }
+    call n = clo<CanonicalNumericIndexString>(P)
+    if (? n: "NumberInt") {
+      return (&& (< -1f n) (< n (- (** 2f 32f) 1f)))
+    } else {}
+  } else {}
+  return false
 }

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -2516,3 +2516,4 @@ YieldExpression[0,0].Evaluation
 YieldExpression[1,0].Evaluation
 YieldExpression[2,0].Evaluation
 __CLAMP__
+__IS_ARRAY_INDEX__

--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -543,10 +543,6 @@ trait AbsTransferDecl { self: Analyzer =>
             v <- transfer(expr)
             st <- get
           } yield v.duplicated(st)
-        case EIsArrayIndex(expr) =>
-          for {
-            v <- transfer(expr)
-          } yield v.isArrayIndex
         case EMath(n)              => AbsValue(Math(n))
         case EInfinity(pos)        => AbsValue(Infinity(pos))
         case ENumber(n) if n.isNaN => AbsValue(Double.NaN)

--- a/src/main/scala/esmeta/analyzer/domain/value/ValueBasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/ValueBasicDomain.scala
@@ -428,16 +428,6 @@ trait ValueBasicDomainDecl { self: Self =>
             else s,
           )
         case _ => Bot
-      def isArrayIndex: Elem = elem.getSingle match
-        case Zero => Bot
-        case One(Str(s)) =>
-          val d = ESValueParser.str2number(s).double
-          val ds = toStringHelper(d)
-          val UPPER = (1L << 32) - 1
-          val l = d.toLong
-          apply(ds == s && 0 <= l && d == l && l < UPPER)
-        case One(_) => apply(F)
-        case Many   => exploded("EIsArrayIndex")
 
       /** completion helpers */
       def wrapCompletion: Elem = wrapCompletion("normal")

--- a/src/main/scala/esmeta/analyzer/domain/value/ValueDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/ValueDomain.scala
@@ -153,7 +153,6 @@ trait ValueDomainDecl { self: Self =>
       def substring(from: Elem): Elem
       def substring(from: Elem, to: Elem): Elem
       def trim(leading: Boolean, trailing: Boolean): Elem
-      def isArrayIndex: Elem
 
       /** single check */
       def isSingle: Boolean = elem.getSingle match

--- a/src/main/scala/esmeta/analyzer/domain/value/ValueTypeDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/value/ValueTypeDomain.scala
@@ -385,7 +385,6 @@ trait ValueTypeDomainDecl { self: Self =>
             else IntTy
           else MathTopTy
         Elem(ValueTy(math = mathTy))
-      def isArrayIndex: Elem = boolTop
 
       /** completion helpers */
       def wrapCompletion: Elem =

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -836,7 +836,10 @@ class Compiler(
             val lv = toERef(fb, x, EStr("length"))
             is(lv, zero)
           case StrictMode => T // XXX assume strict mode
-          case ArrayIndex => EIsArrayIndex(x)
+          case ArrayIndex =>
+            val (b, bExpr) = fb.newTIdWithExpr
+            fb.addInst(ICall(b, AUX_IS_ARRAY_INDEX, List(x)))
+            bExpr
           case FalseToken => is(ESourceText(x), EStr("false"))
           case TrueToken  => is(ESourceText(x), EStr("true"))
           case DataProperty =>

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -428,15 +428,6 @@ class Interpreter(
     case EDuplicated(expr) =>
       val vs = eval(expr).getList(expr, st).values
       Bool(vs.toSet.size != vs.length)
-    case EIsArrayIndex(expr) =>
-      eval(expr) match
-        case Str(s) =>
-          val d = ESValueParser.str2number(s).double
-          val ds = toStringHelper(d)
-          val UPPER = (1L << 32) - 1
-          val l = d.toLong
-          Bool(ds == s && 0 <= l && d == l && l < UPPER)
-        case _ => Bool(false)
     case EMath(n)              => Math(n)
     case EInfinity(pos)        => Infinity(pos)
     case ENumber(n) if n.isNaN => Number(Double.NaN)

--- a/src/main/scala/esmeta/ir/Expr.scala
+++ b/src/main/scala/esmeta/ir/Expr.scala
@@ -27,7 +27,6 @@ case class EConvert(cop: COp, expr: Expr) extends Expr
 case class ETypeOf(base: Expr) extends Expr
 case class ETypeCheck(base: Expr, tyExpr: Expr) extends Expr
 case class EDuplicated(list: Expr) extends Expr
-case class EIsArrayIndex(expr: Expr) extends Expr
 case class EClo(fname: String, captured: List[Name]) extends Expr
 case class ECont(fname: String) extends Expr
 

--- a/src/main/scala/esmeta/ir/package.scala
+++ b/src/main/scala/esmeta/ir/package.scala
@@ -106,3 +106,4 @@ def PARAM_NEW_TARGET = Param(NAME_NEW_TARGET)
 /** predefined auxiliary functions */
 inline def getAux(name: String): EClo = EClo("__" + name + "__", Nil)
 def AUX_CLAMP = getAux("CLAMP")
+def AUX_IS_ARRAY_INDEX = getAux("IS_ARRAY_INDEX")

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -153,8 +153,6 @@ trait Parsers extends TyParsers {
       case e ~ t => ETypeCheck(e, t)
     } | "(" ~ "duplicated" ~> expr <~ ")" ^^ {
       case e => EDuplicated(e)
-    } | "(" ~ "array-index" ~> expr <~ ")" ^^ {
-      case e => EIsArrayIndex(e)
     } | "clo<" ~> fname ~ opt("," ~ "[" ~> repsep(name, ",") <~ "]") <~ ">" ^^ {
       case s ~ cs => EClo(s, cs.getOrElse(Nil))
     } | ("cont<" ~> fname <~ ">") ^^ {

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -168,8 +168,6 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "(? " >> expr >> ": " >> ty >> ")"
       case EDuplicated(expr) =>
         app >> "(duplicated " >> expr >> ")"
-      case EIsArrayIndex(expr) =>
-        app >> "(array-index " >> expr >> ")"
       case EClo(fname, captured) =>
         given Rule[Iterable[Name]] = iterableRule("[", ", ", "]")
         app >> "clo<" >> fname

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -103,8 +103,6 @@ trait UnitWalker extends BasicUnitWalker {
       walk(fname)
     case EDuplicated(expr) =>
       walk(expr)
-    case EIsArrayIndex(expr) =>
-      walk(expr)
     case EDebug(expr) =>
       walk(expr)
     case expr: ERandom     => walk(expr)

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -111,8 +111,6 @@ trait Walker extends BasicWalker {
       ECont(walk(fname))
     case EDuplicated(expr) =>
       EDuplicated(walk(expr))
-    case EIsArrayIndex(expr) =>
-      EIsArrayIndex(walk(expr))
     case EDebug(expr) =>
       EDebug(walk(expr))
     case expr: ERandom     => walk(expr)


### PR DESCRIPTION
`IsIntegralNumber` AO used in `__IS_ARRAY_INDEX__` will be removed in es2025. should we model that AO now?