### PR TITLE
Set `-Xss4m` JVM option for executable

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
 -Xms1g
 -Xmx3g
--Xss1g
+-Xss4m
 -XX:ReservedCodeCacheSize=512m
 -Dfile.encoding=utf8

--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,7 @@ lazy val assemblyJavaOpts = Seq(
   "-Xms1g",
   "-Xmx3g",
   "-XX:ReservedCodeCacheSize=512m",
+  "-Xss4m",
   "-Dfile.encoding=utf8",
 )
 


### PR DESCRIPTION
This PR fixed a problem related to a limited stack size in https://github.com/tc39/test262/pull/4188 of Test262.