### PR TITLE
Fix Random Termination of `WebServer`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,8 +150,8 @@ ThisBuild / assemblyPrependShellScript := Some(
 
 // library versions
 val CirceVersion = "0.14.10"
-val AkkaVersion = "2.10.0"
-val AkkaHttpVersion = "10.7.0"
+val AkkaVersion = "2.10.5"
+val AkkaHttpVersion = "10.7.1"
 
 // project root
 lazy val root = project
@@ -173,14 +173,9 @@ lazy val root = project
         .cross(CrossVersion.for3Use2_13),
       ("org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0")
         .cross(CrossVersion.for3Use2_13),
-      ("com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion)
-        .cross(CrossVersion.for3Use2_13),
-      ("com.typesafe.akka" %% "akka-stream" % AkkaVersion)
-        .cross(CrossVersion.for3Use2_13),
-      ("com.typesafe.akka" %% "akka-http" % AkkaHttpVersion)
-        .cross(CrossVersion.for3Use2_13),
-      ("ch.megard" %% "akka-http-cors" % "1.2.0")
-        .cross(CrossVersion.for3Use2_13), // cors
+      "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
     ),
     resolvers += "Akka library repository".at("https://repo.akka.io/maven"),
 

--- a/src/main/scala/esmeta/web/WebServer.scala
+++ b/src/main/scala/esmeta/web/WebServer.scala
@@ -5,53 +5,127 @@ import esmeta.web.routes.*
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpMethods.*
 import akka.http.scaladsl.model.*
+import akka.http.scaladsl.model.HttpMethods.*
 import akka.http.scaladsl.server.*
-import akka.http.scaladsl.server.Directives.{cors => _, *}
-import StatusCodes.*
-import ch.megard.akka.http.cors.scaladsl.CorsDirectives.*
-import ch.megard.akka.http.cors.scaladsl.settings.*
+import akka.http.scaladsl.server.Directives.*
+import akka.http.scaladsl.settings.{CorsSettings, ServerSettings}
+import akka.pattern.after
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Sink, Source}
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration.*
 import scala.io.StdIn
+import scala.util.{Failure, Success}
 
 class WebServer(cfg: CFG, port: Int) {
+  var shutdownByUser = false;
+  var currentSystem: Option[ActorSystem[?]] = None
+
   def run: Unit = {
+    up
+    StdIn.readLine();
+    shutdownByUser = true;
+    for (system <- currentSystem) {
+      println("Terminating Server...")
+      system.terminate()
+    }
+  }
+
+  def up: Unit = {
     implicit val system = ActorSystem(Behaviors.empty, "esmeta-web")
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.executionContext
+
+    currentSystem.foreach(_.terminate());
+    currentSystem = Some(system);
 
     // exception handler
     val exceptionHandler = ExceptionHandler {
       case e: Throwable =>
         e.printStackTrace
-        complete(HttpResponse(InternalServerError, entity = e.toString))
+        complete(
+          HttpResponse(StatusCodes.InternalServerError, entity = e.toString),
+        )
     }
 
-    // cors settings
-    val settings = CorsSettings.defaultSettings
+    val corsSettings = CorsSettings(system.settings.config)
       .withAllowCredentials(false)
-      .withMaxAge(None)
-      .withAllowedMethods(List(GET, POST, PUT, DELETE))
-
-    // root router
-    val rootRoute = cors(settings) {
-      handleExceptions(exceptionHandler)(
-        concat(
-          pathPrefix("spec")(SpecRoute(cfg)), // spec route
-          pathPrefix("exec")(ExecRoute(cfg)), // exec route
-          pathPrefix("breakpoint")(BreakpointRoute()), // breakpoint route
-          pathPrefix("state")(StateRoute()), // state route
-          pathPrefix("meta")(MetaRoute()), // meta route
+      .withMaxAge(Duration.Zero)
+      .withAllowAnyOrigin()
+      .withAllowAnyHeader()
+      .withAllowGenericHttpRequests(true)
+      .withAllowedMethods(
+        Set(
+          HttpMethods.GET,
+          HttpMethods.POST,
+          HttpMethods.PUT,
+          HttpMethods.DELETE,
+          HttpMethods.HEAD,
+          HttpMethods.OPTIONS,
         ),
       )
+
+    // root router
+    val rootRoute = cors(corsSettings) {
+      withRequestTimeout(30.seconds) {
+        withRequestTimeoutResponse { _ =>
+          HttpResponse(
+            StatusCodes.ServiceUnavailable,
+            entity = "Request timed out",
+          )
+        } {
+          handleExceptions(exceptionHandler)(
+            concat(
+              pathPrefix("spec")(SpecRoute(cfg)), // spec route
+              pathPrefix("exec")(ExecRoute(cfg)), // exec route
+              pathPrefix("breakpoint")(BreakpointRoute()), // breakpoint route
+              pathPrefix("state")(StateRoute()), // state route
+              pathPrefix("meta")(MetaRoute()), // meta route
+            ),
+          )
+        }
+      }
+
     }
-    val bindingFuture = Http().newServerAt(ESMETA_HOST, port).bind(rootRoute)
+
+    // serial queue with timeout
+    val queue = Source
+      .queue[(RequestContext, Promise[RouteResult])](
+        1024,
+        OverflowStrategy.backpressure,
+      )
+      .mapAsync(1) {
+        case (ctx, promise) =>
+          val fut = rootRoute(ctx)
+          fut.onComplete(promise.complete)
+          fut
+      }
+      .to(Sink.ignore)
+      .run()
+
+    // serialized route which handles request in fifo
+    val serialRoute: Route = ctx => {
+      val promise = Promise[RouteResult]()
+      queue.offer((ctx, promise))
+      promise.future
+    }
+
+    val bindingFuture = Http().newServerAt(ESMETA_HOST, port).bind(serialRoute)
+
+    system.whenTerminated.onComplete {
+      case Success(_) =>
+        if (shutdownByUser) {
+          println("ActorSystem terminated by user.")
+        } else {
+          println("ActorSystem terminated. Restarting...")
+          up
+        }
+      case Failure(e) =>
+        println(s"ActorSystem crashed: $e")
+    }
 
     println(s"Server now online at http://$ESMETA_HOST:$port")
     println("Press RETURN to stop...")
-    StdIn.readLine() // let it run until user presses return
-    bindingFuture
-      .flatMap(_.unbind()) // trigger unbinding from the port
-      .onComplete(_ => system.terminate()) // and shutdown when done
   }
 }


### PR DESCRIPTION
## This pull request makes the following changes:
* Fixes unexpected shutdowns of `esmeta web`. If the service terminates for any reason other than a user-requested stop, the actor system now restarts automatically.
* Updates Akka-related dependencies and removes no more needed dependencies.
* Use a serialized queue for the API, which is useful in situations where multiple API requests might compete — such as when a user holds down the ‘step’ button, causing several requests to be sent rapidly.