### PR TITLE
Support CI Warning for Newly Introduced Phrases

### DIFF
--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test fuzz inject mutate dump-debugger dump-visualizer"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets -extract:warn-action -extract:warn-action-diff"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets -extract:warn-action"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"

--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test fuzz inject mutate dump-debugger dump-visualizer"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:warn-action -extract:allowed-yets"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets -extract:warn-action -extract:warn-action-diff"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"

--- a/.completion
+++ b/.completion
@@ -14,7 +14,7 @@ _esmeta_completions() {
   cmdList="help extract compile build-cfg tycheck parse eval web test262-test fuzz inject mutate dump-debugger dump-visualizer"
   globalOpt="-silent -error -status -time -test262dir"
   helpOpt=""
-  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets"
+  extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:warn-action -extract:allowed-yets"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
   tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -320,7 +320,7 @@ class Extractor(
 
   // get head contents from parent elements
   private def getHeadContent(parent: Element): String =
-    parent.getFirstChildContent
+    parent.getFirstChildElem.html.unescapeHtml
 
   // extract template name
   private val templatePattern = "_(\\w+)_.*".r

--- a/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
+++ b/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
@@ -28,15 +28,14 @@ object NewPhraseAlert:
         loc = step.loc.getOrElse(???)
         line = elem.startLine + loc.start.line - 1
         endLine = elem.startLine + loc.end.line - 1
-        if (diffLines.contains(line) || diffLines.contains(endLine))
+        interval = (line until endLine + 1).toSet
+        if (interval intersect diffLines).nonEmpty
       } do
         GitHubAction.println(
           tag = "warning",
           file = Some("spec.html"),
           line = Some(line),
           endLine = Some(endLine),
-          col = Some(elem.startCol + loc.start.column - 1),
-          endColumn = Some(elem.startCol + loc.end.column - 1),
           title = Some("Newly Introduced Unkown Step"), // TODO
           message = Some(
             s"""
@@ -52,19 +51,11 @@ object NewPhraseAlert:
         headElem = algo.headElem
         if (langType.ty.isInstanceOf[ty.UnknownTy] &&
         langType.ty.asInstanceOf[ty.UnknownTy].msg.isDefined)
-        // if (!ignoreYetTypes.contains(langType.toString))
         loc = langType.loc.getOrElse(???)
-        line = headElem.startLine + loc.start.line
-        endLine = headElem.startLine + loc.end.line
-        if (
-          // TODO
-          diffLines.contains(line) ||
-          diffLines.contains(line - 1) ||
-          diffLines.contains(line + 1) ||
-          diffLines.contains(endLine) ||
-          diffLines.contains(endLine - 1) ||
-          diffLines.contains(endLine + 1)
-        )
+        line = headElem.startLine + loc.start.line - 1
+        endLine = headElem.startLine + loc.end.line - 1
+        interval = (line until endLine + 1).toSet
+        if (interval intersect diffLines).nonEmpty
       } do
         GitHubAction.println(
           tag = "warning",
@@ -84,8 +75,11 @@ object NewPhraseAlert:
         )
     }
 
+  // NOTE that column numbers might not be accurate
   extension (elem: Element)
+
+    /* start line number of the element (1-base) */
     def startLine: Int = elem.sourceRange.start.lineNumber
-    def startCol: Int = elem.sourceRange.start.columnNumber
+
+    /* end line number of the element (1-base) */
     def endLine: Int = elem.sourceRange.end.lineNumber
-    def endCol: Int = elem.sourceRange.end.columnNumber

--- a/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
+++ b/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
@@ -36,10 +36,10 @@ object NewPhraseAlert:
           file = Some("spec.html"),
           line = Some(line),
           endLine = Some(endLine),
-          title = Some("Newly Introduced Unkown Step"), // TODO
+          title = Some("Newly Introduced Unknown Step"), // TODO
           message = Some(
             s"""
-        | This step cannot be understand by ESMeta.
+        | This step cannot be understood by ESMeta.
         | Type checking body of this algorithm (${algo.name}) will not be performed after this line.""".stripMargin
               .replace('\n', ' ')
               .trim(),
@@ -60,15 +60,15 @@ object NewPhraseAlert:
         GitHubAction.println(
           tag = "warning",
           file = Some("spec.html"),
-          title = Some("Newly Introduced Unkown Type"),
+          title = Some("Newly Introduced Unknown Type"),
           line = Some(line),
           endLine = Some(endLine),
           message = Some(
             s"""
-        | This is a type which ESMeta cannot understand. This will cause following consequences:
-        | 1. This algorithm (${algo.name}) will not be in the initial type check targets.
-        | 2. This algorithm can be type checked when called by another algorithm in the working set, but type (${langType}) will be treated as bottom (⊥).
-        |""".stripMargin
+            | This is a type which ESMeta cannot understand. This will cause the following consequences:
+            | 1. This algorithm (${algo.name}) will not be in the initial type check targets.
+            | 2. This algorithm can be type checked when called by another algorithm in the working set, but type (${langType}) will be treated as bottom (⊥).
+            |""".stripMargin
               .replace('\n', ' ')
               .trim(),
           ),

--- a/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
+++ b/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
@@ -1,0 +1,77 @@
+package esmeta.extractor.util
+
+import esmeta.*
+import esmeta.spec.Spec
+import esmeta.util.*
+import io.circe.*, io.circe.syntax.*, io.circe.parser.*
+import org.jsoup.nodes.Element
+
+object NewPhraseAlert:
+  def warnYets(
+    spec: Spec,
+    ignoreYetSteps: List[String],
+    ignoreYetTypes: List[String],
+  ): Unit =
+    for {
+      algo <- spec.algorithms
+      elem = algo.elem
+    } do {
+
+      val acceptables = ManualInfo.compileRule("inst").keySet ++ ignoreYetSteps
+
+      for {
+        step <- algo.steps
+        if (step.isInstanceOf[lang.YetStep])
+        if (!acceptables.contains(
+          step.toString(detail = true, location = false),
+        ))
+      } do
+        val loc = step.loc.getOrElse(???)
+        GitHubAction.println(
+          tag = "warning",
+          file = Some("spec.html"),
+          line = Some(elem.startLine + loc.start.line - 1),
+          endLine = Some(elem.startLine + loc.end.line - 1),
+          col = Some(elem.startCol + loc.start.column - 1),
+          endColumn = Some(elem.startCol + loc.end.column - 1),
+          title = Some("Newly Introduced Unkown Step"), // TODO
+          message = Some(
+            s"""
+        | This step cannot be understand by ESMeta.
+        | Type checking body of this algorithm (${algo.name}) will not be performed after this line.""".stripMargin
+              .replace('\n', ' ')
+              .trim(),
+          ),
+        )
+
+      for {
+        langType <- (algo.retTy :: algo.head.funcParams.map(_.ty))
+        headElem = algo.headElem
+        if (langType.ty.isInstanceOf[ty.UnknownTy] &&
+        langType.ty.asInstanceOf[ty.UnknownTy].msg.isDefined)
+        if (!ignoreYetTypes.contains(langType.toString))
+      } do
+        val loc = langType.loc.getOrElse(???)
+        GitHubAction.println(
+          tag = "warning",
+          file = Some("spec.html"),
+          line = Some(headElem.startLine + loc.start.line),
+          endLine = Some(headElem.startLine + loc.end.line),
+          title = Some("Newly Introduced Unkown Type"),
+          message = Some(
+            s"""
+        | This is a type which ESMeta cannot understand. This will cause following consequences:
+        | 1. This algorithm (${algo.name}) will not be in the initial type check targets.
+        | 2. This algorithm can be type checked when called by another algorithm in the working set, but type (${langType}) will be treated as bottom (⊥).
+        |""".stripMargin
+              .replace('\n', ' ')
+              .trim(),
+          ),
+        )
+    }
+
+  extension (elem: Element)
+    def startLine: Int = elem.sourceRange.start.lineNumber
+    def startCol: Int = elem.sourceRange.start.columnNumber
+    def endLine: Int = elem.sourceRange.end.lineNumber
+    def endCol: Int = elem.sourceRange.end.columnNumber

--- a/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
+++ b/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
@@ -16,9 +16,7 @@ object NewPhraseAlert:
       elem = algo.elem
     } do {
 
-      val acceptables =
-        ManualInfo.compileRule("inst").keySet // ++ ignoreYetSteps
-
+      val acceptables = ManualInfo.compileRule("inst").keySet
       for {
         step <- algo.steps
         if (step.isInstanceOf[lang.YetStep])
@@ -36,13 +34,15 @@ object NewPhraseAlert:
           file = Some("spec.html"),
           line = Some(line),
           endLine = Some(endLine),
-          title = Some("Newly Introduced Unknown Step"), // TODO
+          title = Some("Newly Introduced Unknown Step"),
           message = Some(
             s"""
-        | This step cannot be understood by ESMeta.
-        | Type checking body of this algorithm (${algo.name}) will not be performed after this line.""".stripMargin
+            | This step cannot be understood by ESMeta.
+            | Type checking body of this algorithm (${algo.name})
+            | will not be performed after this line.
+            |""".stripMargin
               .replace('\n', ' ')
-              .trim(),
+              .trim,
           ),
         )
 
@@ -65,12 +65,14 @@ object NewPhraseAlert:
           endLine = Some(endLine),
           message = Some(
             s"""
-            | This is a type which ESMeta cannot understand. This will cause the following consequences:
+            | This is a type which ESMeta cannot understand.
+            | This will cause the following consequences:
             | 1. This algorithm (${algo.name}) will not be in the initial type check targets.
-            | 2. This algorithm can be type checked when called by another algorithm in the working set, but type (${langType}) will be treated as bottom (⊥).
+            | 2. This algorithm can be type checked when called by another algorithm in the working set,
+            | but type (${langType}) will be treated as bottom (⊥).
             |""".stripMargin
               .replace('\n', ' ')
-              .trim(),
+              .trim,
           ),
         )
     }

--- a/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
+++ b/src/main/scala/esmeta/extractor/util/NewPhraseAlert.scala
@@ -53,14 +53,25 @@ object NewPhraseAlert:
         if (langType.ty.isInstanceOf[ty.UnknownTy] &&
         langType.ty.asInstanceOf[ty.UnknownTy].msg.isDefined)
         // if (!ignoreYetTypes.contains(langType.toString))
+        loc = langType.loc.getOrElse(???)
+        line = headElem.startLine + loc.start.line
+        endLine = headElem.startLine + loc.end.line
+        if (
+          // TODO
+          diffLines.contains(line) ||
+          diffLines.contains(line - 1) ||
+          diffLines.contains(line + 1) ||
+          diffLines.contains(endLine) ||
+          diffLines.contains(endLine - 1) ||
+          diffLines.contains(endLine + 1)
+        )
       } do
-        val loc = langType.loc.getOrElse(???)
         GitHubAction.println(
           tag = "warning",
           file = Some("spec.html"),
-          line = Some(headElem.startLine + loc.start.line),
-          endLine = Some(headElem.startLine + loc.end.line),
           title = Some("Newly Introduced Unkown Type"),
+          line = Some(line),
+          endLine = Some(endLine),
           message = Some(
             s"""
         | This is a type which ESMeta cannot understand. This will cause following consequences:

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -2,6 +2,7 @@ package esmeta.phase
 
 import esmeta.*
 import esmeta.extractor.Extractor
+import esmeta.extractor.util.NewPhraseAlert
 import esmeta.lang.*
 import esmeta.lang.util.ParserForEval.{getParseCount, getCacheCount}
 import esmeta.spec.*
@@ -30,6 +31,12 @@ case object Extract extends Phase[Unit, Spec] {
       println(f"- # of using cached result: $getCacheCount%,d")
     if (config.log) log(spec)
     if (config.strict) checkStrict(spec, config)
+    // TODO
+    //     if (config.warnAction) {
+    //   val s = config.ignoreYetSteps.map(readJson[List[String]]).getOrElse(Nil)
+    //   val t = config.ignoreYetTypes.map(readJson[List[String]]).getOrElse(Nil)
+    //   NewPhraseAlert.warnYets(spec, s, t)
+    // }
     spec
   } else {
     runREPL
@@ -201,6 +208,11 @@ case object Extract extends Phase[Unit, Spec] {
       "turn on strict parsing mode, which makes extractor fail when any 'yet-step' or 'yet-type`. (default: false)",
     ),
     (
+      "warn-action",
+      BoolOption(_.warnAction = _),
+      "print workflow commands to warn novel yet-steps GitHub action ",
+    ),
+    (
       "allowed-yets",
       StrOption((c, s) => c.allowedYets = Some(s)),
       "set a file containing allowed `yet`s (default: none).",
@@ -212,6 +224,7 @@ case object Extract extends Phase[Unit, Spec] {
     var eval: Boolean = false,
     var repl: Boolean = false,
     var strict: Boolean = false,
+    var warnAction: Boolean = false,
     var allowedYets: Option[String] = None,
   )
 }

--- a/src/main/scala/esmeta/spec/Algorithm.scala
+++ b/src/main/scala/esmeta/spec/Algorithm.scala
@@ -16,6 +16,9 @@ case class Algorithm(
   /** HTML elements */
   var elem: Element = Element("emu-alg")
 
+  /** HTML element for head */
+  var headElem: Element = Element("div")
+
   /** check whether it is incomplete */
   lazy val complete: Boolean = incompleteSteps.isEmpty
 

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -177,16 +177,21 @@ trait Parsers extends LangParsers {
   // Algorithms
   // ---------------------------------------------------------------------------
 
+  /* skip newlines around the parser  */
+  private def surroundedBy[A](p: Parser[A]): Parser[A] =
+    val newlinable = "[ \n\t]+".r
+    rep(newlinable) ~> p <~ rep(newlinable)
+
   // abstract operation (AO) heads
   lazy val absOpHeadGen: Parser[Boolean => AbstractOperationHead] = {
-    opt(semanticsKind) ~> name ~ params ~ retTy ^^ {
+    surroundedBy(opt(semanticsKind) ~> name ~ params ~ retTy) ^^ {
       case name ~ params ~ rty => AbstractOperationHead(_, name, params, rty)
     }
   }.named("spec.AbstractOperationHead")
 
   // numeric method heads
   lazy val numMethodHead: Parser[NumericMethodHead] = {
-    (langType <~ "::") ~ name ~ params ~ retTy ^^ {
+    surroundedBy((langType <~ "::") ~ name ~ params ~ retTy) ^^ {
       case t ~ x ~ ps ~ rty => NumericMethodHead(t, x, ps, rty)
     }
   }.named("spec.NumericMethodHead")
@@ -232,7 +237,7 @@ trait Parsers extends LangParsers {
   lazy val sdoHeadGen: Parser[
     Option[SyntaxDirectedOperationHead.Target] => SyntaxDirectedOperationHead,
   ] = {
-    semanticsKind ~ name ~ params ~ retTy ^^ {
+    surroundedBy(semanticsKind ~ name ~ params ~ retTy) ^^ {
       case isStatic ~ x ~ params ~ rty =>
         SyntaxDirectedOperationHead(_, x, isStatic, params, rty)
     }
@@ -240,21 +245,21 @@ trait Parsers extends LangParsers {
 
   // concrete method head generator
   lazy val concMethodHeadGen: Parser[Param => ConcreteMethodHead] = {
-    name ~ params ~ retTy ^^ {
+    surroundedBy(name ~ params ~ retTy) ^^ {
       case name ~ params ~ rty => ConcreteMethodHead(name, _, params, rty)
     }
   }.named("spec.ConcreteMethodHead")
 
   // internal method head generator
   lazy val inMethodHeadGen: Parser[Param => InternalMethodHead] = {
-    ("[[" ~> name <~ "]]") ~ params ~ retTy ^^ {
+    surroundedBy(("[[" ~> name <~ "]]") ~ params ~ retTy) ^^ {
       case name ~ params ~ rty => InternalMethodHead(name, _, params, rty)
     }
   }.named("spec.InternalMethodHead")
 
   // built-in heads
   lazy val builtinHead: Parser[BuiltinHead] = {
-    builtinPath ~ params ~ retTy ^^ {
+    surroundedBy(builtinPath ~ params ~ retTy) ^^ {
       case r ~ params ~ rty => BuiltinHead(r, params, rty)
     }
   }.named("spec.BuiltinHead")

--- a/src/main/scala/esmeta/util/GitHubAction.scala
+++ b/src/main/scala/esmeta/util/GitHubAction.scala
@@ -1,0 +1,30 @@
+package esmeta.util
+
+object GitHubAction:
+
+  /** workflow command for GitHub Actions
+    *
+    * @notes
+    *   1-based line and column numbers
+    */
+  def println(
+    tag: "warning" | "error",
+    file: Option[String] = None,
+    line: Option[Int] = None,
+    endLine: Option[Int] = None,
+    col: Option[Int] = None,
+    endColumn: Option[Int] = None,
+    title: Option[String] = None,
+    message: Option[String] = None,
+  ): Unit =
+    val args = List(
+      "file" -> file,
+      "line" -> line,
+      "endLine" -> endLine,
+      "col" -> col,
+      "endColumn" -> endColumn,
+      "title" -> title,
+    ).flatMap { case (param, opt) => opt.map(param -> _) }
+      .map { case (param, value) => s"$param=$value" }
+      .mkString(",")
+    Predef.println(s"::$tag ${args}::${message.getOrElse("")}")

--- a/src/main/scala/esmeta/util/HtmlUtils.scala
+++ b/src/main/scala/esmeta/util/HtmlUtils.scala
@@ -4,6 +4,7 @@ import esmeta.*
 import org.apache.commons.text.StringEscapeUtils
 import org.jsoup.*
 import org.jsoup.nodes.*
+import org.jsoup.parser.*
 import org.jsoup.select.*
 
 /** HTML utilities */
@@ -23,7 +24,8 @@ object HtmlUtils {
 
     /** parse HTML string */
     def toHtml: Document =
-      val document = Jsoup.parse(str)
+      val parser = Parser.htmlParser().setTrackPosition(true)
+      val document = Jsoup.parse(str, parser)
       document.outputSettings.prettyPrint(false)
       document
   }


### PR DESCRIPTION
This pull request depends on #298.

It introduces the `-extract:warn-action option`, which resolves issue #289 by flagging any newly added “Yet” phrases (for steps and types) in the GitHub Actions workflow of [tc39/ecma262](https://github.com/tc39/ecma262).

The option accepts a JSON array of line numbers through standard input and emits a **warning** for each matching phrase on those lines. (We plan to write [documentation](https://github.com/es-meta/docs) explaining the consequences and impact of newly introduced “Yet” phrases on `esmeta tycheck`.)

Example — Check for lines 1, 2, and 3:
```
$ esmeta extract -extract:warn-action <<< "[1,2,3]"
```

To enable automatic warnings in a pull-request check, pass the lines added in the diff.
See the YAML snippet below for an example configuration. To see how the warning messages appear, check out [this example PR](https://github.com/ku-plrg/ecma262/pull/1/files).

```yaml
name: ESMeta New 'Yet' Phrases Detection

on: [pull_request]

jobs:
  esmeta-new-phrases:
    runs-on: ubuntu-latest

    env:
      ESMETA_HOME: vendor/esmeta

    steps:
      - name: Checkout
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
      - name: Setup JDK
        uses: actions/setup-java@v4
        with:
          distribution: temurin
          java-version: 17
      - name: Setup SBT
        uses: sbt/setup-sbt@v1
      - name: download esmeta
        run: |
          mkdir -p "${ESMETA_HOME}"
          cd "${ESMETA_HOME}"
          git init
          git remote add origin https://github.com/es-meta/esmeta.git
          git fetch --depth 1 origin a9b543cc0ae8d467f9b67d03a48aeb2494cb57bf ;
          git checkout FETCH_HEAD
      - name: build esmeta
        run: |
          cd "${ESMETA_HOME}"
          sbt assembly
      - name: link
        run: |
          rmdir "${ESMETA_HOME}"/ecma262 \
            && ln -s "$(pwd)" "${ESMETA_HOME}"/ecma262

      - id: collect
        name: List added line numbers
        shell: bash
        env:
          FILE_PATH: spec.html
          BASE_SHA: ${{ github.event.pull_request.base.sha }}
          HEAD_SHA: ${{ github.sha }}
        run: |
          # zero-context diff, limited to the file we care about
          added_lines=$(git diff -U0 --no-color "${BASE_SHA}" "${HEAD_SHA}" -- "${FILE_PATH}" |
          # keep only the hunk headers (the @@ lines)
          awk '
            # Example header: @@ -158,0 +159,2 @@
            /^@@/ {
              # Extract “+<start>[,<count>]” part
              match($0, /\+([0-9]+)(,([0-9]+))?/, a)
              start = a[1]
              count = (a[3] == "" ? 1 : a[3])
              # Print every line number in the added range
              for (i = 0; i < count; i++) print start + i
            }
          ')

          # Join line numbers with comma or space (whichever format you need)
          added_joined=$(echo "$added_lines" | paste -sd "," -)
          added_lines_json="[$added_joined]"

          # Set it as an output value
          echo "added_lines=$added_lines_json" >> "$GITHUB_OUTPUT"

      - name: check newly introduces phrases
        run: |
          "${ESMETA_HOME}"/bin/esmeta extract \
            -status \
            -extract:warn-action <<< ${{ steps.collect.outputs.added_lines }}

```
