### PR TITLE
Update WebServer.scala

### DIFF
--- a/src/main/scala/esmeta/package.scala
+++ b/src/main/scala/esmeta/package.scala
@@ -9,9 +9,7 @@ val LINE_SEP = System.getProperty("line.separator")
 val VERSION = "0.5.0"
 
 /** base project directory root */
-val BASE_DIR =
-  val path = System.getenv("ESMETA_HOME")
-  if (path == null) throw NoEnvVarError else path
+val BASE_DIR = sys.env.getOrElse("ESMETA_HOME", throw NoEnvVarError)
 
 /** log directory */
 val LOG_DIR = s"$BASE_DIR/logs"

--- a/src/main/scala/esmeta/web/WebServer.scala
+++ b/src/main/scala/esmeta/web/WebServer.scala
@@ -13,6 +13,7 @@ import StatusCodes.*
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives.*
 import ch.megard.akka.http.cors.scaladsl.settings.*
 import scala.io.StdIn
+import scala.sys
 
 class WebServer(cfg: CFG, port: Int) {
   def run: Unit = {
@@ -44,8 +45,8 @@ class WebServer(cfg: CFG, port: Int) {
         ),
       )
     }
-
-    val bindingFuture = Http().newServerAt("localhost", port).bind(rootRoute)
+    val host = sys.env.get("ESMETA_HOST").filter(_.nonEmpty).getOrElse("localhost")
+    val bindingFuture = Http().newServerAt(host, port).bind(rootRoute)
 
     println(s"Server now online at port $port.\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return

--- a/src/main/scala/esmeta/web/WebServer.scala
+++ b/src/main/scala/esmeta/web/WebServer.scala
@@ -13,7 +13,6 @@ import StatusCodes.*
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives.*
 import ch.megard.akka.http.cors.scaladsl.settings.*
 import scala.io.StdIn
-import scala.sys
 
 class WebServer(cfg: CFG, port: Int) {
   def run: Unit = {
@@ -45,10 +44,10 @@ class WebServer(cfg: CFG, port: Int) {
         ),
       )
     }
-    val host = sys.env.get("ESMETA_HOST").filter(_.nonEmpty).getOrElse("localhost")
-    val bindingFuture = Http().newServerAt(host, port).bind(rootRoute)
+    val bindingFuture = Http().newServerAt(ESMETA_HOST, port).bind(rootRoute)
 
-    println(s"Server now online at port $port.\nPress RETURN to stop...")
+    println(s"Server now online at http://$ESMETA_HOST:$port")
+    println("Press RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture
       .flatMap(_.unbind()) // trigger unbinding from the port

--- a/src/main/scala/esmeta/web/package.scala
+++ b/src/main/scala/esmeta/web/package.scala
@@ -8,3 +8,6 @@ def initDebugger(cfg: CFG, sourceText: String): Unit =
   val cachedAst = cfg.scriptParser.from(sourceText)
   _debugger = Some(Debugger(Initialize(cfg, sourceText, Some(cachedAst))))
 private var _debugger: Option[Debugger] = None
+
+/** web server host */
+val ESMETA_HOST = sys.env.getOrElse("ESMETA_HOST", "localhost")


### PR DESCRIPTION
Use ESMETA_HOST environment variable for server host configuration

- The server now uses the value of the ESMETA_HOST environment variable, if set.
- If the variable is not set, the default value "localhost" is used.