### PR TITLE
Add type modeling for each typed array case

### DIFF
--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -438,6 +438,20 @@ type TypedArray extends ExoticObject {
   ByteLength: Int[0+] | Enum[~auto~];
 }
 
+// https://tc39.es/ecma262/#table-the-typedarray-constructors
+type Int8Array extends TypedArray { TypedArrayName: String["Int8Array"]; }
+type Uint8Array extends TypedArray { TypedArrayName: String["Uint8Array"]; }
+type Uint8ClampedArray extends TypedArray { TypedArrayName: String["Uint8ClampedArray"]; }
+type Int16Array extends TypedArray { TypedArrayName: String["Int16Array"]; }
+type Uint16Array extends TypedArray { TypedArrayName: String["Uint16Array"]; }
+type Int32Array extends TypedArray { TypedArrayName: String["Int32Array"]; }
+type Uint32Array extends TypedArray { TypedArrayName: String["Uint32Array"]; }
+type BigInt64Array extends TypedArray { TypedArrayName: String["BigInt64Array"]; }
+type BigUint64Array extends TypedArray { TypedArrayName: String["BigUint64Array"]; }
+type Float16Array extends TypedArray { TypedArrayName: String["Float16Array"]; }
+type Float32Array extends TypedArray { TypedArrayName: String["Float32Array"]; }
+type Float64Array extends TypedArray { TypedArrayName: String["Float64Array"]; }
+
 // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
 type ModuleNamespaceExoticObject extends ExoticObject {
   def GetPrototypeOf;

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -16,4 +16,4 @@
   - yet: 191
   - unknown: 658
 - tables: 99
-- type model: 95
+- type model: 107


### PR DESCRIPTION
The current type modeling only represents `TypedArray`.

However, we need to add each separate case of `TypedArray` (e.g., `Uint8Array`) because https://github.com/tc39/ecma262/pull/3655 uses `Uint8Array` type and causes [errors in the type check](https://github.com/tc39/ecma262/actions/runs/16356191963/job/46215053136?pr=3655) due to the lack of its type modeling.

We have verified that this PR resolves the issue.