### PR TITLE
Add EMPTY type to PromiseResult

### DIFF
--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -823,10 +823,20 @@ type AsyncFromSyncIterator extends OrdinaryObject {
 // https://tc39.es/ecma262/#sec-properties-of-promise-instances
 type Promise extends OrdinaryObject {
   PromiseState: Enum[~pending~, ~fulfilled~, ~rejected~];
-  PromiseResult: ESValue;
+  PromiseResult: ESValue | Enum[~empty~];
   PromiseFulfillReactions: List[Record[PromiseReactionRecord]];
   PromiseRejectReactions: List[Record[PromiseReactionRecord]];
   PromiseIsHandled: Boolean;
+}
+
+type PendingPromise extends Promise {
+  PromiseState: Enum[~pending~];
+  PromiseResult: Enum[~empty~];
+}
+
+type SettledPromise extends Promise {
+  PromiseState: Enum[~fulfilled~, ~rejected~];
+  PromiseResult: ESValue;
 }
 
 // https://tc39.es/ecma262/#sec-properties-of-generator-instances

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -16,4 +16,4 @@
   - yet: 191
   - unknown: 658
 - tables: 99
-- type model: 107
+- type model: 109


### PR DESCRIPTION
The `PromisResult` Type was updated in [tc39/ecma262#3491](https://github.com/tc39/ecma262/pull/3491), but this change has not yet been incorporated into esmeta.

As a result, the following **type mismatch** occurs, even though the `Object` structurally satisfies the `Promise` type
```
[ParamTypeMismatch] Call[35542] argument assignment to first parameter _promise_ when Call[35542] function call from INTRINSICS.yet:PromiseRejectFunction (step 7, 8:24(412)-8:58(446)) to RejectPromise
- expected: Record[Promise]
- actual  : Record[Object { DefineOwnProperty: Clo["Record[OrdinaryObject].DefineOwnProperty"], Delete: Clo["Record[OrdinaryObject].Delete"], Extensible: Boolean, Get: Clo["Record[OrdinaryObject].Get"], GetOwnProperty: Clo["Record[OrdinaryObject].GetOwnProperty"], GetPrototypeOf: Clo["Record[OrdinaryObject].GetPrototypeOf"], HasProperty: Clo["Record[OrdinaryObject].HasProperty"], IsExtensible: Clo["Record[OrdinaryObject].IsExtensible"], OwnPropertyKeys: Clo["Record[OrdinaryObject].OwnPropertyKeys"], PreventExtensions: Clo["Record[OrdinaryObject].PreventExtensions"], PrivateElements: Nil, PromiseFulfillReactions: List[Record[PromiseReactionRecord { Capability: Record[PromiseCapabilityRecord], Handler: Enum[~empty~], Type: Enum[~fulfill~] }]], PromiseIsHandled: Boolean, PromiseRejectReactions: List[Record[PromiseReactionRecord { Capability: Record[PromiseCapabilityRecord], Handler: Record[JobCallbackRecord], Type: Enum[~reject~] }]], PromiseResult: Enum[~empty~], PromiseState: Enum[~pending~], Prototype: Record[OrdinaryObject], Set: Clo["Record[OrdinaryObject].Set"], SetPrototypeOf: Clo["Record[OrdinaryObject].SetPrototypeOf"], __MAP__: Map }]
```

This PR updates esmeta to incorporate and reflect that change.