### PR TITLE
Make `EClo` capture expressions rather than names 

### DIFF
--- a/src/main/scala/esmeta/analyzer/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/AbsTransfer.scala
@@ -412,9 +412,13 @@ trait AbsTransferDecl { self: Analyzer =>
           cfg.fnameMap.get(fname) match {
             case Some(f) =>
               for {
-                st <- get
-                captured = cap.map(x => x -> st.lookupLocal(x)).toMap
-              } yield AbsValue(AClo(f, captured))
+                captured <- join(cap.map {
+                  case (x, e) =>
+                    for {
+                      v <- transfer(e)
+                    } yield (x, v)
+                })
+              } yield AbsValue(AClo(f, captured.toMap))
             case None =>
               for { _ <- put(AbsState.Bot) } yield AbsValue.Bot
           }

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -676,7 +676,10 @@ class Compiler(
           body = body,
           prefix = prefix,
         )
-        EClo(cn, captured.map(compile))
+        EClo(
+          cn,
+          captured.map(x => { val n = compile(x); (n, ERef(n)) }),
+        )
       case XRefExpression(XRefExpressionOperator.Algo, id) =>
         EClo(spec.getAlgoById(id).head.fname, Nil)
       case XRefExpression(XRefExpressionOperator.ParamLength, id) =>

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -345,7 +345,7 @@ class Interpreter(
       )
     case EClo(fname, captured) =>
       val func = cfg.fnameMap.getOrElse(fname, throw UnknownFunc(fname))
-      Clo(func, Map.from(captured.map(x => x -> st(x))))
+      Clo(func, Map.from(captured.map { (x, e) => x -> eval(e) }))
     case ECont(fname) =>
       val func = cfg.fnameMap.getOrElse(fname, throw UnknownFunc(fname))
       val captured = st.context.locals.collect { case (x: Name, v) => x -> v }

--- a/src/main/scala/esmeta/ir/Expr.scala
+++ b/src/main/scala/esmeta/ir/Expr.scala
@@ -27,7 +27,7 @@ case class EMathOp(mop: MOp, args: List[Expr]) extends Expr
 case class EConvert(cop: COp, expr: Expr) extends Expr
 case class ETypeOf(base: Expr) extends Expr
 case class ETypeCheck(base: Expr, tyExpr: Expr) extends Expr
-case class EClo(fname: String, captured: List[Name]) extends Expr
+case class EClo(fname: String, captured: List[(Name, Expr)]) extends Expr
 case class ECont(fname: String) extends Expr
 
 // debugging expressions

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -148,8 +148,16 @@ trait Parsers extends TyParsers {
       case e => ETypeOf(e)
     } | "(" ~ "?" ~> expr ~ (":" ~> expr) <~ ")" ^^ {
       case e ~ t => ETypeCheck(e, t)
-    } | "clo<" ~> fname ~ opt("," ~ "[" ~> repsep(name, ",") <~ "]") <~ ">" ^^ {
-      case s ~ cs => EClo(s, cs.getOrElse(Nil))
+    } | "clo<" ~> fname ~ opt(
+      "," ~ "[" ~> repsep(name ~ opt("=" ~> expr), ",") <~ "]",
+    ) <~ ">" ^^ {
+      case s ~ cs =>
+        EClo(
+          s,
+          cs.map(lst =>
+            lst.map { case x ~ eopt => x -> eopt.getOrElse(ERef(x)) },
+          ).getOrElse(Nil),
+        )
     } | ("cont<" ~> fname <~ ">") ^^ {
       case s => ECont(s)
     } | "(" ~ "debug" ~> expr <~ ")" ^^ {

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -149,7 +149,7 @@ trait Parsers extends TyParsers {
     } | "(" ~ "?" ~> expr ~ (":" ~> expr) <~ ")" ^^ {
       case e ~ t => ETypeCheck(e, t)
     } | "clo<" ~> fname ~ opt(
-      "," ~ "[" ~> repsep(name ~ opt("=" ~> expr), ",") <~ "]",
+      "," ~ "{" ~> repsep(name ~ opt(":" ~> expr), ",") <~ "}",
     ) <~ ">" ^^ {
       case s ~ cs =>
         EClo(

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -164,13 +164,15 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case ETypeCheck(expr, ty) =>
         app >> "(? " >> expr >> ": " >> ty >> ")"
       case EClo(fname, captured) =>
-        given Rule[Iterable[Name]] = iterableRule("[", ", ", "]")
+        given Rule[Iterable[(Name, Expr)]] = iterableRule("{", ", ", "}")
+        given Rule[(Name, Expr)] = {
+          case (app, (name, expr)) =>
+            expr match
+              case ERef(`name`) => app >> name
+              case _            => app >> name >> " : " >> expr
+        }
         app >> "clo<" >> fname
-        if (!captured.isEmpty) then
-          app >> ", "
-          app.wrap("[", "]")(for {
-            (name, expr) <- captured
-          } app >> name >> " = " >> expr >> ",")
+        if (!captured.isEmpty) then app >> ", " >> captured
         app >> ">"
       case ECont(fname) =>
         app >> "cont<" >> fname >> ">"

--- a/src/main/scala/esmeta/ir/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ir/util/Stringifier.scala
@@ -166,7 +166,11 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case EClo(fname, captured) =>
         given Rule[Iterable[Name]] = iterableRule("[", ", ", "]")
         app >> "clo<" >> fname
-        if (!captured.isEmpty) app >> ", " >> captured
+        if (!captured.isEmpty) then
+          app >> ", "
+          app.wrap("[", "]")(for {
+            (name, expr) <- captured
+          } app >> name >> " = " >> expr >> ",")
         app >> ">"
       case ECont(fname) =>
         app >> "cont<" >> fname >> ">"

--- a/src/main/scala/esmeta/ir/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ir/util/UnitWalker.scala
@@ -97,7 +97,7 @@ trait UnitWalker extends BasicUnitWalker {
     case ETypeCheck(expr, ty) =>
       walk(expr); walk(ty)
     case EClo(fname, captured) =>
-      walk(fname); walkList(captured, walk)
+      walk(fname); walkList(captured, { case (n, e) => (walk(n), walk(e)) })
     case ECont(fname) =>
       walk(fname)
     case EDebug(expr) =>

--- a/src/main/scala/esmeta/ir/util/Walker.scala
+++ b/src/main/scala/esmeta/ir/util/Walker.scala
@@ -105,7 +105,10 @@ trait Walker extends BasicWalker {
     case ETypeCheck(expr, ty) =>
       ETypeCheck(walk(expr), walk(ty))
     case EClo(fname, captured) =>
-      EClo(walk(fname), walkList(captured, walk))
+      EClo(
+        walk(fname),
+        walkList(captured, { case (n, e) => (walk(n), walk(e)) }),
+      )
     case ECont(fname) =>
       ECont(walk(fname))
     case EDebug(expr) =>

--- a/src/test/scala/esmeta/ir/IRTest.scala
+++ b/src/test/scala/esmeta/ir/IRTest.scala
@@ -123,7 +123,9 @@ object IRTest {
   lazy val normal = EEnum("normal")
   lazy val empty = EEnum("empty")
   lazy val clo = EClo("f", Nil)
-  lazy val cloWithCaptured = EClo("f", List(x))
+  lazy val cloWithCaptured = EClo("f", List((x -> ERef(x))))
+  lazy val cloWithCapturedComplex =
+    EClo("f", List((x -> EBinary(BOp.Add, ERef(y), EMath(1)))))
   lazy val cont = ECont("g")
 
   // references

--- a/src/test/scala/esmeta/ir/JsonTinyTest.scala
+++ b/src/test/scala/esmeta/ir/JsonTinyTest.scala
@@ -178,7 +178,8 @@ class JsonTinyTest extends IRTest {
       normal -> "~normal~",
       empty -> "~empty~",
       clo -> "clo<f>",
-      cloWithCaptured -> "clo<f, [x]>",
+      cloWithCaptured -> "clo<f, {x}>",
+      cloWithCapturedComplex -> "clo<f, {x : (+ y 1)}>",
       cont -> "cont<g>",
     )
 

--- a/src/test/scala/esmeta/ir/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/ir/StringifyTinyTest.scala
@@ -191,7 +191,8 @@ class StringifyTinyTest extends IRTest {
       normal -> "~normal~",
       empty -> "~empty~",
       clo -> "clo<f>",
-      cloWithCaptured -> "clo<f, [x]>",
+      cloWithCaptured -> "clo<f, {x}>",
+      cloWithCapturedComplex -> "clo<f, {x : (+ y 1)}>",
       cont -> "cont<g>",
     )
 

--- a/tests/ir/expr/binary-equal.ir
+++ b/tests/ir/expr/binary-equal.ir
@@ -21,11 +21,11 @@ def h() = { }
   assert (= clo<g> clo<g>)
   assert (! (= clo<g> clo<h>)) // because different fids
   let a = 0
-  let clo1 = clo<g, [a]>
-  let clo2 = clo<g, [a]>
+  let clo1 = clo<g, {a}>
+  let clo2 = clo<g, {a}>
   assert (= clo1 clo2)
   a = 1
-  let clo3 = clo<g, [a]>
+  let clo3 = clo<g, {a}>
   assert (! (= clo1 clo3)) // becuase `a` points to 0 in clo1 but 1 in clo3
   // continuations
   assert (= cont<g> cont<g>)


### PR DESCRIPTION
This PR allows `EClo` to capture all kinds of expressions, and make it use more Record-like syntax.

```diff
- let x = y + 1
- let f = clo<A, [x]>
+ let f = clo<A, {x : (+ y 1)}>
```

It also allows simpler syntax for `name`-> `ERef(name)`:
```
let f = clo<A, {x}> // Same with clo<A, {x : x}>
```

## Test
sbt test : PASS
test262-test : P/P = 25,276/25,276 (100.00%) [07:56] (on lambda2)