### PR TITLE
Support `IfAbruptCloseAsyncIterator` shorthand

### DIFF
--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -105,6 +105,7 @@ class Compiler(
   val shorthands = Set(
     "IfAbruptCloseIterator",
     "IfAbruptRejectPromise",
+    "IfAbruptCloseAsyncIterator",
   )
 
   private def isObject(tname: String): Boolean =


### PR DESCRIPTION
## This pull request makes the following changes:
This PR adds the shorthand `IfAbruptCloseAsyncIterator` to support proposals that have reached Stage 4. This operation is specified in [tc39/ecma262/pull/3581](https://github.com/tc39/ecma262/pull/3581) for Array.fromAsync, and is expected to be used in [proposal-async-iterator-helpers](https://github.com/tc39/proposal-async-iterator-helpers) as well.

## Type Check Result
Passed on [09fe8d](https://github.com/js-choi/ecma262/commit/09fe8d132748c0e87b204de727b522c1c91b2239) (using `esmeta-ignore.json`)

## Related Issues
https://github.com/es-meta/esmeta/issues/284