### PR TITLE
Remove `uninit` value

### DIFF
--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -884,7 +884,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
             TypeGuard(guard)
           }
         case EExists(Field(x: Local, EStr(field))) =>
-          val binding = Binding.Init
+          val binding = Binding.Exist
           for {
             lv <- transfer(x)
             given AbsState <- get
@@ -1607,7 +1607,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       field: String,
       positive: Boolean,
     )(using np: NodePoint[_]): Updater =
-      refineField(x, field, Binding.Init, positive)
+      refineField(x, field, Binding.Exist, positive)
 
     /** refine types with `typeof` constraints */
     def refineType(
@@ -1726,7 +1726,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           val refined = vs(1).ty.str.getSingle match
             case One(f) =>
               ValueTy(
-                record = ObjectT.record.update(f, Binding.Init, refine = true),
+                record = ObjectT.record.update(f, Binding.Exist, refine = true),
               )
             case _ => ObjectT
           val prov = Provenance(func)

--- a/src/main/scala/esmeta/error/InterpreterError.scala
+++ b/src/main/scala/esmeta/error/InterpreterError.scala
@@ -108,11 +108,6 @@ case class UnknownFunc(name: String)
 case class WrongStringRef(str: String, field: Value)
   extends InterpreterError(s"wrong access of string reference: $str.$field")
 
-// missing cases
-case object UncheckedUnint extends InterpreterError(s"unchecked uninit")
-case class UncheckedAbrupt(value: Value) // TODO remove
-  extends InterpreterError(s"unchecked abrupt completion: $value")
-
 // assertion failed
 case class AssertionFail(expr: Expr)
   extends InterpreterError(s"assertion failure: $expr")

--- a/src/main/scala/esmeta/state/State.scala
+++ b/src/main/scala/esmeta/state/State.scala
@@ -168,10 +168,7 @@ case class State(
       // recursively get detailed types for completion records
       val recDetail = tname == "CompletionRecord"
       val fm = FieldMap(
-        map.map {
-          case (k, Uninit)   => k -> Binding.Uninit
-          case (k, v: Value) => k -> Binding(typeOf(v, detail = recDetail))
-        }.toMap,
+        map.map { (k, v) => k -> Binding(typeOf(v, detail = recDetail)) }.toMap,
       )
       RecordT(tname, fm)
     case RecordObj(tname, _) => RecordT(tname)

--- a/src/main/scala/esmeta/state/Uninit.scala
+++ b/src/main/scala/esmeta/state/Uninit.scala
@@ -1,4 +1,0 @@
-package esmeta.state
-
-/** IR values */
-object Uninit extends StateElem

--- a/src/main/scala/esmeta/state/package.scala
+++ b/src/main/scala/esmeta/state/package.scala
@@ -195,4 +195,3 @@ def toStringHelper(x: Double, radix: Int = 10): String = {
 // -----------------------------------------------------------------------------
 type Undef = Undef.type
 type Null = Null.type
-type Uninit = Uninit.type

--- a/src/main/scala/esmeta/state/util/Stringifier.scala
+++ b/src/main/scala/esmeta/state/util/Stringifier.scala
@@ -32,7 +32,6 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case elem: Obj         => objRule(app, elem)
       case elem: Value       => valueRule(app, elem)
       case elem: RefTarget   => refTargetRule(app, elem)
-      case elem: Uninit      => uninitRule(app, elem)
       case elem: Feature     => featureRule(app, elem)
       case elem: CallPath    => callPathRule(app, elem)
 
@@ -85,7 +84,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "Map " >> map.map { case (k, v) => (k.toString, v) }
       case RecordObj(tname, map) =>
         app >> "Record"
-        given Rule[Iterable[(String, Value | Uninit)]] =
+        given Rule[Iterable[(String, Value)]] =
           sortedMapRule("{", "}", " : ")
         if (tname.nonEmpty) app >> "[" >> tname >> "]"
         app >> " " >> map.map { case (k, v) => (s"\"$k\"", v) }
@@ -170,9 +169,6 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case FieldTarget(base, Str(inlineField(str))) => app >> base >> "." >> str
       case FieldTarget(base, field) => app >> base >> "[" >> field >> "]"
     }
-
-  // uninit
-  given uninitRule: Rule[Uninit] = (app, _) => app >> "uninit"
 
   // syntax directed operation information
   given featureRule: Rule[Feature] = (app, feature) =>

--- a/src/main/scala/esmeta/state/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/state/util/UnitWalker.scala
@@ -16,7 +16,6 @@ trait UnitWalker extends BasicUnitWalker {
     case elem: Obj         => walk(elem)
     case elem: Value       => walk(elem)
     case elem: RefTarget   => walk(elem)
-    case elem: Uninit      => walk(elem)
     case elem: Feature     => walk(elem)
     case elem: CallPath    => walk(elem)
 
@@ -75,9 +74,6 @@ trait UnitWalker extends BasicUnitWalker {
 
   // ir id
   def walk(id: Var): Unit = {}
-
-  // uninit value
-  def walk(uninit: Uninit): Unit = {}
 
   // feature
   def walk(feature: Feature): Unit = {}

--- a/src/main/scala/esmeta/ty/FieldMap.scala
+++ b/src/main/scala/esmeta/ty/FieldMap.scala
@@ -66,13 +66,13 @@ case class FieldMap(map: Map[String, Binding])
   /** field map containment check */
   def contains(record: RecordObj, heap: Heap): Boolean =
     var fields = map.keySet
-    fields.forall { f => this(f).contains(record.get(Str(f)), heap) }
+    fields.forall { f => this(f).contains(record.get(f), heap) }
 }
 
 object FieldMap extends Parser.From(Parser.fieldMap) {
   lazy val Top: FieldMap = FieldMap()
   def apply(fields: (String, Binding)*): FieldMap = FieldMap(fields.toMap)
   def init(fields: String*): FieldMap = FieldMap(
-    fields.map(_ -> Binding.Init).toMap,
+    fields.map(_ -> Binding.Exist).toMap,
   )
 }

--- a/src/main/scala/esmeta/ty/RecordTy.scala
+++ b/src/main/scala/esmeta/ty/RecordTy.scala
@@ -234,7 +234,7 @@ object RecordTy extends Parser.From(Parser.recordTy) {
     refine: Boolean,
   ): Map[String, FieldMap] = {
     val (t, fm) = pair
-    val existCheck = bind == Binding.Init
+    val existCheck = bind == Binding.Exist
     val refined = bind && (if (refine) get(pair, field) else getField(t, field))
     if (refined.isBottom)
       // TODO check why this is needed and remove it if possible
@@ -244,7 +244,7 @@ object RecordTy extends Parser.From(Parser.recordTy) {
       var newFM = fm + (field -> refined)
       getPropRefiner(field) match
         case Some(fs) =>
-          for (f <- fs) newFM += f -> (get(pair, f) && Binding.Init)
+          for (f <- fs) newFM += f -> (get(pair, f) && Binding.Exist)
           Map(normalize(t -> newFM))
         case None =>
           val set = (

--- a/src/main/scala/esmeta/ty/TyModel.scala
+++ b/src/main/scala/esmeta/ty/TyModel.scala
@@ -174,9 +174,9 @@ case class TyModel(decls: List[TyDecl] = Nil) extends TyElem {
       .fold(Map())(_.elems.collect {
         case AbsMethod(m) => m -> Binding.Bot
         case ConMethod(m, opt, tgt) =>
-          m -> Binding(CloT(tgt.getOrElse(s"Record[$t].$m")), opt, opt)
+          m -> Binding(CloT(tgt.getOrElse(s"Record[$t].$m")), opt)
         case Field(f, opt, typeStr) =>
-          f -> Binding(ValueTy.from(typeStr), opt, opt)
+          f -> Binding(ValueTy.from(typeStr), opt)
       })
       .toMap
   }

--- a/src/main/scala/esmeta/ty/util/Parser.scala
+++ b/src/main/scala/esmeta/ty/util/Parser.scala
@@ -43,19 +43,15 @@ trait Parsers extends BasicParsers {
 
   // field type map
   given fieldMap: Parser[FieldMap] = {
-    lazy val field = word ~ opt(":" ~> binding) ^^ {
-      case f ~ v => f -> v.getOrElse(Binding.Init)
-    }
+    lazy val field = word ~ binding ^^ { case f ~ b => f -> b }
     "{" ~> rep(field <~ opt(",")) <~ "}" ^^ { case ts => FieldMap(ts.toMap) }
   }.named("ty.FieldMap")
 
   // field bindings
   given binding: Parser[Binding] = {
-    val uninit = "U" ^^^ true | "" ^^^ false
-    val absent = "A" ^^^ true | "" ^^^ false
-    opt("[" ~> uninit ~ absent <~ "]") ~ valueTy ^^ {
-      case None ~ v        => Binding(v, false, false)
-      case Some(u ~ a) ~ v => Binding(v, u, a)
+    opt(opt("?") ~ (":" ~> valueTy)) ^^ {
+      case None        => Binding.Exist
+      case Some(o ~ v) => Binding(v, o.isDefined)
     }
   }.named("ty.Binding")
 

--- a/src/main/scala/esmeta/ty/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/ty/util/UnitWalker.scala
@@ -57,7 +57,6 @@ trait UnitWalker extends BasicUnitWalker {
   /** field binding */
   def walk(binding: Binding): Unit =
     walk(binding.value)
-    walk(binding.uninit)
     walk(binding.absent)
 
   /** types */

--- a/src/main/scala/esmeta/ty/util/Walker.scala
+++ b/src/main/scala/esmeta/ty/util/Walker.scala
@@ -57,7 +57,6 @@ trait Walker extends BasicWalker {
   /** field binding */
   def walk(binding: Binding): Binding = Binding(
     walk(binding.value),
-    walk(binding.uninit),
     walk(binding.absent),
   )
 

--- a/src/test/scala/esmeta/state/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/state/StringifyTinyTest.scala
@@ -164,7 +164,6 @@ class StringifyTinyTest extends StateTest {
       Bool(false) -> "false",
       Undef -> "undefined",
       Null -> "null",
-      Uninit -> "uninit",
       Enum("empty") -> "~empty~",
       CodeUnit(97) -> "97cu",
     )

--- a/src/test/scala/esmeta/ty/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/ty/StringifyTinyTest.scala
@@ -66,12 +66,8 @@ class StringifyTinyTest extends TyTest {
       |}""".stripMargin,
       fieldMap2 -> """{
       |  p
-      |  q : [U] Boolean
-      |}""".stripMargin,
-      fieldMap3 -> """{
-      |  p
-      |  q : [A] Boolean
-      |  r : [UA] Null
+      |  q: Boolean
+      |  r?: Undefined
       |}""".stripMargin,
     )
 
@@ -79,6 +75,7 @@ class StringifyTinyTest extends TyTest {
       AnyT -> "Any",
       CompT -> "Completion",
       AbruptT -> "Abrupt",
+      AbruptT("return", "throw") -> "Abrupt[return, throw]",
       NormalT(NumberT) -> "Normal[Number]",
       MapT -> "Map",
       MapT(StrT, RecordT("Binding")) -> "Map[String -> Record[Binding]]",
@@ -94,7 +91,7 @@ class StringifyTinyTest extends TyTest {
       RecordT("Cat") -> "Record[Cat]",
       RecordT("Cat", "Dog") -> "Record[Cat | Dog]",
       RecordT("Object", Map("PrivateElements" -> NilT)) ->
-      "Record[Object { PrivateElements : Nil }]",
+      "Record[Object { PrivateElements: Nil }]",
       RecordT(
         "",
         Map(
@@ -103,7 +100,7 @@ class StringifyTinyTest extends TyTest {
           "Q" -> NumberT,
           "R" -> BoolT,
         ),
-      ) -> "Record[{ P, Q : Number, R : Boolean, S }]",
+      ) -> "Record[{ P, Q: Number, R: Boolean, S }]",
       FunctionT -> "Record[FunctionObject]",
       ConstructorT -> "Record[Constructor]",
       NilT -> "Nil",

--- a/src/test/scala/esmeta/ty/TyTest.scala
+++ b/src/test/scala/esmeta/ty/TyTest.scala
@@ -30,14 +30,10 @@ trait TyTest extends ESMetaTest {
 
   // field type map
   val fieldMap0 = FieldMap()
-  val fieldMap1 = FieldMap("p" -> Binding(AnyT, false, false))
+  val fieldMap1 = FieldMap("p" -> Binding(AnyT, false))
   val fieldMap2 = FieldMap(
-    "p" -> Binding(AnyT, false, false),
-    "q" -> Binding(BoolT, true, false),
-  )
-  val fieldMap3 = FieldMap(
-    "p" -> Binding(AnyT, false, false),
-    "q" -> Binding(BoolT, false, true),
-    "r" -> Binding(NullT, true, true),
+    "p" -> Binding(AnyT, false),
+    "q" -> Binding(BoolT, false),
+    "r" -> Binding(UndefT, true),
   )
 }


### PR DESCRIPTION
Instead of using the `uninit` value for not-yet-initialized fields for records, we initialize fields with `undefined` as described [Object Internal Methods and Internal Slots](https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots) in ECMA-262:

> Unless specified otherwise, the initial value of an internal slot is the value **undefined**.

While it describes the initial value only for internal slots of objects, we apply this interpretation to fields of any records. Therefore, this PR updates the `contains` check for field types as follows:
```scala
 def contains(v: Option[Value], heap: Heap): Boolean = v match
    case Some(Undef)        => true // Undef represents uninitialized value
    case Some(value: Value) => this.value.contains(value, heap)
    case None               => this.absent
}
```