### PR TITLE
Fix BackEdgeWalker

### DIFF
--- a/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
+++ b/src/main/scala/esmeta/compiler/BackEdgeWalker.scala
@@ -12,15 +12,15 @@ class BackEdgeWalker(fb: FuncBuilder) extends UnitWalker {
     walk(elem)
     this.overriden = false
     elem
-  override def walk(inst: Inst): Unit = if (overriden || inst.langOpt.isEmpty)
+  override def walk(inst: Inst): Unit = if (overriden || inst.loc.isEmpty)
     inst.setLangOpt(fb.langs.headOption)
     super.walk(inst)
 
-  override def walk(expr: Expr): Unit = if (overriden || expr.langOpt.isEmpty)
+  override def walk(expr: Expr): Unit = if (overriden || expr.loc.isEmpty)
     expr.setLangOpt(fb.langs.headOption)
     super.walk(expr)
 
-  override def walk(ref: Ref): Unit = if (overriden || ref.langOpt.isEmpty)
+  override def walk(ref: Ref): Unit = if (overriden || ref.loc.isEmpty)
     ref.setLangOpt(fb.langs.headOption)
     super.walk(ref)
 }

--- a/src/main/scala/esmeta/ir/util/Parser.scala
+++ b/src/main/scala/esmeta/ir/util/Parser.scala
@@ -356,8 +356,8 @@ trait Parsers extends TyParsers {
     tag: Char,
   )(parser: Parser[T]): Parser[T] =
     parser ~ ((s"@@$tag" ~> (loc ^^ Some.apply)) | (s"@@@$tag" ~> "" ^^^ None) | "" ^^^ None) ^^ {
-      case i ~ l =>
-        i.langOpt = Some(new Syntax { loc = l })
+      case i ~ lOpt =>
+        for (l <- lOpt) do i.langOpt = Some(new Syntax { loc = Some(l) })
         i
     }
 


### PR DESCRIPTION
## This pull request makes the following changes:
* `BackEdgeWalker.scala` now uses `.loc` (`.langOpt.flatMap(_.loc)`) instead of `.langOpt`
* Fixes a bug in which inst/expr loaded from `ManualInfo.scala` were missing back-edges.

You can check on your own:
```bash
$ sbt console
scala> import esmeta.*
scala> val cfg = CmdBuildCFG(Nil)
scala> val OrdinaryGetOwnProperty = cfg.funcs.find(_.name == "OrdinaryGetOwnProperty").get
scala> OrdinaryGetOwnProperty.irFunc.body.asInstanceOf[ir.ISeq].insts(0).langOpt.get.loc.isDefined
val res0: Boolean = true // Previously `false` on the base branch
```

## Test262 Result:
```
[########################################] 100.00% (48,376/48,376) - P:N = 25,276:23,100 => P/P = 25,276/25,276 (100.00%) [05:20]
```
