### PR TITLE
Use fixed number of threads in test262-test concurrent mode

### DIFF
--- a/src/main/scala/esmeta/cfg/CFG.scala
+++ b/src/main/scala/esmeta/cfg/CFG.scala
@@ -7,6 +7,7 @@ import esmeta.parser.{ESParser, AstFrom}
 import esmeta.spec.{Spec, Grammar}
 import esmeta.ty.TyModel
 import esmeta.util.BaseUtils.*
+import esmeta.util.{ConcurrentPolicy => CP}
 import esmeta.util.ProgressBar
 import esmeta.util.SystemUtils.*
 
@@ -79,7 +80,7 @@ case class CFG(
       iterable = funcs,
       getName = (x, _) => x.name,
       detail = false,
-      concurrent = true,
+      concurrent = CP.Auto,
     )
     for (func <- progress)
       val path = s"$baseDir/${func.normalizedName}"

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -93,9 +93,10 @@ case object Test262Test extends Phase[CFG, Summary] {
     (
       "concurrent",
       NumOption((c, k) =>
-        c.concurrent = if (k <= 1) then CP.Single else CP.Fixed(k),
+        c.concurrent =
+          if (k <= 0) then CP.Auto else if (k == 1) CP.Single else CP.Fixed(k),
       ),
-      "set the number of thread to use concurrently (default: no concurrent mode).",
+      "set the number of thread to use concurrently (default: no concurrent mode). If number <= 0, use automatically determined number of threads.",
     ),
     (
       "verbose",

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -7,6 +7,7 @@ import esmeta.interpreter.*
 import esmeta.state.*
 import esmeta.util.*
 import esmeta.util.BaseUtils.*
+import esmeta.util.{ConcurrentPolicy => CP}
 import esmeta.util.SystemUtils.*
 import esmeta.es.*
 import esmeta.es.util.Coverage
@@ -91,8 +92,10 @@ case object Test262Test extends Phase[CFG, Summary] {
     ),
     (
       "concurrent",
-      BoolOption(c => c.concurrent = true),
-      "turn on concurrent mode.",
+      NumOption((c, k) =>
+        c.concurrent = if (k <= 1) then CP.Single else CP.Fixed(k),
+      ),
+      "set the number of thread to use concurrently (default: no concurrent mode).",
     ),
     (
       "verbose",
@@ -107,7 +110,7 @@ case object Test262Test extends Phase[CFG, Summary] {
     var timeLimit: Option[Int] = None,
     var withYet: Boolean = false,
     var log: Boolean = false,
-    var concurrent: Boolean = false,
+    var concurrent: CP = CP.Single,
     var features: Option[List[String]] = None,
     var verbose: Boolean = false,
   )

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -96,7 +96,8 @@ case object Test262Test extends Phase[CFG, Summary] {
         c.concurrent =
           if (k <= 0) then CP.Auto else if (k == 1) CP.Single else CP.Fixed(k),
       ),
-      "set the number of thread to use concurrently (default: no concurrent mode). If number <= 0, use automatically determined number of threads.",
+      "set the number of thread to use concurrently (default: no concurrent)." +
+      " If number <= 0, use automatically determined number of threads.",
     ),
     (
       "verbose",

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -1,6 +1,6 @@
 package esmeta.phase
 
-import esmeta.*
+import esmeta.{CommandConfig, TEST_MODE}
 import esmeta.cfg.CFG
 import esmeta.error.*
 import esmeta.interpreter.*
@@ -34,6 +34,13 @@ case object Test262Test extends Phase[CFG, Summary] {
     val targets =
       if (cmdConfig.targets.isEmpty) None
       else Some(cmdConfig.targets)
+
+    if (config.timeLimit.isDefined && config.concurrent == CP.Auto)
+      error(
+        "Turing on both time limit option (-test262-test:timeout and " +
+        "the concurrent mode (-test262-test:concurrent) with " +
+        "automatic thread number is not allowed.",
+      )
 
     // run test262 eval test
     val summary = test262.evalTest(

--- a/src/main/scala/esmeta/test262/Test262.scala
+++ b/src/main/scala/esmeta/test262/Test262.scala
@@ -12,6 +12,7 @@ import esmeta.state.*
 import esmeta.test262.util.*
 import esmeta.util.*
 import esmeta.util.BaseUtils.*
+import esmeta.util.{ConcurrentPolicy => CP}
 import esmeta.util.SystemUtils.*
 import java.util.concurrent.TimeoutException
 
@@ -72,7 +73,7 @@ case class Test262(
     removed: Iterable[(Test, ReasonPath)] = Nil,
     useProgress: Boolean = false,
     useErrorHandler: Boolean = true,
-    concurrent: Boolean = false,
+    concurrent: CP = CP.Single,
     verbose: Boolean = false,
   ): ProgressBar[Test] = ProgressBar(
     msg = s"Run Test262 $name tests",
@@ -102,7 +103,7 @@ case class Test262(
     useProgress: Boolean = false,
     useCoverage: Boolean = false,
     timeLimit: Option[Int] = None, // default: no limit
-    concurrent: Boolean = false,
+    concurrent: CP = CP.Single,
     verbose: Boolean = false,
   ): Summary = {
     // extract tests from paths
@@ -161,7 +162,7 @@ case class Test262(
     log: Boolean = false,
     useProgress: Boolean = false,
     timeLimit: Option[Int] = None, // default: no limit
-    concurrent: Boolean = false,
+    concurrent: CP = CP.Single,
     verbose: Boolean = false,
   ): Summary = {
     // extract tests from paths

--- a/src/main/scala/esmeta/util/BaseUtils.scala
+++ b/src/main/scala/esmeta/util/BaseUtils.scala
@@ -82,10 +82,7 @@ object BaseUtils {
   /** get caught error message */
   def getError[T](f: => T): Option[Throwable] =
     try { f; None }
-    catch {
-      case e: ExecutionException => Some(e.getCause())
-      case e: Throwable          => Some(e)
-    }
+    catch case e: Throwable => Some(e)
 
   /** get indentation */
   def getIndent(str: String): Int =

--- a/src/main/scala/esmeta/util/BaseUtils.scala
+++ b/src/main/scala/esmeta/util/BaseUtils.scala
@@ -7,6 +7,7 @@ import esmeta.*
 import esmeta.error.*
 import scala.Console.*
 import scala.collection.mutable
+import scala.concurrent.ExecutionException
 import scala.util.Random
 
 /** base utilities */
@@ -81,7 +82,10 @@ object BaseUtils {
   /** get caught error message */
   def getError[T](f: => T): Option[Throwable] =
     try { f; None }
-    catch { case e: Throwable => Some(e) }
+    catch {
+      case e: ExecutionException => Some(e.getCause())
+      case e: Throwable          => Some(e)
+    }
 
   /** get indentation */
   def getIndent(str: String): Int =

--- a/src/main/scala/esmeta/util/ConcurrentPolicy.scala
+++ b/src/main/scala/esmeta/util/ConcurrentPolicy.scala
@@ -1,0 +1,6 @@
+package esmeta.util
+
+enum ConcurrentPolicy:
+  case Single
+  case Fixed(nThread: Int)
+  case Auto

--- a/src/main/scala/esmeta/util/ProgressBar.scala
+++ b/src/main/scala/esmeta/util/ProgressBar.scala
@@ -92,9 +92,12 @@ case class ProgressBar[T](
       gcount.incrementAndGet
 
     concurrent match
-      case CP.Single   => tests.foreach(_.apply)
-      case CP.Fixed(n) => doConcurrent(tests)(using fixedThread(n))
-      case CP.Auto     => doConcurrent(tests)
+      case CP.Single => tests.foreach(_.apply)
+      case CP.Fixed(n) =>
+        val (service, eCtxt) = fixedThread(n)
+        doConcurrent(tests)(using eCtxt)
+        service.shutdown()
+      case CP.Auto => doConcurrent(tests)
 
     updateTime
 

--- a/src/main/scala/esmeta/util/ProgressBar.scala
+++ b/src/main/scala/esmeta/util/ProgressBar.scala
@@ -95,8 +95,11 @@ case class ProgressBar[T](
       case CP.Single => tests.foreach(_.apply)
       case CP.Fixed(n) =>
         val (service, eCtxt) = fixedThread(n)
-        doConcurrent(tests)(using eCtxt)
-        service.shutdown()
+        try {
+          doConcurrent(tests)(using eCtxt)
+        } finally {
+          service.shutdown()
+        }
       case CP.Auto => doConcurrent(tests)
 
     updateTime

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -203,18 +203,13 @@ object SystemUtils {
     Await.result(Future(Try(f)), duration).get
 
   /** concurrently execute a list of functions */
-  def concurrent[T](
-    fs: Iterable[() => T],
-    duration: Duration = Duration.Inf,
-  )(using ctxt: ExecutionContext = ExecutionContext.global): Iterable[T] =
-    implicit val context: ExecutionContext = ctxt
-    Await
-      .result(
-        Future.sequence(fs.map(f => Future(Try(f())))),
-        duration,
-      )
-      .map(_.get)
+  def concurrent[T](fs: Iterable[() => T], duration: Duration = Duration.Inf)(
+    using ctxt: ExecutionContext = ExecutionContext.global,
+  ): Iterable[T] = Await
+    .result(Future.sequence(fs.map(f => Future(Try(f())))), duration)
+    .map(_.get)
 
+  /** use fixed thread pool */
   def fixedThread(nThread: Int): (ExecutorService, ExecutionContext) =
     val service = Executors.newFixedThreadPool(nThread)
     (service, ExecutionContext.fromExecutor(service))

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -207,12 +207,10 @@ object SystemUtils {
     fs: Iterable[() => T],
     duration: Duration = Duration.Inf,
   )(using ctxt: ExecutionContext = ExecutionContext.global): Iterable[T] =
+    implicit val context: ExecutionContext = ctxt
     Await
       .result(
-        {
-          implicit val context: ExecutionContext = ctxt
-          Future.sequence(fs.map(f => Future(Try(f()))))
-        },
+        Future.sequence(fs.map(f => Future(Try(f())))),
         duration,
       )
       .map(_.get)

--- a/src/test/scala/esmeta/test262/EvalLargeTest.scala
+++ b/src/test/scala/esmeta/test262/EvalLargeTest.scala
@@ -1,12 +1,14 @@
 package esmeta.test262
 
+import esmeta.util.{ConcurrentPolicy => CP}
+
 class EvalLargeTest extends Test262Test {
   val name: String = "test262EvalTest"
 
   // registration
   def init: Unit = check(name) {
     val summary = Test262Test.test262.evalTest(
-      concurrent = true,
+      concurrent = CP.Auto,
       verbose = true,
     )
     val f = summary.failCount

--- a/src/test/scala/esmeta/test262/ParseLargeTest.scala
+++ b/src/test/scala/esmeta/test262/ParseLargeTest.scala
@@ -1,12 +1,14 @@
 package esmeta.test262
 
+import esmeta.util.{ConcurrentPolicy => CP}
+
 class ParseLargeTest extends Test262Test {
   val name: String = "test262ParseTest"
 
   // registration
   def init: Unit = check(name) {
     val summary = Test262Test.test262.parseTest(
-      concurrent = true,
+      concurrent = CP.Auto,
       verbose = true,
     )
     val f = summary.failCount


### PR DESCRIPTION
This PR makes following changes:

* Change `-test262-test:concurrent` option to be `number`.
* Use fixed number of threads in `test262-test` concurrent mode.

It is expected to resolve issue #251 (if proper number of threads is given).