### PR TITLE
fix: missing spec location for return type mismatch

### DIFF
--- a/src/main/scala/esmeta/ty/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ty/util/Stringifier.scala
@@ -347,7 +347,7 @@ class Stringifier(
         app >> (idx + 1).toOrdinal >> " parameter _" >> param.lhs.name >> "_"
         app >> " when " >> cp
       case InternalReturnPoint(func, node, irReturn) =>
-        app >> "return statement in " >> func.name >> irReturn
+        app >> "return statement in " >> func.name >> irReturn.langOpt
       case FieldBasePoint(fieldPoint) =>
         app >> "base in" >> fieldPoint
       case FieldPoint(func, node, field) =>


### PR DESCRIPTION
This PR is a hotfix for eb56dcd, addressing a fix for stringifying spec location of return type mismatch, despite the issue being fundamentally resolved.
```diff
- [ReturnTypeMismatch] Block[6087] return statement in OrdinaryCallEvaluateBodyreturn %0
+ [ReturnTypeMismatch] Block[6087] return statement in OrdinaryCallEvaluateBody (step 1, 2:14-101)
```
