### PR TITLE
Fixed MapObj to use LinkedHashMap as fields

### DIFF
--- a/src/main/scala/esmeta/analyzer/domain/obj/ObjBasicDomain.scala
+++ b/src/main/scala/esmeta/analyzer/domain/obj/ObjBasicDomain.scala
@@ -98,7 +98,7 @@ trait ObjBasicDomainDecl { self: Self =>
           tname = tname,
           map = (for {
             (k, fieldV) <- fields
-          } yield AValue.from(k) -> AbsValue(fieldV.value)).toMap,
+          } yield AValue.from(k) -> AbsValue(fieldV)).toMap,
           order = Some(m.keys.map(AValue.from)),
         )
       case ListObj(values)     => KeyWiseList(values.map(AbsValue(_)))

--- a/src/main/scala/esmeta/injector/Injector.scala
+++ b/src/main/scala/esmeta/injector/Injector.scala
@@ -234,7 +234,7 @@ class Injector(
             val2str(p).map(propStr => {
               for {
                 field <- fields
-                value <- props.get(Str(field)).map(_.value.toPureValue)
+                value <- props.get(Str(field)).map(_.toPureValue)
               } value match
                 case sv: SimpleValue =>
                   set += s"${field.toLowerCase}: ${sv2str(sv)}"

--- a/src/main/scala/esmeta/state/Heap.scala
+++ b/src/main/scala/esmeta/state/Heap.scala
@@ -7,7 +7,7 @@ import esmeta.error.NotSupported.Category.*
 import esmeta.ir.{Func => IRFunc, *}
 import esmeta.es.builtin.*
 import esmeta.util.BaseUtils.*
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map => MMap, LinkedHashMap => LMMap}
 
 /** IR heaps */
 case class Heap(
@@ -82,7 +82,7 @@ case class Heap(
     m: Map[PureValue, PureValue],
   )(using CFG): Addr = {
     val irMap =
-      if (tname == "Record") MapObj(tname, MMap(), 0) else MapObj(tname)
+      if (tname == "Record") MapObj(tname, LMMap(), 0) else MapObj(tname)
     for ((k, v) <- m) irMap.update(k, v)
     if (hasSubMap(tname))
       val subMap = MapObj("SubMap")

--- a/src/main/scala/esmeta/state/Obj.scala
+++ b/src/main/scala/esmeta/state/Obj.scala
@@ -57,8 +57,8 @@ case class MapObj(
   def keys: Vector[PureValue] = keys(intSorted = false)
   def keys(intSorted: Boolean): Vector[PureValue] = {
     if (!intSorted) {
-      if (ty == "SubMap") fields.toVector.map(_._1)
-      else fields.toVector.map(_._1).sortBy(_.toString)
+      if (ty == "SubMap") fields.keys.toVector
+      else fields.keys.toVector.sortBy(_.toString)
     } else
       (for {
         case (Str(s), _) <- fields.toVector

--- a/src/main/scala/esmeta/state/Obj.scala
+++ b/src/main/scala/esmeta/state/Obj.scala
@@ -4,7 +4,7 @@ import esmeta.cfg.*
 import esmeta.error.*
 import esmeta.ir.{Func => IRFunc, *}
 import esmeta.parser.ESValueParser
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{LinkedHashMap => LMMap}
 
 // Objects
 sealed trait Obj extends StateElem {
@@ -12,8 +12,7 @@ sealed trait Obj extends StateElem {
   /** getters */
   def apply(field: PureValue): Value = (this, field) match
     case (SymbolObj(desc), Str("Description")) => desc
-    case (MapObj(_, fields, _), field) =>
-      fields.get(field).fold[Value](Absent)(_.value)
+    case (MapObj(_, fields, _), field) => fields.getOrElse(field, Absent)
     case (ListObj(values), Math(decimal)) =>
       val idx = decimal.toInt
       if (0 <= idx && idx < values.length) values(idx)
@@ -23,7 +22,7 @@ sealed trait Obj extends StateElem {
 
   /** copy of object */
   def copied: Obj = this match
-    case MapObj(tname, fields, size) => MapObj(tname, MMap.from(fields), size)
+    case MapObj(tname, fields, size) => MapObj(tname, LMMap.from(fields), size)
     case ListObj(values)             => ListObj(Vector.from(values))
     case _                           => this
 }
@@ -31,7 +30,7 @@ sealed trait Obj extends StateElem {
 /** map objects */
 case class MapObj(
   var ty: String, // TODO handle type
-  val fields: MMap[PureValue, MapObj.Field],
+  val fields: LMMap[PureValue, Value],
   var size: Int,
 ) extends Obj {
 
@@ -43,11 +42,7 @@ case class MapObj(
 
   /** updates */
   def update(field: PureValue, value: Value): this.type =
-    val id = fields
-      .get(field)
-      .map(_.creationTime)
-      .getOrElse({ size += 1; size })
-    fields += field -> MapObj.Field(value, id)
+    fields += field -> value
     this
 
   /** deletes */
@@ -55,17 +50,14 @@ case class MapObj(
 
   /** pairs of map */
   def pairs: Map[PureValue, Value] = (fields.map {
-    case (k, (MapObj.Field(v, _))) => k -> v
+    case (k, v) => k -> v
   }).toMap
 
   /** keys of map */
   def keys: Vector[PureValue] = keys(intSorted = false)
   def keys(intSorted: Boolean): Vector[PureValue] = {
     if (!intSorted) {
-      if (ty == "SubMap")
-        fields.toVector
-          .sortBy(_._2._2)
-          .map(_._1)
+      if (ty == "SubMap") fields.toVector.map(_._1)
       else fields.toVector.map(_._1).sortBy(_.toString)
     } else
       (for {
@@ -79,14 +71,11 @@ case class MapObj(
 }
 object MapObj {
 
-  /** field values */
-  case class Field(value: Value, creationTime: Int)
-
   /** apply with type model */
   def apply(tname: String)(fields: (PureValue, Value)*)(using CFG): MapObj =
     val obj: MapObj = MapObj(tname)
     for { ((k, v), idx) <- fields.zipWithIndex }
-      obj.fields += k -> Field(v, idx + obj.size)
+      obj.fields += k -> v
     obj.size += fields.size
     obj
 
@@ -94,9 +83,9 @@ object MapObj {
     // TODO do not explicitly store methods in object but use a type model when
     // accessing methods
     val methods = cfg.tyModel.getMethod(tname)
-    val obj = MapObj(tname, MMap(), methods.size)
+    val obj = MapObj(tname, LMMap(), methods.size)
     for { ((name, fname), idx) <- methods.zipWithIndex }
-      obj.fields += Str(name) -> Field(Clo(cfg.fnameMap(fname), Map()), idx)
+      obj.fields += Str(name) -> Clo(cfg.fnameMap(fname), Map())
     obj
 }
 

--- a/src/main/scala/esmeta/state/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/state/util/UnitWalker.scala
@@ -45,7 +45,6 @@ trait UnitWalker extends BasicUnitWalker {
     case ListObj(values)      => walkIterable(values, walk)
     case SymbolObj(desc)      => walk(desc)
     case _: YetObj            =>
-  def walk(field: MapObj.Field): Unit = walk(field.value)
 
   // value
   def walk(v: Value): Unit = v match

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -121,12 +121,12 @@ case class ValueTy(
           case MapObj(tname, props, _) =>
             isSubTy(tname, name.set) ||
             (tname == "Record" && (props.forall {
-              case (Str(key), MapObj.Field(value, _)) =>
+              case (Str(key), value) =>
                 record(key).contains(value, heap)
               case _ => false
             })) ||
             (tname == "SubMap" && (props.forall {
-              case (key, MapObj.Field(value, _)) =>
+              case (key, value) =>
                 ValueTy(pureValue = subMap.key).contains(key, heap) &&
                 ValueTy(pureValue = subMap.value).contains(value, heap)
             }))

--- a/src/test/scala/esmeta/state/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/state/StringifyTinyTest.scala
@@ -4,7 +4,8 @@ import esmeta.cfg.*
 import esmeta.ir.{Func => IRFunc, FuncKind => IRFuncKind, *}
 import esmeta.es.*
 import esmeta.util.BaseUtils.*
-import scala.collection.mutable.{Map => MMap, ListBuffer}
+import scala.collection.mutable.{Map => MMap, LinkedHashMap => LMMap}
+import scala.collection.mutable.ListBuffer
 
 /** stringify test */
 class StringifyTinyTest extends StateTest {
@@ -88,9 +89,9 @@ class StringifyTinyTest extends StateTest {
     // -------------------------------------------------------------------------
     // Objects
     // -------------------------------------------------------------------------
-    lazy val map = MapObj("A", MMap(), 0)
+    lazy val map = MapObj("A", LMMap(), 0)
     lazy val singleMap =
-      MapObj("A", MMap(Str("p") -> MapObj.Field(Str("p"), 0)), 1)
+      MapObj("A", LMMap(Str("p") -> Str("p")), 1)
     lazy val list = ListObj(Vector(Math(42), Str("x")))
     lazy val symbol = SymbolObj(Str("description"))
     lazy val yet = YetObj("A", "message")

--- a/src/test/scala/esmeta/ty/ContainsTinyTest.scala
+++ b/src/test/scala/esmeta/ty/ContainsTinyTest.scala
@@ -3,7 +3,7 @@ package esmeta.ty
 import esmeta.cfg.*
 import esmeta.ir.{Func => IRFunc, FuncKind => IRFuncKind, *}
 import esmeta.state.*
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map => MMap, LinkedHashMap => LMMap}
 import esmeta.es.*
 
 /** contains test */
@@ -41,10 +41,10 @@ class ContainsTinyTest extends TyTest {
 
     // pre-defined heap
     lazy val mapAddr = NamedAddr("mapAddr")
-    lazy val mapObj = MapObj("A", MMap(), 0)
+    lazy val mapObj = MapObj("A", LMMap(), 0)
     lazy val recordAddr = NamedAddr("recordAddr")
     lazy val recordObj =
-      MapObj("Record", MMap(Str("P") -> MapObj.Field(Number(42), 0)), 1)
+      MapObj("Record", LMMap(Str("P") -> Number(42)), 1)
     lazy val nilAddr = NamedAddr("nilAddr")
     lazy val nilObj = ListObj(Vector())
     lazy val listAddr = NamedAddr("listAddr")
@@ -53,7 +53,7 @@ class ContainsTinyTest extends TyTest {
     lazy val symbolObj = SymbolObj(Str("desc"))
     lazy val subMapAddr = NamedAddr("subMapAddr")
     lazy val subMapObj =
-      MapObj("SubMap", MMap(symbolAddr -> MapObj.Field(Number(42), 0)), 1)
+      MapObj("SubMap", LMMap(symbolAddr -> Number(42)), 1)
     given Heap = Heap(
       MMap(
         mapAddr -> mapObj,


### PR DESCRIPTION
This PR includes:
- Fix on `MapObj` to use `LinkedHashMap` as `fields`
  - from: `MMap[PureValue, MapObj.Field]` with `Field(value: Value, creationTime: Int)`
  - to: `LMMap[PureValue, Value]`, where `LMMap` is `mutable.LinkedHashMap`

Passed Test262 tests