### PR TITLE
Downgrade Akka to match Akka Http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ ThisBuild / assemblyPrependShellScript := Some(
 
 // library versions
 val CirceVersion = "0.14.10"
-val AkkaVersion = "2.10.1"
+val AkkaVersion = "2.10.0"
 val AkkaHttpVersion = "10.7.0"
 
 // project root


### PR DESCRIPTION
`esmeta web` does not work on the current HEAD of dev branch (a7f0eb6ef0fbcf46bba63d2659097c14c05b3720) with the following error:
```
[ESMeta v0.5.1] Unexpected error occurred:
[error] java.lang.IllegalStateException: You are using version 2.10.1 of Akka, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 2.10.1 of the [akka-pki] artifacts to your project. Here's a complete collection of detected artifacts: (2.10.0, [akka-pki]), (2.10.1, [akka-actor, akka-actor-typed, akka-protobuf-v3, akka-slf4j, akka-stream]). See also: https://doc.akka.io/libraries/akka-core/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed
[error]         at akka.util.ManifestInfo.checkSameVersion(ManifestInfo.scala:183)
```

This PR fixes this error by using the proper version of Akka that matches Akka HTTP.