### PR TITLE
Add Strict Option to Extract Phase

### DIFF
--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test fuzz inject mutate dump-debugger dump-visualizer"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:ignore"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"

--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test fuzz inject mutate dump-debugger dump-visualizer"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:eval -extract:repl"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:ignore"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -75,7 +75,7 @@ case object Extract extends Phase[Unit, Spec] {
     val disAllowedYetConds = {
       val ignoredConds = ignoreMap.get("yet-conds").getOrElse(List.empty)
       spec.yetConds
-        .map(_.toString(detail = true, location = false))
+        .map(_.toString(detail = false, location = false))
         .filterNot(ignoredConds.contains)
     }
 
@@ -83,7 +83,7 @@ case object Extract extends Phase[Unit, Spec] {
       val ignoredSteps = ignoreMap.get("yet-steps").getOrElse(List.empty)
       (ManualInfo.compileRule("inst").keySet ++
       spec.yetSteps.map(
-        _.toString(detail = true, location = false),
+        _.toString(detail = false, location = false),
       ))
         .filterNot(ignoredSteps.contains)
     }
@@ -102,29 +102,32 @@ case object Extract extends Phase[Unit, Spec] {
   private def log(spec: Spec): Unit = {
     mkdir(EXTRACT_LOG_DIR)
 
-    dumpJson(
+    dumpFile(
       name = "not yet supported steps",
       data = spec.yetSteps
-        .map(_.toString(detail = true, location = false))
-        .sorted,
-      filename = s"$EXTRACT_LOG_DIR/yet-steps.json",
+        .map(_.toString(detail = false, location = false))
+        .sorted
+        .mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/yet-steps",
     )
 
-    dumpJson(
+    dumpFile(
       name = "not yet supported conditions",
       data = spec.yetConds
-        .map(_.toString(detail = true, location = false))
-        .sorted,
-      filename = s"$EXTRACT_LOG_DIR/yet-conds.json",
+        .map(_.toString(detail = false, location = false))
+        .sorted
+        .mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/yet-conds",
     )
 
     val yetTypes = spec.yetTypes
-    dumpJson(
+    dumpFile(
       name = "not yet parsed types",
       data = spec.yetTypes
         .map(_.toString)
-        .sorted,
-      filename = s"$EXTRACT_LOG_DIR/yet-types.json",
+        .sorted
+        .mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/yet-types",
     )
 
     dumpJson(
@@ -132,10 +135,10 @@ case object Extract extends Phase[Unit, Spec] {
         "not yet supported steps, not yet supported conditions, and not yet parsed types in one file",
       data = Map(
         "yet-steps" -> spec.yetSteps
-          .map(_.toString(detail = true, location = false))
+          .map(_.toString(detail = false, location = false))
           .sorted,
         "yet-conds" -> spec.yetConds
-          .map(_.toString(detail = true, location = false))
+          .map(_.toString(detail = false, location = false))
           .sorted,
         "yet-types" -> spec.yetTypes
           .map(_.toString)
@@ -153,13 +156,14 @@ case object Extract extends Phase[Unit, Spec] {
       getName = algo => s"${algo.normalizedName}.algo",
     )
 
-    dumpJson(
+    dumpFile(
       name = "algorithms whose string form is not equal to the original prose",
       data = spec.algorithms
         .filter(algo => algo.normalizedCode != algo.body.toString)
         .map(algo => s"$EXTRACT_LOG_DIR/algos/${algo.normalizedName}.algo")
-        .sorted,
-      filename = s"$EXTRACT_LOG_DIR/yet-equal-algos.json",
+        .sorted
+        .mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/yet-equal-algos",
     )
 
     dumpFile(

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -47,6 +47,7 @@ case object Extract extends Phase[Unit, Spec] {
   }
 
   private def checkStrict(spec: Spec, config: Config): Unit = {
+    // TODO warn unused elements in ignore file
     val ignoreMap = config.allowedYets match
       case None =>
         warn(

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -51,7 +51,7 @@ case object Extract extends Phase[Unit, Spec] {
     val ignoreMap = config.allowedYets match
       case None =>
         warn(
-          s"no ignore file for `allowed-yet-types`; using default allowlist. (default: none)",
+          s"no ignore file for allowed `yets` found; using default allowlist. (default: none)",
         )
         Map.empty
       case Some(value) => readJson[Map[String, List[String]]](value)
@@ -61,7 +61,7 @@ case object Extract extends Phase[Unit, Spec] {
       ignoreMap.keySet.subsetOf(Set("yet-steps", "yet-conds", "yet-types"))
     if (!isWellShaped) {
       warn(
-        s"invalid ignore file for `allowed-yet-types`: expected keys are `yet-steps`, `yet-conds`, and `yet-types`, but given ${ignoreMap.keySet}.",
+        s"invalid ignore file for allowed `yets`: expected keys are `yet-steps`, `yet-conds`, and `yet-types`, but given ${ignoreMap.keySet}.",
       )
     }
 
@@ -102,34 +102,6 @@ case object Extract extends Phase[Unit, Spec] {
   private def log(spec: Spec): Unit = {
     mkdir(EXTRACT_LOG_DIR)
 
-    dumpFile(
-      name = "not yet supported steps",
-      data = spec.yetSteps
-        .map(_.toString(detail = false, location = false))
-        .sorted
-        .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/yet-steps",
-    )
-
-    dumpFile(
-      name = "not yet supported conditions",
-      data = spec.yetConds
-        .map(_.toString(detail = false, location = false))
-        .sorted
-        .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/yet-conds",
-    )
-
-    val yetTypes = spec.yetTypes
-    dumpFile(
-      name = "not yet parsed types",
-      data = spec.yetTypes
-        .map(_.toString)
-        .sorted
-        .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/yet-types",
-    )
-
     dumpJson(
       name =
         "not yet supported steps, not yet supported conditions, and not yet parsed types in one file",
@@ -144,7 +116,7 @@ case object Extract extends Phase[Unit, Spec] {
           .map(_.toString)
           .sorted,
       ),
-      filename = s"$EXTRACT_LOG_DIR/total-yets.json",
+      filename = s"$EXTRACT_LOG_DIR/yets.json",
     )
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")
@@ -177,7 +149,7 @@ case object Extract extends Phase[Unit, Spec] {
 
   // run REPL
   private val replWelcomeMessage =
-    """Welcome to REPL for metalanguage parser .
+    """Welcome to REPL for metalanguage parser.
       |Please input any metalanguage step as an input of the parser.
       |If you want to exit, please type `q` ro `quit`.""".stripMargin
   def runREPL: Unit =

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -25,6 +25,14 @@ case object Extract extends Phase[Unit, Spec] {
       println(f"- # of actual parsing: $getParseCount%,d")
       println(f"- # of using cached result: $getCacheCount%,d")
     if (config.log) log(spec)
+    if (config.strict) {
+      // TODO exclude yets from rule.json
+      if (spec.yetTypes.nonEmpty || spec.incompleteSteps.nonEmpty) {
+        raise(
+          s"extracting failed in complete mode: found ${spec.yetTypes.length} yet-types and ${spec.incompleteSteps.length} yet-steps.",
+        )
+      }
+    }
     spec
   } else {
     runREPL
@@ -140,11 +148,23 @@ case object Extract extends Phase[Unit, Spec] {
       BoolOption(_.repl = _),
       "use a REPL for metalanguage parser.",
     ),
+    (
+      "strict",
+      BoolOption(_.strict = _),
+      "turn on strict parsing mode, which makes extractor fail when any 'yet-step' or 'yet-type`. (default: false)",
+    ),
+    (
+      "ignore",
+      StrOption((c, s) => c.ignore = Some(s)),
+      "path of allowlist file (json) for strict parsing mode.",
+    ),
   )
   case class Config(
     var target: Option[String] = None,
     var log: Boolean = false,
     var eval: Boolean = false,
     var repl: Boolean = false,
+    var strict: Boolean = false,
+    var ignore: Option[String] = None,
   )
 }

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -41,8 +41,36 @@ case class Spec(
     step <- algo.steps
   } yield step
 
-  /** get incomplete algorithm steps */
+  /** get incomplete algorithm steps
+    *
+    * @see
+    *   [[yetSteps]], [[yetConds]]
+    */
   lazy val incompleteSteps: List[Step] = allSteps.filter(!_.complete)
+
+  private lazy val yetStepsAndConds: (List[Step], List[Condition]) = {
+    var yetSteps = Vector[Step]()
+    var yetConds = Vector[Condition]()
+    for (step <- incompleteSteps) step match
+      case IfStep(cond, _, _, _) => yetConds :+= cond
+      case AssertStep(cond)      => yetConds :+= cond
+      case _                     => yetSteps :+= step
+    (yetSteps.toList, yetConds.toList)
+  }
+
+  /** get incomplete algorithm steps, refined from [[incompleteSteps]]
+    *
+    * @see
+    *   [[incompleteSteps]]
+    */
+  lazy val yetSteps: List[Step] = yetStepsAndConds._1
+
+  /** get incomplete algorithm conditions, refined from [[incompleteSteps]]
+    *
+    * @see
+    *   [[incompleteSteps]]
+    */
+  lazy val yetConds: List[Condition] = yetStepsAndConds._2
 
   /** get complete algorithm steps */
   lazy val completeSteps: List[Step] = allSteps.filter(_.complete)
@@ -57,7 +85,7 @@ case class Spec(
   lazy val knownTypes: List[Type] =
     types.collect { case ty @ Type(_: ValueTy) => ty }
 
-  /** get known types */
+  /** get unknown types with `msg` defined. */
   lazy val yetTypes: List[Type] =
     types.collect { case ty @ Type(UnknownTy(Some(_))) => ty }
 

--- a/src/main/scala/esmeta/util/BaseUtils.scala
+++ b/src/main/scala/esmeta/util/BaseUtils.scala
@@ -31,7 +31,7 @@ object BaseUtils {
 
   /** show a warning message */
   def warn[T](x: T, showTrace: Boolean = false): T =
-    warn("WARNING", x, showTrace)
+    warn(setColor(YELLOW)("WARNING"), x, showTrace)
   def warn[T](head: String, x: T, showTrace: Boolean): T =
     Console.err.println(s"[$head] $x")
     if (showTrace)
@@ -39,9 +39,9 @@ object BaseUtils {
       println(getStackTrace.take(STACK_TRACE_DEPTH).mkString(LINE_SEP + "    "))
     x
 
-  /** show a deubgging message */
+  /** show a debugging message */
   def debug[T](x: T, showTrace: Boolean = false): T =
-    warn("DEBUG", x, showTrace)
+    warn(setColor(CYAN)("DEBUG"), x, showTrace)
 
   /** get duration time in milliseconds */
   def time[T](f: => T): (Long, T) = {


### PR DESCRIPTION
This PR adds the `-extract:strict` option as a resolution for issue #288.

With this option enabled, the extraction process will terminate if any yet cond, yet step, or yet type is encountered.

```bash
$ esmeta tycheck -extract:strict

========================================
 extract phase
----------------------------------------
[WARNING] no ignore file for `allowed-yet-types`; using default allowlist. (default: none)
[ESMeta v0.6.3] extracting failed in strict extract mode: found 191 yet-types, 587 yet-steps and 186 yet-conds. see result of -extract:log for details.
```

An allowlist can be specified using the `-extract:allowed-yets` option.
```bash
$ esmeta tycheck -extract:strict -extract:allowed-yets=path_to_file.json
```

The allowlist should look like the following (empty fields can be omitted):
```json
{
  "yet-steps" : [
    "Choose any such _cell_."
  ],
  "yet-conds" : [
    "the host is a web browser"
  ],
  "yet-types" : [
    "*\"ok\"* or *\"timed-out\"*"
  ]
}
```

The `logs/extract/yets.json` file can be used to allow all yet phrases.
(However, please do not use `logs/extract/yets.json` directly as the value for `-extract:allowed-yets`, since the logs may be overwritten. Instead, copy the file and use the copy.)


This PR also changes some log file format as json.

```diff
logs
└── extract
    ├── …
    ├── yet-equal-algos
-   ├── yet-conds
-   ├── yet-steps
-   ├── yet-types
+   └── yets.json
```

