### PR TITLE
Fix bugs in handling `FunctionT` and `ConstructorT`

### DIFF
--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -884,7 +884,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
             TypeGuard(guard)
           }
         case EExists(Field(x: Local, EStr(field))) =>
-          val binding = Binding.Exist
+          val binding = Binding.Init
           for {
             lv <- transfer(x)
             given AbsState <- get
@@ -1080,7 +1080,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
             Field(Global("EXECUTION_STACK"), EMath(0)),
             EStr("Function"),
           ) if np.func.isBuiltin =>
-        AbsValue(RecordT("Constructor"))
+        AbsValue(ConstructorT)
       // a precise type for intrinsic objects
       case Field(Field(base, EStr("Intrinsics")), EStr(name)) =>
         for {
@@ -1607,7 +1607,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       field: String,
       positive: Boolean,
     )(using np: NodePoint[_]): Updater =
-      refineField(x, field, Binding.Exist, positive)
+      refineField(x, field, Binding.Init, positive)
 
     /** refine types with `typeof` constraints */
     def refineType(
@@ -1726,7 +1726,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           val refined = vs(1).ty.str.getSingle match
             case One(f) =>
               ValueTy(
-                record = ObjectT.record.update(f, Binding.Exist, refine = true),
+                record = ObjectT.record.update(f, Binding.Init, refine = true),
               )
             case _ => ObjectT
           val prov = Provenance(func)

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1291,10 +1291,9 @@ trait Parsers extends IndentParsers {
     "Record" ~ "{" ~> repsep(fieldLiteral, ",") <~ "}" ^^ {
       case fs => RecordT("", fs.map(_.name -> AnyT).toMap)
     } | opt("an " | "a ") ~> {
-      (
+      "function object" ^^^ FunctionT |
+      "constructor" ^^^ ConstructorT | (
         "ordinary object" |
-        "function object" |
-        "constructor" |
         "ECMAScript function object" |
         "built-in function object" |
         "Array exotic object" ^^^ "Array" |

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -835,6 +835,14 @@ class Stringifier(detail: Boolean, location: Boolean) {
           m -= "ThrowCompletion"
           tys :+= "throw completion".withArticle(article)
         }
+        for (fm <- m.get("Object")) {
+          if (fm == FieldMap.init("Call"))
+            m -= "Object"
+            tys :+= "function object".withArticle(article)
+          if (fm == FieldMap.init("Call", "Construct"))
+            m -= "Object"
+            tys :+= "constructor".withArticle(article)
+        }
         for ((name, _) <- m) {
           // split camel case with a space
           tys :+= name.split("(?=[A-Z])").mkString(" ").withArticle(article)

--- a/src/main/scala/esmeta/ty/Binding.scala
+++ b/src/main/scala/esmeta/ty/Binding.scala
@@ -32,12 +32,9 @@ case class Binding(
   def ||(that: => Binding): Binding =
     if (this eq that) this
     else
-      val uninit =
-        if (this == Binding.Absent && !that.absent && !that.value.isBottom) true
-        else this.uninit || that.uninit
       Binding(
         this.value || that.value,
-        uninit,
+        this.uninit || that.uninit,
         this.absent || that.absent,
       )
 

--- a/src/main/scala/esmeta/ty/FieldMap.scala
+++ b/src/main/scala/esmeta/ty/FieldMap.scala
@@ -56,7 +56,8 @@ case class FieldMap(map: Map[String, Binding])
   def apply(field: String): Binding = map.getOrElse(field, Binding.Top)
 
   /** field update */
-  def update(field: String, binding: Binding): FieldMap =
+  def +(pair: (String, Binding)): FieldMap =
+    val (field, binding) = pair
     FieldMap(map + (field -> binding))
 
   /** fields */
@@ -71,4 +72,7 @@ case class FieldMap(map: Map[String, Binding])
 object FieldMap extends Parser.From(Parser.fieldMap) {
   lazy val Top: FieldMap = FieldMap()
   def apply(fields: (String, Binding)*): FieldMap = FieldMap(fields.toMap)
+  def init(fields: String*): FieldMap = FieldMap(
+    fields.map(_ -> Binding.Init).toMap,
+  )
 }

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -52,12 +52,12 @@ case class TyModel(decls: List[TyDecl] = Nil) extends TyElem {
       }
   }
 
-  /** manual refiner */
-  lazy val existRefinerOf: Map[String, Map[String, String]] = Map(
-    "Object" -> Map(
-      "Call" -> "FunctionObject",
-      "Construct" -> "Constructor",
-    ),
+  /** refiner that requires propagation */
+  def getPropRefiner(field: String): Option[List[String]] =
+    propRefinerOf.get(field)
+  lazy val propRefinerOf: Map[String, List[String]] = Map(
+    "Call" -> Nil,
+    "Construct" -> List("Call"),
   )
 
   lazy val normalizedOf: String => Option[(String, FieldMap)] = cached { t =>
@@ -67,7 +67,7 @@ case class TyModel(decls: List[TyDecl] = Nil) extends TyElem {
       fs = ownFieldsOf(t)
       nfm = elems.foldLeft(fm) { (fm, elem) =>
         val f = elem.name
-        fm.update(f, getField(p, f) && fs(f))
+        fm + (f -> (getField(p, f) && fs(f)))
       }
     } yield p -> nfm
   }

--- a/src/main/scala/esmeta/ty/package.scala
+++ b/src/main/scala/esmeta/ty/package.scala
@@ -61,8 +61,8 @@ def ContT(nids: Int*): ValueTy =
   if (nids.isEmpty) BotT
   else ValueTy(cont = Fin(nids.toSet))
 lazy val ObjectT: ValueTy = RecordT("Object")
-lazy val FunctionT: ValueTy = RecordT("FunctionObject")
-lazy val ConstructorT: ValueTy = RecordT("Constructor")
+lazy val FunctionT: ValueTy = RecordT("Object", List("Call"))
+lazy val ConstructorT: ValueTy = RecordT("Object", List("Call", "Construct"))
 lazy val ArrayT: ValueTy = RecordT("Array")
 lazy val TypedArrayT: ValueTy = RecordT("TypedArray")
 lazy val RegExpT: ValueTy = RecordT("RegExp")
@@ -80,6 +80,8 @@ lazy val RealmT: ValueTy = RecordT("RealmRecord")
 lazy val RecordT: ValueTy = ValueTy(record = RecordTy.Top)
 def RecordT(names: Set[String]): ValueTy = ValueTy(record = RecordTy(names))
 def RecordT(names: String*): ValueTy = RecordT(names.toSet)
+def RecordT(name: String, fields: List[String]): ValueTy =
+  ValueTy(record = RecordTy(name, fields))
 def RecordT(name: String, fields: Map[String, ValueTy]): ValueTy =
   ValueTy(record = RecordTy(name, fields))
 def RecordT(name: String, fieldMap: FieldMap): ValueTy =

--- a/src/main/scala/esmeta/ty/util/Parser.scala
+++ b/src/main/scala/esmeta/ty/util/Parser.scala
@@ -187,9 +187,12 @@ trait Parsers extends BasicParsers {
 
   private lazy val singleRecordTy: Parser[RecordTy] = {
     import RecordTy.*
-    lazy val pair = opt(word) ~ opt(fieldMap) ^^ {
-      case k ~ v => (k.getOrElse(""), v.getOrElse(FieldMap.Top))
-    }
+    lazy val pair =
+      "FunctionObject" ^^^ ("Object" -> FieldMap.init("Call")) |
+      "Constructor" ^^^ ("Object" -> FieldMap.init("Call", "Construct")) |
+      opt(word) ~ opt(fieldMap) ^^ {
+        case k ~ v => (k.getOrElse(""), v.getOrElse(FieldMap.Top))
+      }
     "Record[" ~> repsep(pair, "|") <~ "]" ^^ {
       case fs => Elem(fs.toMap)
     } | "Record" ^^^ Top

--- a/src/main/scala/esmeta/ty/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ty/util/Stringifier.scala
@@ -224,9 +224,18 @@ class Stringifier(
           mayOR >> "Throw"
           if (!fm.isTop) app >> " " >> fm
         }
-        if (m.nonEmpty)
+        var preds = Vector[(String, FieldMap)]()
+        for (fm <- m.get("Object")) {
+          if (fm == FieldMap.init("Call"))
+            m -= "Object"
+            preds :+= ("FunctionObject", FieldMap())
+          if (fm == FieldMap.init("Call", "Construct"))
+            m -= "Object"
+            preds :+= ("Constructor", FieldMap())
+        }
+        if (m.nonEmpty || preds.nonEmpty)
           if (prevExists) app >> OR
-          app >> "Record[" >> m.toList.sortBy(_._1) >> "]"
+          app >> "Record[" >> (m.toList ++ preds).sortBy(_._1) >> "]"
         else app
 
   /** AST value types */

--- a/src/test/scala/esmeta/ty/OpTinyTest.scala
+++ b/src/test/scala/esmeta/ty/OpTinyTest.scala
@@ -9,14 +9,18 @@ class OpTinyTest extends TyTest {
     checkEqual("or")(
       (ObjectT || FunctionT) -> ObjectT,
       (ReturnT || AbruptT("break")) -> (ReturnT || BreakT),
+      (FunctionT || FunctionT) -> FunctionT,
       (FunctionT || RecordT("ECMAScriptFunctionObject")) -> FunctionT,
     )
 
     checkEqual("and")(
       (ObjectT && FunctionT) -> FunctionT,
       (AbruptT && ReturnT) -> ReturnT,
+      (FunctionT && FunctionT) -> FunctionT,
       (ConstructorT && RecordT("ECMAScriptFunctionObject")) ->
-      RecordT("ECMAScriptFunctionObject"),
+      RecordT("ECMAScriptFunctionObject", List("Construct")),
+      (FunctionT && RecordT("ProxyExoticObject")) ->
+      RecordT("ProxyExoticObject", List("Call")),
     )
 
     checkEqual("order")(

--- a/src/test/scala/esmeta/ty/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/ty/StringifyTinyTest.scala
@@ -104,6 +104,8 @@ class StringifyTinyTest extends TyTest {
           "R" -> BoolT,
         ),
       ) -> "Record[{ P, Q : Number, R : Boolean, S }]",
+      FunctionT -> "Record[FunctionObject]",
+      ConstructorT -> "Record[Constructor]",
       NilT -> "Nil",
       ListT(NumberT) -> "List[Number]",
       SymbolT -> "Record[Symbol]",


### PR DESCRIPTION
We found a bug in the type checker through the [ecma262 CI](https://github.com/tc39/ecma262/actions/runs/16358715380/job/46222498674) for https://github.com/tc39/ecma262/pull/3653.
This occurs due to the incorrect handling of types for `function object` and `constructor`.
To correctly handle them, it revised the intersection and normalization of record types.