### PR TITLE
Update versions of libraries and CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/build.sbt
+++ b/build.sbt
@@ -144,9 +144,10 @@ ThisBuild / assemblyPrependShellScript := Some(
   defaultUniversalScript(shebang = false),
 )
 
-// Akka
-val AkkaVersion = "2.6.19"
-val AkkaHttpVersion = "10.2.8"
+// library versions
+val CirceVersion = "0.14.10"
+val AkkaVersion = "2.10.1"
+val AkkaHttpVersion = "10.7.0"
 
 // project root
 lazy val root = project
@@ -156,17 +157,17 @@ lazy val root = project
 
     // libraries
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core" % "0.14.1",
-      "io.circe" %% "circe-generic" % "0.14.1",
-      "io.circe" %% "circe-parser" % "0.14.1",
-      "org.scalatest" %% "scalatest" % "3.2.11" % Test,
-      "org.apache.commons" % "commons-text" % "1.9",
-      "org.jsoup" % "jsoup" % "1.14.3",
-      "org.jline" % "jline" % "3.13.3",
-      "org.graalvm.polyglot" % "js" % "24.1.1" pomOnly (),
-      ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2")
+      "io.circe" %% "circe-core" % CirceVersion,
+      "io.circe" %% "circe-generic" % CirceVersion,
+      "io.circe" %% "circe-parser" % CirceVersion,
+      "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+      "org.apache.commons" % "commons-text" % "1.13.0",
+      "org.jsoup" % "jsoup" % "1.18.3",
+      "org.jline" % "jline" % "3.29.0",
+      "org.graalvm.polyglot" % "js" % "24.1.2" pomOnly (),
+      ("org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0")
         .cross(CrossVersion.for3Use2_13),
-      ("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
+      ("org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0")
         .cross(CrossVersion.for3Use2_13),
       ("com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion)
         .cross(CrossVersion.for3Use2_13),
@@ -174,9 +175,10 @@ lazy val root = project
         .cross(CrossVersion.for3Use2_13),
       ("com.typesafe.akka" %% "akka-http" % AkkaHttpVersion)
         .cross(CrossVersion.for3Use2_13),
-      ("ch.megard" %% "akka-http-cors" % "1.1.2")
+      ("ch.megard" %% "akka-http-cors" % "1.2.0")
         .cross(CrossVersion.for3Use2_13), // cors
     ),
+    resolvers += "Akka library repository".at("https://repo.akka.io/maven"),
 
     // Copy all managed dependencies to <build-root>/lib_managed/ This is
     // essentially a project-local cache.  There is only one lib_managed/ in

--- a/src/main/scala/esmeta/es/util/JsonProtocol.scala
+++ b/src/main/scala/esmeta/es/util/JsonProtocol.scala
@@ -22,7 +22,7 @@ class JsonProtocol(cfg: CFG) extends StateJsonProtocol(cfg) {
           "path" -> path.map(_.toString).asJson,
         )
     }
-  // given nodeViewDecoder: Decoder[NodeView] = deriveDecoder
+  given nodeViewDecoder: Decoder[NodeView] = deriveDecoder
   given nodeViewEncoder: Encoder[NodeView] =
     Encoder.instance(nv =>
       Json.obj(
@@ -37,6 +37,10 @@ class JsonProtocol(cfg: CFG) extends StateJsonProtocol(cfg) {
   given condViewEncoder: Encoder[CondView] = deriveEncoder
   given funcViewDecoder: Decoder[FuncView] = deriveDecoder
   given funcViewEncoder: Encoder[FuncView] = deriveEncoder
+
+  // conditions
+  given condDecoder: Decoder[Cond] = deriveDecoder
+  given condEncoder: Encoder[Cond] = deriveEncoder
 
   // meta-info for each view or features
   given nodeViewInfoDecoder: Decoder[NodeViewInfo] = deriveDecoder

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -165,12 +165,12 @@ trait Parsers extends TyParsers {
 
   // abstract syntax tree (AST) expressions
   lazy val astExpr: Parser[AstExpr] =
-    ("|" ~> word <~ "|") ~ parseParams ~
+    ("|" ~> word <~ "|") ~ ("(" ~> expr <~ ")") ^^ {
+      case n ~ e => ELexical(n, e)
+    } ||| ("|" ~> word <~ "|") ~ parseParams ~
     ("<" ~> int <~ ">") ~
     (opt("(" ~> repsep(opt(expr), ",") <~ ")") ^^ { _.getOrElse(Nil) }) ^^ {
       case n ~ as ~ i ~ es => ESyntactic(n, as, i, es.toVector)
-    } ||| ("|" ~> word <~ "|") ~ ("(" ~> expr <~ ")") ^^ {
-      case n ~ e => ELexical(n, e)
     }
   lazy val parseParams: Parser[List[Boolean]] =
     opt("[" ~> rep(simpleBool) <~ "]") ^^ { _.getOrElse(Nil) }

--- a/src/main/scala/esmeta/parser/ESParser.scala
+++ b/src/main/scala/esmeta/parser/ESParser.scala
@@ -217,7 +217,7 @@ case class ESParser(
       else res
     val parser = Parser { in => aux(trie, in, Failure("", in)) }
     // XXX `x ?.1 : y` is `x ? .1 : y` but not `x ?. 1 : y`
-    parser ||| ("?." <~ not("\\d".r))
+    ("?." <~ not("\\d".r)) ||| parser
 
   // automatic semicolon insertion
   private def insertSemicolon(reader: EPackratReader[Char]): Option[String] = {

--- a/src/main/scala/esmeta/parser/ESValueParser.scala
+++ b/src/main/scala/esmeta/parser/ESValueParser.scala
@@ -309,8 +309,8 @@ object ESValueParser extends UnicodeParsers with RegexParsers {
     lazy val Hex4Digits: S =
       MV.Hex4Digits ^^ { case x => Character.toChars(x.toInt).mkString }
     lazy val UnicodeEscapeSequence: S =
-      "u" ~> SV.Hex4Digits |||
-      "u{" ~> MV.CodePoint <~ "}" ^^ { case n => cp2str(n) }
+      "u{" ~> MV.CodePoint <~ "}" ^^ { case n => cp2str(n) } |||
+      "u" ~> SV.Hex4Digits
     lazy val TemplateEscapeSequence: S =
       SV.CharacterEscapeSequence |
       "0" <~ not(Predef.DecimalDigit) ^^^ "\u0000" |

--- a/src/main/scala/esmeta/spec/util/JsonProtocol.scala
+++ b/src/main/scala/esmeta/spec/util/JsonProtocol.scala
@@ -14,6 +14,10 @@ object JsonProtocol extends BasicJsonProtocol {
   given Decoder[Spec] = deriveDecoder
   given Encoder[Spec] = deriveEncoder
 
+  // version
+  given Decoder[Spec.Version] = deriveDecoder
+  given Encoder[Spec.Version] = deriveEncoder
+
   // tables
   given Decoder[Table] = deriveDecoder
   given Encoder[Table] = deriveEncoder

--- a/src/main/scala/esmeta/web/WebServer.scala
+++ b/src/main/scala/esmeta/web/WebServer.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods.*
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.*
-import akka.http.scaladsl.server.Directives.*
+import akka.http.scaladsl.server.Directives.{cors => _, *}
 import StatusCodes.*
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives.*
 import ch.megard.akka.http.cors.scaladsl.settings.*


### PR DESCRIPTION
This PR updates versions of libraries and CodeQL in GitHub Actions.

Note that the order of `|||` in the Scala parser combinator has changed since v1.12.0 or v2.0.0 (See https://github.com/scala/scala-parser-combinators/pull/166). It means that if `p ||| q` accepts the same length of characters, the new version returns the parsing result of `p` instead of `q`.