### PR TITLE
Rename `BaseUtils.error`

### DIFF
--- a/src/main/scala/esmeta/analyzer/repl/REPL.scala
+++ b/src/main/scala/esmeta/analyzer/repl/REPL.scala
@@ -128,7 +128,7 @@ trait ReplDecl { self: Self =>
             }
         }
       }) {}
-    } catch { case e: EndOfFileException => error("stop for debugging") }
+    } catch { case e: EndOfFileException => raise("stop for debugging") }
 
     // original control point
     private var origCp: Option[ControlPoint] = None

--- a/src/main/scala/esmeta/analyzer/repl/command/CmdExit.scala
+++ b/src/main/scala/esmeta/analyzer/repl/command/CmdExit.scala
@@ -19,6 +19,6 @@ trait CmdExitDecl { self: Self =>
     def apply(
       cpOpt: Option[ControlPoint],
       args: List[String],
-    ): Unit = error("stop for debugging")
+    ): Unit = raise("stop for debugging")
   }
 }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -256,7 +256,7 @@ trait AbsStateDecl { self: TyChecker =>
     /** define variables */
     def define(x: Var, value: AbsValue): AbsState = x match
       case x: Local  => this.update(x, value, refine = false)
-      case x: Global => error("do not support defining global variables")
+      case x: Global => raise("do not support defining global variables")
 
     /** identifier setter */
     def update(x: Var, value: AbsValue, refine: Boolean): AbsState = x match

--- a/src/main/scala/esmeta/cfg/Func.scala
+++ b/src/main/scala/esmeta/cfg/Func.scala
@@ -145,7 +145,7 @@ case class Func(
     for {
       pdfPath <- pdfPathOpt
       e <- getError(executeCmd(s"""dot -Tpdf "$dotPath" -o "$pdfPath""""))
-    } error(s"""[DOT] [$name]: exception occurred while converting to pdf:
+    } raise(s"""[DOT] [$name]: exception occurred while converting to pdf:
                |
                |$e""".stripMargin)
 

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -698,7 +698,7 @@ class Compiler(
               ),
             )
             xExpr
-          case _ => error(s"invalid math operation: $expr")
+          case _ => raise(s"invalid math operation: $expr")
       case ConversionExpression(op, expr) =>
         import ConversionExpressionOperator.*
         op match
@@ -798,7 +798,7 @@ class Compiler(
       case (Sin, List(e))      => EMathOp(MOp.Sin, List(e))
       case (Sqrt, List(e))     => EMathOp(MOp.Sqrt, List(e))
       case (Tan, List(e))      => EMathOp(MOp.Tan, List(e))
-      case _ => error(s"invalid math operationr: $op with $args")
+      case _ => raise(s"invalid math operationr: $op with $args")
 
   /** compile binary operators */
   def compile(op: BinaryExpressionOperator): BOp = op match
@@ -1068,7 +1068,7 @@ class Compiler(
     val algo = spec.fnameMap(fname)
     val names = args.map {
       case ERef(name: Name) => name
-      case e                => error(s"invalid arguments for shorthands: $e")
+      case e                => raise(s"invalid arguments for shorthands: $e")
     }
     val nameMap = (algo.head.funcParams.map(p => Name(p.name)) zip names).toMap
     val renameWalker = new IRWalker {
@@ -1193,7 +1193,7 @@ class Compiler(
     val (name, f) = pair
     name -> { (fb, args) =>
       optional(f(fb, args)).getOrElse(
-        error(s"invalid arguments: $name(${args.mkString(", ")})"),
+        raise(s"invalid arguments: $name(${args.mkString(", ")})"),
       )
     }
   }

--- a/src/main/scala/esmeta/es/util/Stringifier.scala
+++ b/src/main/scala/esmeta/es/util/Stringifier.scala
@@ -43,7 +43,7 @@ class Stringifier(
           case _ =>
             if (symbol.getNt.isDefined) cs.headOption match
               case Some(hd) => hd.map(aux); cs = cs.tail
-              case _        => error(s"invalid AST: $origAst")
+              case _        => raise(s"invalid AST: $origAst")
     aux(origAst)
     app
 

--- a/src/main/scala/esmeta/injector/ExitTag.scala
+++ b/src/main/scala/esmeta/injector/ExitTag.scala
@@ -26,7 +26,7 @@ enum ExitTag extends InjectorElem {
 object ExitTag {
   def apply(st: => State): ExitTag = try {
     def errorWith(v: Value): Nothing =
-      error(s"unexpected exit status: ${st.getString(v)}")
+      raise(s"unexpected exit status: ${st.getString(v)}")
     st(GLOBAL_RESULT) match
       case Undef => Normal
       case addr: Addr =>

--- a/src/main/scala/esmeta/injector/Injector.scala
+++ b/src/main/scala/esmeta/injector/Injector.scala
@@ -216,9 +216,9 @@ class Injector(
                 case obj @ RecordObj("CompletionRecord", _) =>
                   obj(Str("Value")) match
                     case addr: Addr => addr
-                    case v          => error("not an address: $v")
+                    case v          => raise("not an address: $v")
                 case _ => addr
-            case v => error("not an address: $v")
+            case v => raise("not an address: $v")
           val len = newSt(propsAddr, Str("length")).asMath.toInt
           val array = (0 until len)
             .map(k => newSt(propsAddr, Math(k)))

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -15,7 +15,7 @@ import esmeta.spec.{
   BuiltinHead,
 }
 import esmeta.ty.*
-import esmeta.util.BaseUtils.{error => _, *}
+import esmeta.util.BaseUtils.{raise => _, *}
 import esmeta.util.SystemUtils.*
 import esmeta.{EVAL_LOG_DIR, LINE_SEP}
 import java.io.PrintWriter

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -1,6 +1,6 @@
 package esmeta.interpreter
 
-import esmeta.TEST_MODE
+import esmeta.{EVAL_LOG_DIR, LINE_SEP, TEST_MODE}
 import esmeta.cfg.*
 import esmeta.error.*
 import esmeta.error.NotSupported.Category.{Type => _, *}
@@ -15,16 +15,15 @@ import esmeta.spec.{
   BuiltinHead,
 }
 import esmeta.ty.*
-import esmeta.util.BaseUtils.{raise => _, *}
+import esmeta.util.Loc
+import esmeta.util.BaseUtils.*
 import esmeta.util.SystemUtils.*
-import esmeta.{EVAL_LOG_DIR, LINE_SEP}
 import java.io.PrintWriter
 import java.math.MathContext.DECIMAL128
 import java.util.concurrent.TimeoutException
 import scala.annotation.tailrec
 import scala.collection.mutable.{Map => MMap}
 import scala.math.{BigInt => SBigInt}
-import esmeta.util.Loc
 
 /** extensible helper of IR interpreter with a CFG */
 class Interpreter(

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -372,7 +372,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "square root of " >> e
       case (Tan, List(e)) =>
         app >> "tangent of " >> e
-      case _ => error(s"invalid math operationr: $op with $args")
+      case _ => raise(s"invalid math operationr: $op with $args")
 
   // multiline expressions
   given multilineExprRule: Rule[MultilineExpression] = (app, expr) =>

--- a/src/main/scala/esmeta/parser/Lexer.scala
+++ b/src/main/scala/esmeta/parser/Lexer.scala
@@ -122,7 +122,7 @@ trait Lexer extends UnicodeParsers {
       abbrCPs
         .getOrElse(
           abbr,
-          error(s"unknown code point abbreviation: <$abbr>"),
+          raise(s"unknown code point abbreviation: <$abbr>"),
         )
         .map(_.toChar)
         .mkString("[", "", "]")

--- a/src/main/scala/esmeta/phase/Fuzz.scala
+++ b/src/main/scala/esmeta/phase/Fuzz.scala
@@ -1,6 +1,6 @@
 package esmeta.phase
 
-import esmeta.{error => _, *}
+import esmeta.*
 import esmeta.cfg.CFG
 import esmeta.util.*
 import esmeta.util.BaseUtils.*

--- a/src/main/scala/esmeta/phase/Fuzz.scala
+++ b/src/main/scala/esmeta/phase/Fuzz.scala
@@ -67,7 +67,7 @@ case object Fuzz extends Phase[CFG, Coverage] {
     (
       "debug",
       NumOption((c, k) =>
-        if (k < 0 || k > 2) error("invalid debug level: please set 0 to 2")
+        if (k < 0 || k > 2) raise("invalid debug level: please set 0 to 2")
         else c.debug = k,
       ),
       "turn on debug mode with level (0: no-debug, 1: partial, 2: all)",

--- a/src/main/scala/esmeta/phase/Test262Test.scala
+++ b/src/main/scala/esmeta/phase/Test262Test.scala
@@ -36,7 +36,7 @@ case object Test262Test extends Phase[CFG, Summary] {
       else Some(cmdConfig.targets)
 
     if (config.timeLimit.isDefined && config.concurrent == CP.Auto)
-      error(
+      raise(
         "Turing on both time limit option (-test262-test:timeout and " +
         "the concurrent mode (-test262-test:concurrent) with " +
         "automatic thread number is not allowed.",

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -77,7 +77,7 @@ case class Spec(
   def getAlgoById(id: String): Algorithm =
     algorithms.filter(_.elem.getId == id) match
       case algo :: Nil => algo
-      case _           => error(s"no algorithms found for $id")
+      case _           => raise(s"no algorithms found for $id")
 
   /** empty check */
   def isEmpty: Boolean =

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -1,5 +1,6 @@
 package esmeta.spec
 
+import esmeta.*
 import esmeta.compiler.Compiler
 import esmeta.lang.*
 import esmeta.parser.{ESParser, AstFrom}
@@ -8,7 +9,6 @@ import esmeta.ty.*
 import esmeta.util.BaseUtils.*
 import esmeta.util.Git
 import esmeta.util.HtmlUtils.*
-import esmeta.{error => ESMetaError, *}
 import org.jsoup.nodes.Document
 
 /** ECMAScript specifications (ECMA-262) */

--- a/src/main/scala/esmeta/state/Context.scala
+++ b/src/main/scala/esmeta/state/Context.scala
@@ -3,7 +3,7 @@ package esmeta.state
 import esmeta.cfg.{Func, Node, Block, Call}
 import esmeta.ir.{Func => IRFunc, *}
 import esmeta.es.Ast
-import esmeta.util.BaseUtils.error
+import esmeta.util.BaseUtils.raise
 import scala.collection.mutable.{Map => MMap}
 
 /** IR contexts */
@@ -30,7 +30,7 @@ case class Context(
   def moveNode: Unit = cursor match
     case NodeCursor(_, block: Block, _) => cursor = Cursor(block.next, func)
     case NodeCursor(_, call: Call, _)   => cursor = Cursor(call.next, func)
-    case _                              => error("cursor can't move to next")
+    case _                              => raise("cursor can't move to next")
 
   /** return variable */
   var retVal: Option[(Return, Value)] = None

--- a/src/main/scala/esmeta/state/State.scala
+++ b/src/main/scala/esmeta/state/State.scala
@@ -92,7 +92,7 @@ case class State(
   def exists(base: Value, field: Value): Boolean = base match
     case addr: Addr    => heap.exists(addr, field)
     case AstValue(ast) => ast.exists(field)
-    case _             => error(s"illegal field existence check: $base[$field]")
+    case _             => raise(s"illegal field existence check: $base[$field]")
 
   /** expand a field of a record object */
   def expand(base: Value, field: Value): Unit = heap.expand(base.asAddr, field)

--- a/src/main/scala/esmeta/util/BaseUtils.scala
+++ b/src/main/scala/esmeta/util/BaseUtils.scala
@@ -27,7 +27,7 @@ object BaseUtils {
   }
 
   /** throw a simple error */
-  def error(any: Any): Nothing = throw ESMetaError(any.toString)
+  def raise(any: Any): Nothing = throw ESMetaError(any.toString)
 
   /** show a warning message */
   def warn[T](x: T, showTrace: Boolean = false): T =
@@ -212,8 +212,8 @@ object BaseUtils {
     name: String = "element",
   ): T = iter.filter(f).toList match
     case List(elem) => elem
-    case Nil        => error(s"no $name")
-    case _          => error(s"multiple ${name}s")
+    case Nil        => raise(s"no $name")
+    case _          => raise(s"multiple ${name}s")
 
   /** escape a string into a shell string */
   def escapeToShellString(string: String): String =

--- a/src/main/scala/esmeta/util/BasicParsers.scala
+++ b/src/main/scala/esmeta/util/BasicParsers.scala
@@ -28,7 +28,7 @@ trait BasicParsers extends JavaTokenParsers {
   // parse with error message
   def errHandle[T](parser: Parser[T], result: ParseResult[T]): T = result match
     case Success(result, _) => result
-    case err                => error(s"[$parser] $err")
+    case err                => raise(s"[$parser] $err")
 
   // parse
   def parseBy[T](parser: Parser[T])(str: String): T =

--- a/src/main/scala/esmeta/util/ConcreteLattice.scala
+++ b/src/main/scala/esmeta/util/ConcreteLattice.scala
@@ -1,6 +1,6 @@
 package esmeta.util
 
-import esmeta.util.BaseUtils.{warn, error}
+import esmeta.util.BaseUtils.{warn, raise}
 
 /** lattice with concrete values */
 trait ConcreteLattice[+A, L[_] <: ConcreteLattice[_, L]] {
@@ -89,7 +89,7 @@ sealed trait Flat[+A] extends ConcreteLattice[A, Flat] { self =>
       case Zero       => Nil.iterator
       case One(value) => Iterator.single(value)
       case Many =>
-        if (stop) error(s"impossible to iterate infinite values")
+        if (stop) raise(s"impossible to iterate infinite values")
         else Nil.iterator
 }
 object Flat:
@@ -183,7 +183,7 @@ sealed trait BSet[+A] extends ConcreteLattice[A, BSet] { self =>
     final def iterator: Iterator[A] = self match
       case Fin(set) => set.iterator
       case Inf =>
-        if (stop) error(s"impossible to iterate infinite values")
+        if (stop) raise(s"impossible to iterate infinite values")
         else Nil.iterator
 }
 case object Inf extends BSet[Nothing]

--- a/src/test/scala/esmeta/lang/TypeSmallTest.scala
+++ b/src/test/scala/esmeta/lang/TypeSmallTest.scala
@@ -68,7 +68,7 @@ class TypeSmallTest extends LangTest {
         if !pass
       } yield langType
       if (failedTypes.nonEmpty) {
-        error(
+        raise(
           s"failed to stringify ${failedTypes.size} types:" +
           failedTypes.map(LINE_SEP + "* " + _.ty.toString).mkString,
         )


### PR DESCRIPTION
This PR renames `BaseUtils.error` as `BaseUtils.raise` to avoid name conflicts.