### PR TITLE
Advanced logging for extractor

### DIFF
--- a/src/main/resources/manuals/rule.json
+++ b/src/main/resources/manuals/rule.json
@@ -3,7 +3,6 @@
     "If control reaches here, then _genContext_ is the running execution context again.": "(= genContext @EXECUTION_STACK[0])",
     "The execution context stack has at least two elements.": "(< 1 (sizeof @EXECUTION_STACK))",
     "The execution context stack is empty.": "(= (sizeof @EXECUTION_STACK) 0)",
-    "_O_ has all of the internal slots of a For-In Iterator Instance (<emu-xref href=\"#sec-properties-of-for-in-iterator-instances\"></emu-xref>).": "(? O: Record[ForInIterator])",
     "The execution context stack is not empty.": "(! (= (sizeof @EXECUTION_STACK) 0))",
     "This is an attempt to change the value of an immutable binding.": "true",
     "When we reach this step, _asyncContext_ has already been removed from the execution context stack and _prevContext_ is the currently running execution context.": "(&& (= prevContext @EXECUTION_STACK[0]) (! (= asyncContext @EXECUTION_STACK[0])))",
@@ -28,7 +27,6 @@
   },
   "inst": {
     "<emu-not-ref>Record</emu-not-ref> that the binding for _N_ in _envRec_ has been initialized.": "envRec.__MAP__[N].initialized = true",
-    "Append the pair (a two element List) consisting of _nextKey_ and _desc_ to the end of _descriptors_.": "push descriptors < (list [nextKey, desc])",
     "Append to _internalSlotsList_ the elements of _additionalInternalSlotsList_.": "call interanlSlotsList = clo<\"__APPEND_LIST__\">(internalSlotsList, additionalInternalSlotsList)",
     "Change its bound value to _V_.": "envRec.__MAP__[N].BoundValue = V",
     "Create a mutable binding in _envRec_ for _N_ and record that it is uninitialized. If _D_ is *true*, record that the newly created binding may be deleted by a subsequent DeleteBinding call.": "{ envRec.__MAP__[N] = (record [MutableBinding] { \"initialized\" : false, \"mutable\" : true, \"strict\" : false })  if (= D true) envRec.__MAP__[N].maybeDeleted = true }",
@@ -89,7 +87,6 @@
     "Return the value currently bound to _N_ in _envRec_.": "return envRec.__MAP__[N].BoundValue",
     "Set _P_'s essential internal methods, except for [[Call]] and [[Construct]], to the definitions specified in <emu-xref href=\"#sec-proxy-object-internal-methods-and-internal-slots\"></emu-xref>.": "{ P.GetPrototypeOf = clo<\"Record[ProxyExoticObject].GetPrototypeOf\"> P.SetPrototypeOf = clo<\"Record[ProxyExoticObject].SetPrototypeOf\"> P.IsExtensible = clo<\"Record[ProxyExoticObject].IsExtensible\"> P.PreventExtensions = clo<\"Record[ProxyExoticObject].PreventExtensions\"> P.GetOwnProperty = clo<\"Record[ProxyExoticObject].GetOwnProperty\"> P.DefineOwnProperty = clo<\"Record[ProxyExoticObject].DefineOwnProperty\"> P.HasProperty = clo<\"Record[ProxyExoticObject].HasProperty\"> P.Get = clo<\"Record[ProxyExoticObject].Get\"> P.Set = clo<\"Record[ProxyExoticObject].Set\"> P.Delete = clo<\"Record[ProxyExoticObject].Delete\"> P.OwnPropertyKeys = clo<\"Record[ProxyExoticObject].OwnPropertyKeys\"> }",
     "Set _obj_'s essential internal methods to the default ordinary object definitions specified in <emu-xref href=\"#sec-ordinary-object-internal-methods-and-internal-slots\"></emu-xref>.": "nop",
-    "Set the bound value for _N_ in _envRec_ to _V_.": "envRec.__MAP__[N].BoundValue = V",
-    "_op_ is `|`. Let _result_ be the result of applying the bitwise inclusive OR operation to _lbits_ and _rbits_.": "let result = (| lbits rbits)"
+    "Set the bound value for _N_ in _envRec_ to _V_.": "envRec.__MAP__[N].BoundValue = V"
   }
 }

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -221,13 +221,7 @@ class Extractor(
         rhsName <- rhs.allNames
         syntax = lhsName + ":" + rhsName
         (idx, subIdx) = idxMap(syntax)
-        rhsParams = rhs.params
-        target = SyntaxDirectedOperationHead.Target(
-          lhsName,
-          idx,
-          subIdx,
-          rhsParams,
-        )
+        target = SyntaxDirectedOperationHead.Target(lhsName, idx, subIdx)
       } yield generator(Some(target))
     } else {
       // special 'Default' case: assigned to special LHS named "Default")

--- a/src/main/scala/esmeta/lang/Type.scala
+++ b/src/main/scala/esmeta/lang/Type.scala
@@ -13,6 +13,9 @@ case class Type(ty: Ty) extends Syntax {
 
   /** normalized type name */
   lazy val normalizedName: String = Type.normalizeName(name)
+
+  /** check whether it is an unknown type */
+  def isUnknown: Boolean = ty.isInstanceOf[UnknownTy]
 }
 object Type extends Parser.From(Parser.langTypeWithUnknown) {
 

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -57,12 +57,21 @@ case object Extract extends Phase[Unit, Spec] {
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")
 
-    // dump algorithms
     dumpDir(
       name = "algorithms",
       iterable = spec.algorithms,
       dirname = s"$EXTRACT_LOG_DIR/algos",
       getName = algo => s"${algo.normalizedName}.algo",
+    )
+
+    dumpFile(
+      name = "algorithms whose string form is not equal to the original prose",
+      data = spec.algorithms
+        .filter(algo => algo.normalizedCode != algo.body.toString)
+        .map(algo => s"$EXTRACT_LOG_DIR/algos/${algo.normalizedName}.algo")
+        .sorted
+        .mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/yet-equal-algos",
     )
 
     dumpFile(

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -57,13 +57,13 @@ case object Extract extends Phase[Unit, Spec] {
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")
 
-    // TODO dump algorithms
-    // dumpDir(
-    //   name = "algorithms",
-    //   iterable = spec.algorithms,
-    //   dirname = s"$EXTRACT_LOG_DIR/algos",
-    //   getName = algo => s"${algo.normalizedName}.algo",
-    // )
+    // dump algorithms
+    dumpDir(
+      name = "algorithms",
+      iterable = spec.algorithms,
+      dirname = s"$EXTRACT_LOG_DIR/algos",
+      getName = algo => s"${algo.normalizedName}.algo",
+    )
 
     dumpFile(
       name = "the summary of extracted specification",

--- a/src/main/scala/esmeta/spec/Algorithm.scala
+++ b/src/main/scala/esmeta/spec/Algorithm.scala
@@ -1,5 +1,6 @@
 package esmeta.spec
 
+import esmeta.LINE_SEP
 import esmeta.lang.*
 import esmeta.lang.util.*
 import esmeta.spec.util.*
@@ -37,4 +38,25 @@ case class Algorithm(
   /** get complete algorithm steps */
   lazy val completeSteps: List[Step] =
     steps.filter(!_.isInstanceOf[YetStep])
+
+  /** normalized code */
+  lazy val normalizedCode = Algorithm.normalizeCode(code)
+}
+object Algorithm {
+
+  /** normalize code by removing unnecessary indents and trailing spaces */
+  def normalizeCode(code: String): String = {
+    // find the indentation level
+    val level = code.linesIterator
+      .filter(_.nonEmpty)
+      .map(_.takeWhile(_.isWhitespace).length / 2)
+      .nextOption
+      .getOrElse(0)
+    val numDrops = (level - 1) * 2
+    // normalize the code
+    code.linesIterator
+      .map(_.drop(numDrops))
+      .mkString(LINE_SEP)
+      .replaceAll("\\s+$", "") // remove trailing spaces
+  }
 }

--- a/src/main/scala/esmeta/spec/Head.scala
+++ b/src/main/scala/esmeta/spec/Head.scala
@@ -45,7 +45,7 @@ sealed trait Head extends SpecElem {
     case head: SyntaxDirectedOperationHead =>
       val Target = SyntaxDirectedOperationHead.Target
       val pre = head.target.fold("<DEFAULT>") {
-        case Target(lhsName, idx, subIdx, _) => s"$lhsName[$idx,$subIdx]"
+        case Target(lhsName, idx, subIdx) => s"$lhsName[$idx,$subIdx]"
       }
       s"$pre.${head.methodName}"
     case head: ConcreteMethodHead =>
@@ -86,7 +86,6 @@ object SyntaxDirectedOperationHead:
     lhsName: String,
     idx: Int,
     subIdx: Int,
-    rhsParams: List[Param],
   ) extends SpecElem
 type SdoHeadTarget = SyntaxDirectedOperationHead.Target
 

--- a/src/main/scala/esmeta/spec/Param.scala
+++ b/src/main/scala/esmeta/spec/Param.scala
@@ -11,4 +11,4 @@ case class Param(
 ) extends SpecElem
 object Param extends Parser.From(Parser.param)
 enum ParamKind extends SpecElem:
-  case Normal, Optional, Variadic, Ellipsis
+  case Normal, Optional, Variadic

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -202,8 +202,7 @@ trait Parsers extends LangParsers {
 
   // algorithm parameter kinds
   lazy val paramKind: Parser[ParamKind] =
-    import ParamKind.*
-    "optional" ^^^ Optional | "..." ^^^ Variadic | "…" ~ "," ^^^ Ellipsis
+    "optional" ^^^ ParamKind.Optional | "..." ^^^ ParamKind.Variadic
 
   // algorithm parameter description
   lazy val paramDesc: Parser[Param] =

--- a/src/main/scala/esmeta/spec/util/Stats.scala
+++ b/src/main/scala/esmeta/spec/util/Stats.scala
@@ -28,9 +28,9 @@ class Stats(spec: Spec) {
       pass + other.pass,
       total + other.total,
     )
+    def isEmpty: Boolean = total == 0
     def fail: Int = total - pass
-    override def toString =
-      if total != 0 then s"${ratioString(pass, total)}" else ""
+    override def toString = if (total != 0) ratioString(pass, total) else ""
   private object PassStat:
     def apply(b: Boolean): PassStat = PassStat(if (b) 1 else 0, 1)
 
@@ -85,26 +85,23 @@ class Stats(spec: Spec) {
 
       // get yet steps
       val printYet = yet && stat.fail != 0 && !elem.children.toList
-        .filter(
-          _.tagName == "emu-alg",
-        )
+        .filter(_.tagName == "emu-alg")
         .isEmpty
       val yetStepStr =
-        if printYet then
+        if (printYet)
           // get algos in same emu-clause
           val algos = spec.algorithms.filter(_.elem.getId == elem.id)
-
           // get yet steps
           algos
             .map(_.incompleteSteps)
             .flatten
-            .map(newline(indent + 2) + _.toString(false))
+            .map(newline(indent + 1) + "1. " + _.toString(false))
             .fold("")(_ + _)
         else ""
 
       // final result
-      if elem.tagName == "body" then stat.toString
-      else if elem.tagName == "emu-clause" then
+      if (elem.tagName == "body") stat.toString
+      else if (elem.tagName == "emu-clause" && !stat.isEmpty)
         s"${newline(indent)}- ${elem.id}:${stat}${yetStepStr}"
       else ""
     }
@@ -122,7 +119,7 @@ class Stats(spec: Spec) {
     ): String =
       val elemStr = getElementString(elem, pstat, yet, indent)
       val children = elem.children.toList
-      if !children.isEmpty then
+      if (!children.isEmpty)
         children
           .map(getString(_, pstat, yet, indent + 1))
           .fold(elemStr)(_ + _)

--- a/src/test/scala/esmeta/ESMetaTest.scala
+++ b/src/test/scala/esmeta/ESMetaTest.scala
@@ -220,7 +220,8 @@ object ESMetaTest {
   // extract specifications
   lazy val spec = Extractor()
   lazy val grammar = spec.grammar
-  lazy val program = Compiler(spec)
+  lazy val compiler = new Compiler(spec)
+  lazy val program = compiler.result
   lazy val cfg = CFGBuilder(program)
   def getCFG(target: String): CFG = CFGBuilder(Compiler(Extractor(target)))
 }

--- a/src/test/scala/esmeta/compiler/ValiditySmallTest.scala
+++ b/src/test/scala/esmeta/compiler/ValiditySmallTest.scala
@@ -13,6 +13,16 @@ class ValiditySmallTest extends CompilerTest {
   def init: Unit = {
     lazy val cur = ESMetaTest.program.completeFuncs.map(_.name).toSet
     check("compilation") { cur }
+    check("no unused manual rules") {
+      val unusedRules = ESMetaTest.compiler.unusedRules
+      if (unusedRules.nonEmpty)
+        fail(
+          "there are unused manual rules:" + unusedRules.toList
+            .map(rule => LINE_SEP + "* " + rule)
+            .sorted
+            .mkString,
+        )
+    }
     val path = s"$RESULT_DIR/complete-funcs"
     val prev = optional(readFile(path).split(LINE_SEP).toSet).getOrElse(cur)
     check("complete IR functions") { assert(prev subsetOf cur) }

--- a/src/test/scala/esmeta/lang/TypeSmallTest.scala
+++ b/src/test/scala/esmeta/lang/TypeSmallTest.scala
@@ -34,10 +34,6 @@ class TypeSmallTest extends LangTest {
           for {
             param <- withParams
           } types += param.ty
-          for {
-            param <- target.toList
-            rhsParam <- param.rhsParams
-          } types += rhsParam.ty
           types += rty
         case spec.ConcreteMethodHead(concMethodName, receiver, params, retTy) =>
           for { param <- params } types += param.ty

--- a/src/test/scala/esmeta/spec/SpecTest.scala
+++ b/src/test/scala/esmeta/spec/SpecTest.scala
@@ -68,36 +68,14 @@ object SpecTest {
     UnknownType,
   )
   lazy val sdoHead2 = SyntaxDirectedOperationHead(
-    Some(
-      Target(
-        "ForStatement",
-        0,
-        5,
-        List(
-          Param("Expression0", UnknownType),
-          Param("Expression1", UnknownType),
-          Param("Expression2", UnknownType),
-          Param("Statement", UnknownType),
-        ),
-      ),
-    ),
+    Some(Target("ForStatement", 0, 5)),
     "VarDeclaredNames",
     true,
     List(Param("withParam", UnknownType)),
     UnknownType,
   )
   lazy val sdoHead3 = SyntaxDirectedOperationHead(
-    Some(
-      Target(
-        "AdditiveExpression",
-        1,
-        0,
-        List(
-          Param("AdditiveExpression", UnknownType),
-          Param("MultiplicativeExpression", UnknownType),
-        ),
-      ),
-    ),
+    Some(Target("AdditiveExpression", 1, 0)),
     "Evaluation",
     false,
     List(),
@@ -111,7 +89,7 @@ object SpecTest {
   )
   lazy val methodHead = InternalMethodHead(
     "SetPrototypeOf",
-    Param("O", Type(ObjectT)),
+    Param("O", UnknownType),
     List(
       Param("V", Type(ObjectT || NullT)),
     ),

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -129,14 +129,30 @@ class StringifyTinyTest extends SpecTest {
     // Algorithm Head
     // -------------------------------------------------------------------------
     checkStringify("Head")(
-      aoHead -> "StringIndexOf(string, searchValue, fromIndex): unknown",
-      numHead -> "Number::unaryMinus(x): unknown",
-      sdoHead1 -> "[SYNTAX] <DEFAULT>.VarDeclaredNames[S](withParam): unknown",
-      sdoHead2 -> "[SYNTAX] ForStatement[0, 5](Expression0, Expression1, Expression2, Statement).VarDeclaredNames[S](withParam): unknown",
-      sdoHead3 -> "[SYNTAX] AdditiveExpression[1, 0](AdditiveExpression, MultiplicativeExpression).Evaluation[R](): unknown",
-      concMethodHead -> "[METHOD] HasBinding(envRec)(N): unknown",
-      methodHead -> "[INTERNAL] SetPrototypeOf(O)(V): unknown",
-      builtinHead -> "[BUILTIN] Boolean(value): unknown",
+      aoHead -> """[abstract operation] StringIndexOf(
+      |  _string_: a String,
+      |  _searchValue_: a String,
+      |  _fromIndex_: a Number,
+      |): unknown""".stripMargin,
+      numHead -> """[numeric method] Number::unaryMinus(
+      |  _x_: a Number,
+      |): unknown""".stripMargin,
+      sdoHead1 -> """[sdo] (static) <DEFAULT>.VarDeclaredNames(
+      |  _withParam_,
+      |): unknown""".stripMargin,
+      sdoHead2 -> """[sdo] (static) ForStatement[0, 5].VarDeclaredNames(
+      |  _withParam_,
+      |): unknown""".stripMargin,
+      sdoHead3 -> "[sdo] (runtime) AdditiveExpression[1, 0].Evaluation(): unknown",
+      concMethodHead -> """[concrete method] HasBinding(_envRec_)(
+      |  _N_: a String,
+      |): unknown""".stripMargin,
+      methodHead -> """[internal method] SetPrototypeOf(_O_)(
+      |  _V_: an Object or *null*,
+      |): unknown""".stripMargin,
+      builtinHead -> """[builtin] Boolean(
+      |  _value_,
+      |): unknown""".stripMargin,
     )
 
     // built-in algorithm paths

--- a/tests/result/compiler/ValiditySmallTest
+++ b/tests/result/compiler/ValiditySmallTest
@@ -1,1 +1,1 @@
-compiler.ValiditySmallTest: 2 / 2
+compiler.ValiditySmallTest: 3 / 3

--- a/tests/result/compiler/ValiditySmallTest.json
+++ b/tests/result/compiler/ValiditySmallTest.json
@@ -1,4 +1,5 @@
 {
   "compilation" : true,
-  "complete IR functions" : true
+  "complete IR functions" : true,
+  "no unused manual rules" : true
 }


### PR DESCRIPTION
This PR contains the following advances in the logging mode for extractor (i.e., `esmeta extract -extract:log`):

- The `logs/extract/stat/{algo-summary,step-summary}` files now show sections only having algorithms.
- The `compilerValidityTest` also checks that there are **no unused manual compilation rules** defined in `src/main/resources/manuals/rule.json`.
- ESMeta supports the stringifier for `Algorithm` objects and dumps string forms of all algorithms to `logs/extract/algos` in the logging mode for the extractor.
- The logging mode also dumps the `yet-equal-algos` that lists all algorithms whose string forms are not equal to the corresponding original definition.
  (In the current version, 1,357/2852 (47.58%) algorithms have string forms exactly equal to the original definition.)