### PR TITLE
Fix esmeta.lang to support idempotency of extraction

### DIFF
--- a/src/main/resources/manuals/algos/RunJobs.algo
+++ b/src/main/resources/manuals/algos/RunJobs.algo
@@ -23,7 +23,7 @@
       1. Push _newContext_ onto the execution context stack; _newContext_ is now the running execution context.
       1. Let _job_ be _nextPending_.[[Job]].
       1. Let _result_ be _job_().
-      1. If _result_ is an abrupt completion,
+      1. If _result_ is an abrupt completion, then
         1. If _errors_ is *undefined*, set _errors_ to « _result_.[[Value]] ».
         1. Otherwise, append _result_.[[Value]] to _errors_.
   </emu-alg>

--- a/src/main/resources/manuals/rule.json
+++ b/src/main/resources/manuals/rule.json
@@ -104,7 +104,6 @@
     "Store the individual bytes of _rawBytesModified_ into _block_, starting at _block_[_byteIndex_].": "{ let idx = 0 while (< idx (sizeof rawBytesModified)) { block[(+ byteIndex idx)] = rawBytesModified[idx] idx = (+ idx 1) } }",
     "Store the individual bytes of _rawBytes_ into _block_, starting at _block_[_byteIndex_].": "{ let idx = 0 while (< idx (sizeof rawBytes)) { block[(+ byteIndex idx)] = rawBytes[idx] idx = (+ idx 1) } }",
     "Store the individual bytes of _replacementBytes_ into _block_, starting at _block_[_byteIndexInBuffer_].": "{ let idx = 0 while (< idx (sizeof replacementBytes)) { block[(+ byteIndexInBuffer idx)] = replacementBytes[idx] idx = (+ idx 1) } }",
-    "set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.": "isLittleEndian = @AGENT_RECORD.LittleEndian",
-    "return the Number value that corresponds to _intValue_.": "return ([number] intValue)"
+    "set _isLittleEndian_ to the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.": "isLittleEndian = @AGENT_RECORD.LittleEndian"
   }
 }

--- a/src/main/resources/manuals/rule.json
+++ b/src/main/resources/manuals/rule.json
@@ -52,8 +52,6 @@
     "If only one argument was passed, return _to_.": "if (= (sizeof ArgumentsList) 0) return to",
     "If the binding for _N_ in _envRec_ is an uninitialized binding, throw a *ReferenceError* exception.": "if (! envRec.__MAP__[N].__INITIALIZED__) { call __errObj__ = clo<\"__NEW_ERROR_OBJ__\">(\"%ReferenceError.prototype%\") call __comp__ = clo<\"ThrowCompletion\">(__errObj__) return __comp__ }",
     "If the execution context stack is empty, return *null*.": "if (= (sizeof @EXECUTION_STACK) 0) return null",
-    "Insert _d_ as the first element of _functionsToInitialize_.": "push d > functionsToInitialize",
-    "Insert _fn_ as the first element of _functionNames_.": "push fn > functionNames",
     "Let _X_ be _O_'s own property whose key is _P_.": "let X = O.__MAP__[P]",
     "Let _agentRecord_ be the surrounding agent's Agent Record.": "let agentRecord = @AGENT_RECORD",
     "Let _args_ be the List of arguments that was passed to this function by [[Call]] or [[Construct]].": "let args = ArgumentsList",

--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -1,6 +1,7 @@
 [
   "AsyncFromSyncIteratorContinuation",
   "AsyncGeneratorYield",
+  "BigIntBitwiseOp",
   "ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody",
   "CompareTypedArrayElements",
   "DoWait",

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -1099,6 +1099,8 @@ GetIterator
 GetIteratorDirect
 GetIteratorFlattenable
 GetIteratorFromMethod
+GetMatchIndexPair
+GetMatchString
 GetMethod
 GetModuleNamespace
 GetNamedTimeZoneEpochNanoseconds

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -466,8 +466,10 @@ CharacterClassEscape[6,0].CompileToCharSet
 CharacterClassEscape[7,0].MayContainStrings
 CharacterClass[0,0].CompileCharacterClass
 CharacterClass[1,0].CompileCharacterClass
+CharacterEscape[2,0].CharacterValue
 CharacterEscape[3,0].CharacterValue
 ClassAtomNoDash[0,0].IsCharacterClass
+ClassAtom[0,0].CharacterValue
 ClassAtom[0,0].IsCharacterClass
 ClassBody[0,0].AllPrivateIdentifiersValid
 ClassContents[0,0].MayContainStrings
@@ -515,7 +517,9 @@ ClassElement[5,0].ComputedPropertyContains
 ClassElement[5,0].IsStatic
 ClassElement[5,0].PrivateBoundIdentifiers
 ClassElement[5,0].PropName
+ClassEscape[0,0].CharacterValue
 ClassEscape[0,0].IsCharacterClass
+ClassEscape[1,0].CharacterValue
 ClassEscape[1,0].IsCharacterClass
 ClassEscape[2,0].IsCharacterClass
 ClassEscape[3,0].IsCharacterClass
@@ -528,6 +532,7 @@ ClassExpression[0,1].HasName
 ClassExpression[0,1].IsFunctionDefinition
 ClassIntersection[0,0].MayContainStrings
 ClassIntersection[1,0].MayContainStrings
+ClassSetCharacter[3,0].CharacterValue
 ClassSetOperand[0,0].CompileToCharSet
 ClassSetOperand[1,0].CompileToCharSet
 ClassSetOperand[2,0].CompileToCharSet

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -758,11 +758,13 @@ ExportDeclaration[3,0].ExportedNames
 ExportDeclaration[3,0].LexicallyScopedDeclarations
 ExportDeclaration[3,0].ModuleRequests
 ExportDeclaration[4,0].Evaluation
+ExportDeclaration[4,0].ExportEntries
 ExportDeclaration[4,0].ExportedBindings
 ExportDeclaration[4,0].ExportedNames
 ExportDeclaration[4,0].LexicallyScopedDeclarations
 ExportDeclaration[4,0].ModuleRequests
 ExportDeclaration[5,0].Evaluation
+ExportDeclaration[5,0].ExportEntries
 ExportDeclaration[5,0].ExportedBindings
 ExportDeclaration[5,0].ExportedNames
 ExportDeclaration[5,0].LexicallyScopedDeclarations
@@ -780,8 +782,10 @@ ExportFromClause[0,0].ExportedNames
 ExportFromClause[1,0].ExportEntriesForModule
 ExportFromClause[1,0].ExportedNames
 ExportFromClause[2,0].ExportedNames
+ExportSpecifier[0,0].ExportEntriesForModule
 ExportSpecifier[0,0].ExportedBindings
 ExportSpecifier[0,0].ExportedNames
+ExportSpecifier[1,0].ExportEntriesForModule
 ExportSpecifier[1,0].ExportedBindings
 ExportSpecifier[1,0].ExportedNames
 ExportSpecifier[1,0].ReferencedBindings
@@ -1113,6 +1117,7 @@ GetNamedTimeZoneOffsetNanoseconds
 GetNewTarget
 GetOwnPropertyKeys
 GetPromiseResolve
+GetSetRecord
 GetStringIndex
 GetSuperBase
 GetSuperConstructor
@@ -2419,6 +2424,12 @@ Statement[9,0].LabelledEvaluation
 StrDecimalLiteral[2,0].StringNumericValue
 StrNumericLiteral[1,0].StringNumericValue
 StrUnsignedDecimalLiteral[0,0].StringNumericValue
+StrUnsignedDecimalLiteral[1,0].StringNumericValue
+StrUnsignedDecimalLiteral[1,1].StringNumericValue
+StrUnsignedDecimalLiteral[1,2].StringNumericValue
+StrUnsignedDecimalLiteral[1,3].StringNumericValue
+StrUnsignedDecimalLiteral[2,0].StringNumericValue
+StrUnsignedDecimalLiteral[2,1].StringNumericValue
 StrUnsignedDecimalLiteral[3,0].StringNumericValue
 StrUnsignedDecimalLiteral[3,1].StringNumericValue
 StringCreate

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -9,7 +9,7 @@
   - complete: 2494 (86.99%)
   - equals: 2528 (88.18%)
 - algorithm steps: 22044
-  - complete: 21309 (96.67%)
+  - complete: 21312 (96.68%)
 - types: 8260
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,9 +7,9 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2483 (86.61%)
-  - equals: 2524 (88.04%)
+  - equals: 2612 (91.11%)
 - algorithm steps: 22044
-  - complete: 21285 (96.56%)
+  - complete: 21290 (96.58%)
 - types: 8260
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2645 (92.26%)
+  - equals: 2655 (92.61%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,9 +7,9 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2477 (86.40%)
-  - equals: 1440 (50.23%)
-- algorithm steps: 22043
-  - complete: 21274 (96.51%)
+  - equals: 1594 (55.60%)
+- algorithm steps: 22044
+  - complete: 21276 (96.52%)
 - types: 8260
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2638 (92.01%)
+  - equals: 2643 (92.19%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -5,16 +5,14 @@
     - numeric string: 16
     - syntactic: 198
   - extended productions for web: 29
-- algorithms: 2867 (86.33%)
-  - complete: 2475
-  - incomplete: 392
-- algorithm steps: 22043 (96.48%)
-  - complete: 21268
-  - incomplete: 775
-- types: 7586 (97.48%)
-  - known: 7395
-  - yet: 191
-  - unknown: 674
+- algorithms: 2867
+  - complete: 2477 (86.40%)
+  - equals: 1440 (50.23%)
+- algorithm steps: 22043
+  - complete: 21274 (96.51%)
+- types: 8260
+  - known: 7395 (89.53%)
+  - yet: 191 (2.31%)
 - tables: 99
 - type model: 109
 - intrinsics: 101

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2608 (90.97%)
+  - equals: 2526 (88.11%)
 - algorithm steps: 22044
   - complete: 21309 (96.67%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2622 (91.45%)
+  - equals: 2638 (92.01%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2483 (86.61%)
-  - equals: 2612 (91.11%)
+  - equals: 2610 (91.04%)
 - algorithm steps: 22044
   - complete: 21290 (96.58%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2477 (86.40%)
-  - equals: 1594 (55.60%)
+  - equals: 2490 (86.85%)
 - algorithm steps: 22044
   - complete: 21276 (96.52%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2528 (88.18%)
+  - equals: 2529 (88.21%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2526 (88.11%)
+  - equals: 2528 (88.18%)
 - algorithm steps: 22044
   - complete: 21309 (96.67%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -6,10 +6,10 @@
     - syntactic: 198
   - extended productions for web: 29
 - algorithms: 2867
-  - complete: 2477 (86.40%)
-  - equals: 2490 (86.85%)
+  - complete: 2483 (86.61%)
+  - equals: 2524 (88.04%)
 - algorithm steps: 22044
-  - complete: 21276 (96.52%)
+  - complete: 21285 (96.56%)
 - types: 8260
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2529 (88.21%)
+  - equals: 2622 (91.45%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -7,7 +7,7 @@
   - extended productions for web: 29
 - algorithms: 2867
   - complete: 2494 (86.99%)
-  - equals: 2643 (92.19%)
+  - equals: 2645 (92.26%)
 - algorithm steps: 22044
   - complete: 21312 (96.68%)
 - types: 8260

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -6,10 +6,10 @@
     - syntactic: 198
   - extended productions for web: 29
 - algorithms: 2867
-  - complete: 2483 (86.61%)
-  - equals: 2610 (91.04%)
+  - complete: 2494 (86.99%)
+  - equals: 2608 (90.97%)
 - algorithm steps: 22044
-  - complete: 21290 (96.58%)
+  - complete: 21309 (96.67%)
 - types: 8260
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -706,7 +706,7 @@ class Compiler(
             )
             xExpr
           case _ => raise(s"invalid math operation: $expr")
-      case ConversionExpression(op, expr) =>
+      case ConversionExpression(op, expr, _) =>
         import ConversionExpressionOperator.*
         op match
           case ToApproxNumber => EConvert(COp.ToApproxNumber, compile(fb, expr))

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -820,7 +820,7 @@ class Compiler(
     case ThisLiteral(_)          => ENAME_THIS
     case ThisParseNodeLiteral(_) => ENAME_THIS
     case NewTargetLiteral()      => ENAME_NEW_TARGET
-    case HexLiteral(hex, name, _) =>
+    case HexLiteral(hex, _, _, name) =>
       if (name.isDefined) ECodeUnit(hex.toChar) else EMath(hex)
     case CodeLiteral(code) => EStr(code)
     case GrammarSymbolLiteral(name, flags) =>

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -637,7 +637,7 @@ class Compiler(
         fb.addInst(ICall(x, fexpr, bExpr :: args.map(compile(fb, _))))
         xExpr
       case InvokeSyntaxDirectedOperationExpression(base, name, args, _, _) =>
-        // XXX BUG in Static Semancis: CharacterValue
+        // XXX BUG in Static Semantics: CharacterValue
         val baseExpr = compile(fb, base)
         val (x, xExpr) = fb.newTIdWithExpr
         fb.addInst(ISdoCall(x, baseExpr, name, args.map(compile(fb, _))))

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -795,7 +795,7 @@ class Compiler(
 
   /** compile literals */
   def compile(fb: FuncBuilder, lit: Literal): Expr = lit match {
-    case ThisLiteral()      => ENAME_THIS
+    case ThisLiteral(_)     => ENAME_THIS
     case NewTargetLiteral() => ENAME_NEW_TARGET
     case HexLiteral(hex, name) =>
       if (name.isDefined) ECodeUnit(hex.toChar) else EMath(hex)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -746,7 +746,7 @@ class Compiler(
         EClo(name, captured.map(compile))
       case XRefExpression(
             XRefExpressionOperator.Algo | XRefExpressionOperator.Definition |
-            XRefExpressionOperator.OrdinaryObjectInternalMethod,
+            XRefExpressionOperator.InternalMethod,
             id,
           ) =>
         EClo(normalize(normalize(spec.getAlgoById(id).head.fname)), Nil)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -539,7 +539,12 @@ class Compiler(
       case ComponentProperty(name, _) => Field(baseRef, EStr(name))
       case BindingProperty(expr) =>
         Field(toStrRef(baseRef, INNER_MAP), compile(fb, expr))
-      case IndexProperty(index, _)   => Field(baseRef, compile(fb, index))
+      case IndexProperty(index) => Field(baseRef, compile(fb, index))
+      case PositionalElementProperty(isFirst) =>
+        val index =
+          if (isFirst) zero
+          else dec(ESizeOf(ERef(compile(fb, base))))
+        Field(baseRef, index)
       case IntrinsicProperty(intr)   => toIntrinsic(baseRef, intr)
       case NonterminalProperty(name) => Field(baseRef, EStr(name))
 

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -532,7 +532,7 @@ class Compiler(
     })
 
   def compile(fb: FuncBuilder, ref: PropertyReference): Field =
-    val PropertyReference(base, prop) = ref
+    val PropertyReference(base, prop, _) = ref
     val baseRef = compile(fb, base)
     prop match
       case FieldProperty(name, _)     => Field(baseRef, EStr(name))

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -252,6 +252,8 @@ class Compiler(
       fb.addInst(IPush(compile(fb, expr), ERef(compile(fb, ref)), false))
     case PrependStep(expr, ref) =>
       fb.addInst(IPush(compile(fb, expr), ERef(compile(fb, ref)), true))
+    case InsertStep(expr, ref) =>
+      fb.addInst(IPush(compile(fb, expr), ERef(compile(fb, ref)), true))
     case AddStep(expr, ref) =>
       // TODO: current IR does not support a set data structure.
       // AddStep represents an element addition to a set.
@@ -734,7 +736,11 @@ class Compiler(
           prefix = prefix,
         )
         EClo(name, captured.map(compile))
-      case XRefExpression(XRefExpressionOperator.Algo(_), id) =>
+      case XRefExpression(
+            XRefExpressionOperator.Algo | XRefExpressionOperator.Definition |
+            XRefExpressionOperator.OrdinaryObjectInternalMethod,
+            id,
+          ) =>
         EClo(normalize(normalize(spec.getAlgoById(id).head.fname)), Nil)
       case XRefExpression(XRefExpressionOperator.ParamLength, id) =>
         EMath(spec.getAlgoById(id).head.originalParams.length)

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -602,7 +602,7 @@ class Compiler(
         xExpr
       case expr: GetItemsExpression =>
         EYet(expr.toString(true, false))
-      case InvokeAbstractOperationExpression(name, args) =>
+      case InvokeAbstractOperationExpression(name, args, _) =>
         val as = args.map(compile(fb, _))
         if (simpleOps contains name) simpleOps(name)(fb, as)
         else if (shorthands contains name) compileShorthand(fb, name, as)
@@ -620,7 +620,7 @@ class Compiler(
         val (x, xExpr) = fb.newTIdWithExpr
         fb.addInst(ICall(x, ERef(compile(fb, ref)), args.map(compile(fb, _))))
         xExpr
-      case InvokeMethodExpression(ref, args) =>
+      case InvokeMethodExpression(ref, args, _) =>
         val Field(base, method) = compile(fb, ref)
         val (b, bExpr) =
           if (base.isPure) (base, ERef(base))
@@ -629,7 +629,7 @@ class Compiler(
         val (x, xExpr) = fb.newTIdWithExpr
         fb.addInst(ICall(x, fexpr, bExpr :: args.map(compile(fb, _))))
         xExpr
-      case InvokeSyntaxDirectedOperationExpression(base, name, args, _) =>
+      case InvokeSyntaxDirectedOperationExpression(base, name, args, _, _) =>
         // XXX BUG in Static Semancis: CharacterValue
         val baseExpr = compile(fb, base)
         val (x, xExpr) = fb.newTIdWithExpr
@@ -734,7 +734,7 @@ class Compiler(
           prefix = prefix,
         )
         EClo(name, captured.map(compile))
-      case XRefExpression(XRefExpressionOperator.Algo, id) =>
+      case XRefExpression(XRefExpressionOperator.Algo(_), id) =>
         EClo(normalize(normalize(spec.getAlgoById(id).head.fname)), Nil)
       case XRefExpression(XRefExpressionOperator.ParamLength, id) =>
         EMath(spec.getAlgoById(id).head.originalParams.length)
@@ -1116,7 +1116,7 @@ class Compiler(
     var found = false
     val walker = new LangUnitWalker {
       override def walk(invoke: InvokeExpression): Unit = invoke match
-        case InvokeAbstractOperationExpression(name, _)
+        case InvokeAbstractOperationExpression(name, _, _)
             if simpleOps contains name =>
         case _ => found = true
     }

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -533,11 +533,11 @@ class Compiler(
     val PropertyReference(base, prop) = ref
     val baseRef = compile(fb, base)
     prop match
-      case FieldProperty(name)        => Field(baseRef, EStr(name))
+      case FieldProperty(name, _)     => Field(baseRef, EStr(name))
       case ComponentProperty(name, _) => Field(baseRef, EStr(name))
       case BindingProperty(expr) =>
         Field(toStrRef(baseRef, INNER_MAP), compile(fb, expr))
-      case IndexProperty(index)      => Field(baseRef, compile(fb, index))
+      case IndexProperty(index, _)   => Field(baseRef, compile(fb, index))
       case IntrinsicProperty(intr)   => toIntrinsic(baseRef, intr)
       case NonterminalProperty(name) => Field(baseRef, EStr(name))
 
@@ -870,7 +870,7 @@ class Compiler(
         val e = compile(fb, expr)
         val c = tys.map(t => ETypeCheck(e, compile(t))).reduce[Expr](or(_, _))
         if (neg) not(c) else c
-      case HasFieldCondition(ref, neg, field) =>
+      case HasFieldCondition(ref, neg, field, _) =>
         val e = exists(toRef(compile(fb, ref), compile(fb, field)))
         if (neg) not(e) else e
       case HasBindingCondition(ref, neg, binding) =>

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -634,7 +634,7 @@ class Compiler(
         xExpr
       case ReturnIfAbruptExpression(expr, check) =>
         returnIfAbrupt(fb, compile(fb, expr), check, false)
-      case ListExpression(entries) =>
+      case ListExpression(entries, _) =>
         EList(entries.map(compile(fb, _)))
       case IntListExpression(from, fInc, to, tInc, asc) =>
         val (f, fExpr) = fb.newTIdWithExpr

--- a/src/main/scala/esmeta/lang/Condition.scala
+++ b/src/main/scala/esmeta/lang/Condition.scala
@@ -27,26 +27,16 @@ case class HasFieldCondition(
   ref: Reference,
   negation: Boolean,
   field: Expression,
-  form: HasFieldConditionForm,
+  form: HasFieldConditionOperator,
 ) extends Condition
 
-enum HasFieldConditionForm {
+enum HasFieldConditionOperator:
   case Field, InternalSlot, InternalMethod
 
-  override def toString: String = this match {
+  override def toString: String = this match
     case Field          => "field"
     case InternalSlot   => "internal slot"
     case InternalMethod => "internal method"
-  }
-}
-
-object HasFieldConditionForm {
-  def fromString(str: String): HasFieldConditionForm = str match {
-    case "internal method" => InternalMethod
-    case "internal slot"   => InternalSlot
-    case _                 => Field
-  }
-}
 
 // binding inclusion conditions
 case class HasBindingCondition(

--- a/src/main/scala/esmeta/lang/Condition.scala
+++ b/src/main/scala/esmeta/lang/Condition.scala
@@ -27,7 +27,26 @@ case class HasFieldCondition(
   ref: Reference,
   negation: Boolean,
   field: Expression,
+  form: HasFieldConditionForm,
 ) extends Condition
+
+enum HasFieldConditionForm {
+  case Field, InternalSlot, InternalMethod
+
+  override def toString: String = this match {
+    case Field          => "field"
+    case InternalSlot   => "internal slot"
+    case InternalMethod => "internal method"
+  }
+}
+
+object HasFieldConditionForm {
+  def fromString(str: String): HasFieldConditionForm = str match {
+    case "internal method" => InternalMethod
+    case "internal slot"   => InternalSlot
+    case _                 => Field
+  }
+}
 
 // binding inclusion conditions
 case class HasBindingCondition(

--- a/src/main/scala/esmeta/lang/Condition.scala
+++ b/src/main/scala/esmeta/lang/Condition.scala
@@ -79,6 +79,7 @@ case class InclusiveIntervalCondition(
   negation: Boolean,
   from: Expression,
   to: Expression,
+  isTextForm: Boolean,
 ) extends Condition
 
 // `contiains` conditions

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -23,7 +23,7 @@ case class RecordExpression(
   form: RecordExpressionForm,
 ) extends Expression
 enum RecordExpressionForm:
-  case Normal(hasArticle: Boolean)
+  case SyntaxLiteral(prefix: Option[String])
   case Text
   case TextWithNoElement(prefix: String, postfix: Option[String])
 
@@ -49,6 +49,7 @@ case class NumberOfExpression(
   name: String,
   pre: Option[String],
   expr: Expression,
+  exclude: Option[Expression],
 ) extends Expression
 
 // intrinsic expressions
@@ -68,17 +69,18 @@ case class GetItemsExpression(nt: Expression, expr: Expression)
   extends Expression
 
 // list expressions
-case class ListExpression(entries: List[Expression], verbose: Boolean)
-  extends Expression
-
-// integer list expressions
-case class IntListExpression(
-  from: CalcExpression,
-  isFromInclusive: Boolean,
-  to: CalcExpression,
-  isToInclusive: Boolean,
-  isAscending: Boolean,
-) extends Expression
+case class ListExpression(form: ListExpressionForm) extends Expression
+enum ListExpressionForm:
+  case LiteralSyntax(entries: List[Expression])
+  case SoleElement(entry: Expression)
+  case EmptyList(isNewUsed: Boolean, typeDesc: Option[String])
+  case IntRange(
+    from: CalcExpression,
+    isFromInclusive: Boolean,
+    to: CalcExpression,
+    isToInclusive: Boolean,
+    isAscending: Boolean,
+  )
 
 // emu-xref expressions
 case class XRefExpression(kind: XRefExpressionOperator, id: String)
@@ -141,7 +143,7 @@ case class InvokeSyntaxDirectedOperationExpression(
   args: List[Expression],
   prefix: Option[
     String,
-  ], // Some("the result of performing" | "the result of" | "the")
+  ], // `the result of performing`, `the result of` or `the`
   tag: HtmlTag,
 ) extends InvokeExpression
 
@@ -263,7 +265,7 @@ object Literal extends Parser.From(Parser.literal)
 
 // `this` literals
 case class ThisLiteral(
-  article: Boolean = false,
+  hasArticle: Boolean = false,
 ) extends Literal
 
 case class ThisParseNodeLiteral(desc: Option[NonterminalLiteral])
@@ -293,7 +295,7 @@ case class NonterminalLiteral(
   ordinal: Option[Int],
   name: String,
   flags: List[String],
-  article: Boolean = false,
+  hasArticle: Boolean = false,
 ) extends Literal
 
 // enum literals
@@ -302,7 +304,7 @@ case class EnumLiteral(name: String) extends Literal
 // string literals
 case class StringLiteral(
   s: String,
-  form: StringLiteralForm = StringLiteralForm.Normal,
+  form: StringLiteralForm = StringLiteralForm.SyntaxLiteral,
 ) extends Literal
 
 // Normal: "{{ string value }}"
@@ -310,7 +312,7 @@ case class StringLiteral(
 // EmptyUnicode: "the empty sequence of Unicode code points"
 // Code: <code>{{ string value }}</code>
 enum StringLiteralForm {
-  case Normal, EmptyString, EmptyUnicode, Code
+  case SyntaxLiteral, EmptyString, EmptyUnicode, Code
 }
 
 // field literals

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -294,8 +294,10 @@ case class StringLiteral(
 // Normal: "{{ string value }}"
 // EmptyString: "the empty String"
 // EmptyUnicode: "the empty sequence of Unicode code points"
+// Code: <code>{{ string value }}</code>
+// TypedArrayCtor: the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this {{ str }} constructor
 enum StringLiteralForm {
-  case Normal, EmptyString, EmptyUnicode
+  case Normal, EmptyString, EmptyUnicode, Code, TypedArrayCtor
 }
 
 // field literals

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -63,7 +63,8 @@ case class GetItemsExpression(nt: Expression, expr: Expression)
   extends Expression
 
 // list expressions
-case class ListExpression(entries: List[Expression]) extends Expression
+case class ListExpression(entries: List[Expression], verbose: Boolean)
+  extends Expression
 
 // integer list expressions
 case class IntListExpression(

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -86,8 +86,7 @@ enum ListExpressionForm:
 case class XRefExpression(kind: XRefExpressionOperator, id: String)
   extends Expression
 enum XRefExpressionOperator extends LangElem:
-  case Algo, Definition, OrdinaryObjectInternalMethod, InternalSlots,
-  ParamLength
+  case Algo, Definition, InternalMethod, InternalSlots, ParamLength
 
 // the sole element expressions
 case class SoleElementExpression(list: Expression) extends Expression

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -80,7 +80,9 @@ case class IntListExpression(
 case class XRefExpression(kind: XRefExpressionOperator, id: String)
   extends Expression
 enum XRefExpressionOperator extends LangElem:
-  case Algo, InternalSlots, ParamLength
+  case Algo(desc: String)
+  case InternalSlots
+  case ParamLength
 
 // the sole element expressions
 case class SoleElementExpression(list: Expression) extends Expression
@@ -97,10 +99,16 @@ case class YetExpression(str: String, block: Option[Block]) extends Expression
 // -----------------------------------------------------------------------------
 sealed trait InvokeExpression extends Expression
 
+enum HtmlTag:
+  case None
+  case BeforeCall(c: String)
+  case AfterCall(c: String)
+
 // abstract operation (AO) invocation expressions
 case class InvokeAbstractOperationExpression(
   name: String,
   args: List[Expression],
+  tag: HtmlTag,
 ) extends InvokeExpression
 
 // numeric method invocation expression
@@ -120,6 +128,7 @@ case class InvokeAbstractClosureExpression(
 case class InvokeMethodExpression(
   ref: PropertyReference,
   args: List[Expression],
+  tag: HtmlTag,
 ) extends InvokeExpression
 
 // syntax-directed operation (SDO) invocation expressions
@@ -127,8 +136,10 @@ case class InvokeSyntaxDirectedOperationExpression(
   base: Expression,
   name: String,
   args: List[Expression],
-  // Some("the result of performing" | "the result of" | "the")
-  prefix: Option[String],
+  prefix: Option[
+    String,
+  ], // Some("the result of performing" | "the result of" | "the")
+  tag: HtmlTag,
 ) extends InvokeExpression
 
 // -----------------------------------------------------------------------------

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -20,6 +20,7 @@ case class ListCopyExpression(expr: Expression) extends Expression
 case class RecordExpression(
   tname: String,
   fields: List[(FieldLiteral, Expression)],
+  article: Boolean = false,
 ) extends Expression
 
 // `length of <string>` expressions
@@ -126,6 +127,8 @@ case class InvokeSyntaxDirectedOperationExpression(
   base: Expression,
   name: String,
   args: List[Expression],
+  // Some("the result of performing" | "the result of" | "the")
+  prefix: Option[String],
 ) extends InvokeExpression
 
 // -----------------------------------------------------------------------------
@@ -246,14 +249,21 @@ object Literal extends Parser.From(Parser.literal)
 
 // `this` literals
 case class ThisLiteral(
-  desc: Option[String | NonterminalLiteral],
+  article: Boolean = false,
 ) extends Literal
+
+case class ThisParseNodeLiteral(desc: Option[NonterminalLiteral])
+  extends Literal
 
 // NewTarget literals
 case class NewTargetLiteral() extends Literal
 
 // code unit literals with hexadecimal numbers
-case class HexLiteral(hex: Int, name: Option[String]) extends Literal
+case class HexLiteral(
+  hex: Int,
+  name: Option[String],
+  hasCodeUnitDescription: Boolean,
+) extends Literal
 
 // code literals
 case class CodeLiteral(code: String) extends Literal
@@ -269,13 +279,24 @@ case class NonterminalLiteral(
   ordinal: Option[Int],
   name: String,
   flags: List[String],
+  article: Boolean = false,
 ) extends Literal
 
 // enum literals
 case class EnumLiteral(name: String) extends Literal
 
 // string literals
-case class StringLiteral(s: String) extends Literal
+case class StringLiteral(
+  s: String,
+  form: StringLiteralForm = StringLiteralForm.Normal,
+) extends Literal
+
+// Normal: "{{ string value }}"
+// EmptyString: "the empty String"
+// EmptyUnicode: "the empty sequence of Unicode code points"
+enum StringLiteralForm {
+  case Normal, EmptyString, EmptyUnicode
+}
 
 // field literals
 case class FieldLiteral(name: String) extends Literal

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -244,7 +244,9 @@ sealed trait Literal extends CalcExpression
 object Literal extends Parser.From(Parser.literal)
 
 // `this` literals
-case class ThisLiteral() extends Literal
+case class ThisLiteral(
+  desc: Option[String | NonterminalLiteral],
+) extends Literal
 
 // NewTarget literals
 case class NewTargetLiteral() extends Literal

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -282,8 +282,9 @@ case class NewTargetLiteral() extends Literal
 // code unit literals with hexadecimal numbers
 case class HexLiteral(
   hex: Int,
-  name: Option[String],
   hasCodeUnitDescription: Boolean,
+  isUnicodePrefix: Boolean,
+  name: Option[String],
 ) extends Literal
 
 // code literals

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -20,8 +20,12 @@ case class ListCopyExpression(expr: Expression) extends Expression
 case class RecordExpression(
   tname: String,
   fields: List[(FieldLiteral, Expression)],
-  article: Boolean = false,
+  form: RecordExpressionForm,
 ) extends Expression
+enum RecordExpressionForm:
+  case Normal(hasArticle: Boolean)
+  case Text
+  case TextWithNoElement(prefix: String, postfix: Option[String])
 
 // `length of <string>` expressions
 case class LengthExpression(expr: Expression) extends Expression
@@ -80,9 +84,8 @@ case class IntListExpression(
 case class XRefExpression(kind: XRefExpressionOperator, id: String)
   extends Expression
 enum XRefExpressionOperator extends LangElem:
-  case Algo(desc: String)
-  case InternalSlots
-  case ParamLength
+  case Algo, Definition, OrdinaryObjectInternalMethod, InternalSlots,
+  ParamLength
 
 // the sole element expressions
 case class SoleElementExpression(list: Expression) extends Expression
@@ -306,9 +309,8 @@ case class StringLiteral(
 // EmptyString: "the empty String"
 // EmptyUnicode: "the empty sequence of Unicode code points"
 // Code: <code>{{ string value }}</code>
-// TypedArrayCtor: the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this {{ str }} constructor
 enum StringLiteralForm {
-  case Normal, EmptyString, EmptyUnicode, Code, TypedArrayCtor
+  case Normal, EmptyString, EmptyUnicode, Code
 }
 
 // field literals

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -307,9 +307,8 @@ case class StringLiteral(s: String, form: StringLiteralForm) extends Literal
 // EmptyString: "the empty String"
 // EmptyUnicode: "the empty sequence of Unicode code points"
 // Code: <code>{{ string value }}</code>
-enum StringLiteralForm {
+enum StringLiteralForm:
   case SyntaxLiteral, EmptyString, EmptyUnicode, Code
-}
 
 // field literals
 case class FieldLiteral(name: String) extends Literal

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -205,9 +205,15 @@ enum UnaryExpressionOperator extends LangElem:
 case class ConversionExpression(
   op: ConversionExpressionOperator,
   expr: Expression,
+  form: ConversionExpressionForm,
 ) extends CalcExpression
 enum ConversionExpressionOperator extends LangElem:
   case ToApproxNumber, ToNumber, ToBigInt, ToMath
+enum ConversionExpressionForm:
+  case SyntaxLiteral
+  // e.g. the {{ op }} value of {{ expr }}", rounded to ...
+  // `the`: article, `of`: pre, `rounded to ...`: post
+  case Text(article: String, pre: String, post: Option[String])
 
 // -----------------------------------------------------------------------------
 // clamp expressions

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -301,10 +301,7 @@ case class NonterminalLiteral(
 case class EnumLiteral(name: String) extends Literal
 
 // string literals
-case class StringLiteral(
-  s: String,
-  form: StringLiteralForm = StringLiteralForm.SyntaxLiteral,
-) extends Literal
+case class StringLiteral(s: String, form: StringLiteralForm) extends Literal
 
 // Normal: "{{ string value }}"
 // EmptyString: "the empty String"

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -34,7 +34,20 @@ sealed trait Property extends Syntax
 object Property extends Parser.From(Parser.prop)
 
 // field property
-case class FieldProperty(name: String) extends Property
+case class FieldProperty(
+  name: String,
+  form: FieldPropertyForm = FieldPropertyForm.Dot,
+) extends Property
+
+// Dot: "." ~> "[[" ~> word <~ "]]" ^^ { FieldProperty(_) }
+// Attribute: ("the value of" ~> variable <~ "'s") ~ ("[[" ~> word <~ "]]" ~ "attribute")
+// Value: (variable <~ "'s") ~ ("[[" ~> word <~ "]]") <~ "value"
+// StrictBinding: ref ~ ("is" ^^^ false | "is not" ^^^ true) <~ "a strict binding"
+// IntrinsicObject: (variable <~ "'s intrinsic object named") ~ variable
+// InitCond: ref ~ ("has been" ^^^ false | "has not" ~ opt("yet") ~ "been" ^^^ true) <~ "initialized"
+enum FieldPropertyForm {
+  case Dot, Attribute, Value, StrictBinding, IntrinsicObject, InitCond
+}
 
 // component property
 case class ComponentProperty(name: String, form: ComponentPropertyForm)
@@ -51,7 +64,8 @@ enum ComponentPropertyForm {
 case class BindingProperty(binding: Expression) extends Property
 
 // index property
-case class IndexProperty(index: Expression) extends Property
+case class IndexProperty(index: Expression, isTextForm: Boolean = false)
+  extends Property
 
 // intrinsic property
 case class IntrinsicProperty(intrinsic: Intrinsic) extends Property

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -37,7 +37,15 @@ object Property extends Parser.From(Parser.prop)
 case class FieldProperty(name: String) extends Property
 
 // component property
-case class ComponentProperty(name: String) extends Property
+case class ComponentProperty(name: String, form: ComponentPropertyForm)
+  extends Property
+
+// Dot: Something.Property
+// Apostrophe: Something's Property
+// Text: the Property of Something
+enum ComponentPropertyForm {
+  case Dot, Apostrophe, Text
+}
 
 // binding property
 case class BindingProperty(binding: Expression) extends Property

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -22,7 +22,11 @@ case class CurrentRealmRecord() extends Reference
 case class ActiveFunctionObject() extends Reference
 
 // references to property
-case class PropertyReference(base: Reference, prop: Property) extends Reference
+case class PropertyReference(
+  base: Reference,
+  prop: Property,
+  prefix: Option[String] = None,
+) extends Reference
 
 // references to agent record
 case class AgentRecord() extends Reference

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -22,7 +22,10 @@ case class CurrentRealmRecord() extends Reference
 case class ActiveFunctionObject() extends Reference
 
 // references to property
-case class PropertyReference(base: Reference, prop: Property) extends Reference
+case class PropertyReference(
+  base: Reference,
+  prop: Property,
+) extends Reference
 
 // references to agent record
 case class AgentRecord() extends Reference
@@ -39,15 +42,11 @@ case class FieldProperty(
   form: FieldPropertyForm = FieldPropertyForm.Dot,
 ) extends Property
 
-// Dot: "." ~> "[[" ~> word <~ "]]" ^^ { FieldProperty(_) }
-// Attribute: ("the value of" ~> variable <~ "'s") ~ ("[[" ~> word <~ "]]" ~ "attribute")
-// Value: (variable <~ "'s") ~ ("[[" ~> word <~ "]]") <~ "value"
-// StrictBinding: ref ~ ("is" ^^^ false | "is not" ^^^ true) <~ "a strict binding"
-// IntrinsicObject: (variable <~ "'s intrinsic object named") ~ variable
-// InitCond: ref ~ ("has been" ^^^ false | "has not" ~ opt("yet") ~ "been" ^^^ true) <~ "initialized"
-enum FieldPropertyForm {
-  case Dot, Attribute, Value, StrictBinding, IntrinsicObject, InitCond
-}
+// Dot: base.[[ field ]]
+// Value: {{ base }}'s [[ {{ field }} ]] value
+// Attribute: the value of {{ base }}'s {{ field }} attribute
+enum FieldPropertyForm:
+  case Dot, Value, Attribute
 
 // component property
 case class ComponentProperty(name: String, form: ComponentPropertyForm)
@@ -56,9 +55,9 @@ case class ComponentProperty(name: String, form: ComponentPropertyForm)
 // Dot: Something.Property
 // Apostrophe: Something's Property
 // Text: the Property of Something
-enum ComponentPropertyForm {
-  case Dot, Apostrophe, Text
-}
+enum ComponentPropertyForm:
+  case Dot, Apostrophe
+  case Text(desc: Option[String])
 
 // binding property
 case class BindingProperty(binding: Expression) extends Property

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -22,10 +22,7 @@ case class CurrentRealmRecord() extends Reference
 case class ActiveFunctionObject() extends Reference
 
 // references to property
-case class PropertyReference(
-  base: Reference,
-  prop: Property,
-) extends Reference
+case class PropertyReference(base: Reference, prop: Property) extends Reference
 
 // references to agent record
 case class AgentRecord() extends Reference
@@ -37,10 +34,7 @@ sealed trait Property extends Syntax
 object Property extends Parser.From(Parser.prop)
 
 // field property
-case class FieldProperty(
-  name: String,
-  form: FieldPropertyForm = FieldPropertyForm.Dot,
-) extends Property
+case class FieldProperty(name: String, form: FieldPropertyForm) extends Property
 
 // Dot: base.[[ field ]]
 // Value: {{ base }}'s [[ {{ field }} ]] value

--- a/src/main/scala/esmeta/lang/Reference.scala
+++ b/src/main/scala/esmeta/lang/Reference.scala
@@ -64,8 +64,10 @@ enum ComponentPropertyForm {
 case class BindingProperty(binding: Expression) extends Property
 
 // index property
-case class IndexProperty(index: Expression, isTextForm: Boolean = false)
-  extends Property
+case class IndexProperty(index: Expression) extends Property
+
+// positional element property (first, last)
+case class PositionalElementProperty(isFirst: Boolean) extends Property
 
 // intrinsic property
 case class IntrinsicProperty(intrinsic: Intrinsic) extends Property

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -4,11 +4,15 @@ import esmeta.lang.util.*
 
 // metalanguage steps
 sealed trait Step extends Syntax {
-  var endingChar = "."
-  lazy val isNextUpper = endingChar == ".";
+  var endingChar = ""
+  lazy val isNextLowercase = endingChar == ";";
 
   var prefix = ""
   var postfix = ""
+
+  lazy val endString =
+    val space = if (postfix.isEmpty) "" else " "
+    prefix + endingChar + space + postfix
 
   /** check whether it is complete */
   def complete: Boolean = this match

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -7,6 +7,9 @@ sealed trait Step extends Syntax {
   var endingChar = "." // "." or ";"
   lazy val isNextUpper = endingChar == ".";
 
+  var prefix = ""
+  var postfix = ""
+
   /** check whether it is complete */
   def complete: Boolean = this match
     case _: YetStep            => false

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -4,6 +4,8 @@ import esmeta.lang.util.*
 
 // metalanguage steps
 sealed trait Step extends Syntax {
+  var endingChar = "." // "." or ";"
+  lazy val isNextUpper = endingChar == ".";
 
   /** check whether it is complete */
   def complete: Boolean = this match
@@ -92,7 +94,6 @@ object IfStep:
   case class ElseConfig(
     newLine: Boolean = true,
     keyword: String = "else", // "else" or "otherwise"
-    isKeywordUpper: Boolean = true,
     comma: Boolean = true,
   )
 

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -4,7 +4,7 @@ import esmeta.lang.util.*
 
 // metalanguage steps
 sealed trait Step extends Syntax {
-  var endingChar = "." // "." or ";"
+  var endingChar = "."
   lazy val isNextUpper = endingChar == ".";
 
   var prefix = ""
@@ -49,6 +49,9 @@ case class AppendStep(elem: Expression, ref: Reference) extends Step
 
 // prepend steps
 case class PrependStep(elem: Expression, ref: Reference) extends Step
+
+// insert steps
+case class InsertStep(elem: Expression, ref: Reference) extends Step
 
 // add steps
 case class AddStep(elem: Expression, ref: Reference) extends Step

--- a/src/main/scala/esmeta/lang/Step.scala
+++ b/src/main/scala/esmeta/lang/Step.scala
@@ -92,6 +92,7 @@ object IfStep:
   case class ElseConfig(
     newLine: Boolean = true,
     keyword: String = "else", // "else" or "otherwise"
+    isKeywordUpper: Boolean = true,
     comma: Boolean = true,
   )
 

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -275,10 +275,11 @@ class CaseCollector extends UnitWalker {
         }
       case _: NewTargetLiteral =>
         s"NewTarget"
-      case HexLiteral(hex, name, codeunit) =>
-        val prefix = if (codeunit) "the code unit " else ""
-        val desc = name.fold("")(" (" + _ + ")")
-        f"${prefix}0x$hex%04X$desc"
+      case HexLiteral(hex, unicode, codeunit, name) =>
+        val codeUnitStr = if (codeunit) "the code unit " else ""
+        val prefixStr = if (unicode) "U+" else "0x"
+        val nameStr = name.fold("")(" (" + _ + ")")
+        f"$codeUnitStr$prefixStr$hex%04X$nameStr"
       case CodeLiteral(code) =>
         s"`{{ str }}`"
       case GrammarSymbolLiteral(name, flags) =>

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -223,14 +223,14 @@ class CaseCollector extends UnitWalker {
             "the running execution context"
           case _: SecondExecutionContext =>
             "the second to top element of the execution context stack"
-          case PropertyReference(base, nt: NonterminalProperty) =>
+          case PropertyReference(base, nt: NonterminalProperty, _) =>
             "the | nt | of {{ ref }}"
-          case PropertyReference(base, bp: BindingProperty) =>
+          case PropertyReference(base, bp: BindingProperty, _) =>
             "the binding for {{ expr }} in {{ ref }}"
-          case PropertyReference(base, PositionalElementProperty(isFirst)) =>
+          case PropertyReference(base, PositionalElementProperty(isFirst), _) =>
             val pos = if (isFirst) "first" else "last"
             s"the $pos element of {{ ref }}"
-          case PropertyReference(base, cp: ComponentProperty) =>
+          case PropertyReference(base, cp: ComponentProperty, _) =>
             import ComponentPropertyForm.*
             cp.form match
               case Dot        => "{{ ref }}.{{ str }}"
@@ -239,7 +239,7 @@ class CaseCollector extends UnitWalker {
                 desc match
                   case Some(d) => s"the {{ str }} $d of {{ ref }}"
                   case None    => s"the {{ str }} of {{ ref }}"
-          case PropertyReference(base, fp: FieldProperty) =>
+          case PropertyReference(base, fp: FieldProperty, _) =>
             fp.form match
               case FieldPropertyForm.Dot =>
                 "{{ ref }}.[[ {{ str }} ]]"
@@ -247,8 +247,9 @@ class CaseCollector extends UnitWalker {
                 "{{ ref }}'s [[ {{ str }} ]] value"
               case FieldPropertyForm.Attribute =>
                 "the value of {{ ref }}'s [[ {{ str }} ]] attribute"
-          case PropertyReference(base, prop) =>
-            "{{ ref }} {{ prop }}"
+          case PropertyReference(base, prop, pre) =>
+            val prefix = pre.fold("")(_ + " ")
+            s"$prefix{{ ref }} {{ prop }}"
           case AgentRecord() =>
             "the Agent Record of the surrounding agent"
         }

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -150,7 +150,7 @@ class CaseCollector extends UnitWalker {
 
   override def walk(expr: Expression): Unit = {
     val add = getAdd(exprs, expr)
-    import ConversionExpressionOperator.*
+    import ConversionExpressionForm.*
     add(expr match {
       case StringConcatExpression(exprs) =>
         "the string-concatenation of {{ expr }}*"
@@ -254,12 +254,11 @@ class CaseCollector extends UnitWalker {
         }
       case MathFuncExpression(op, args) =>
         s"$op({{ expr }}*)"
-      case ConversionExpression(ToApproxNumber, expr) =>
-        s"an implementation-approximated Number value representing {{ expr }}"
-      case ConversionExpression(o, e: (CalcExpression | InvokeExpression)) =>
-        s"$o({{ expr }})"
-      case ConversionExpression(op, expr) =>
-        s"the $op value of {{ expr }}"
+      case ConversionExpression(op, expr, SyntaxLiteral) =>
+        s"$op({{ expr }})"
+      case ConversionExpression(op, expr, Text(a, pre, post)) =>
+        val postStr = post.fold("")(" " + _)
+        s"$a $op value $pre {{expr}}$postStr"
       case ExponentiationExpression(base, power) =>
         s"{{ expr }} <sup>{{ expr }}</sup>"
       case BinaryExpression(left, op, right) =>

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -381,7 +381,8 @@ class CaseCollector extends UnitWalker {
           case SoleElement(e) =>
             "a List whose sole element is {{ expr }}"
           case EmptyList(isNewUsed, typeDesc) =>
-            if (isNewUsed) "a new empty List" else s"an empty List of $typeDesc"
+            if (isNewUsed) "a new empty List"
+            else s"an empty List of ${typeDesc.get}"
           case IntRange(from, isFromInc, to, isToInc, isInc) =>
             val from = if (isFromInc) "inclusive" else "exclusive"
             val to = if (isToInc) "inclusive" else "exclusive"

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -167,8 +167,9 @@ class CaseCollector extends UnitWalker {
           case Text =>
             "a new {{ ty }} whose {{ field }} is {{ expr }}"
           case TextWithNoElement(prefix, postfix) =>
-            val p = postfix.fold("")(" " + _)
-            s"$prefix {{ ty }}$p"
+            val pre = " " + prefix
+            val post = postfix.fold("")(" " + _)
+            s"$pre{{ ty }}$post"
         }
       case LengthExpression(expr) =>
         "the length of {{ expr }}"
@@ -185,7 +186,8 @@ class CaseCollector extends UnitWalker {
       case NumberOfExpression(name, pre, expr, exclude) =>
         val p = pre.fold("")("the " + _ + " ")
         val e =
-          exclude.fold("")(_ => ", excluding all occurrences of {{ expr }}")
+          if (exclude.isDefined) ", excluding all occurrences of {{ expr }}"
+          else ""
         s"the number of $name in $p{{ expr }}$e"
       case SourceTextExpression(expr) =>
         "the source text matched by {{ expr }}"
@@ -200,7 +202,7 @@ class CaseCollector extends UnitWalker {
         val o = op match
           case Algo       => "the definition specified in"
           case Definition => "the algorithm steps defined in"
-          case OrdinaryObjectInternalMethod =>
+          case InternalMethod =>
             "the ordinary object internal method defined in"
           case InternalSlots => "the internal slots listed in"
           case ParamLength =>

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -225,9 +225,9 @@ class CaseCollector extends UnitWalker {
             "the second to top element of the execution context stack"
           case PropertyReference(base, nt: NonterminalProperty) =>
             "the |{{ nt }}| of {{ base }}"
-          case PropertyReference(base, ip: IndexProperty) =>
-            if (ip.isTextForm) "the {{ index }} {{ base }}"
-            else "{{ base }} {{ index }}"
+          case PropertyReference(base, PositionalElementProperty(isFirst)) =>
+            val pos = if (isFirst) "first" else "last"
+            s"the $pos element of {{ base }}"
           case PropertyReference(base, cp: ComponentProperty) =>
             if (cp.form == ComponentPropertyForm.Text) "{{ comp }} {{ base }}"
             else "{{ base }} {{ cp }}"

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -298,10 +298,14 @@ class CaseCollector extends UnitWalker {
           "{{ str }} of {{ expr }} with no arguments"
         else
           "{{ str }} of {{ expr }} with argument(s) {{ expr }}*"
-      case ListExpression(Nil) =>
-        s"« »"
-      case ListExpression(entries) =>
-        s"« {{ expr }}* »"
+      case ListExpression(entries, true) =>
+        entries match
+          case Nil => s"a new empty List"
+          case _   => s"a List whose sole element is {{ expr }}"
+      case ListExpression(entries, false) =>
+        entries match
+          case Nil => "« »"
+          case _   => s"« {{ expr }}* »"
       case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
         val from = if (isFromInc) "inclusive" else "exclusive"
         val to = if (isToInc) "inclusive" else "exclusive"

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -224,17 +224,29 @@ class CaseCollector extends UnitWalker {
           case _: SecondExecutionContext =>
             "the second to top element of the execution context stack"
           case PropertyReference(base, nt: NonterminalProperty) =>
-            "the |{{ nt }}| of {{ base }}"
+            "the | nt | of {{ base }}"
+          case PropertyReference(base, bp: BindingProperty) =>
+            "the binding for {{ expr }} in {{ base }}"
           case PropertyReference(base, PositionalElementProperty(isFirst)) =>
             val pos = if (isFirst) "first" else "last"
             s"the $pos element of {{ base }}"
           case PropertyReference(base, cp: ComponentProperty) =>
-            if (cp.form == ComponentPropertyForm.Text) "{{ comp }} {{ base }}"
-            else "{{ base }} {{ cp }}"
+            import ComponentPropertyForm.*
+            cp.form match
+              case Dot        => "{{ base }}.{{ cp }}"
+              case Apostrophe => "{{ base }}'s {{ cp }}"
+              case Text(desc) =>
+                desc match
+                  case Some(d) => s"the {{ component }} $d of {{ base }}"
+                  case None    => s"the {{ component }} of {{ base }}"
           case PropertyReference(base, fp: FieldProperty) =>
-            if (fp.form == FieldPropertyForm.Attribute)
-              "the value of {{ base }} {{ field }}"
-            else "{{ base }} {{ field }}"
+            fp.form match
+              case FieldPropertyForm.Dot =>
+                "{{ base }}.[[ {{ field }} ]]"
+              case FieldPropertyForm.Value =>
+                "{{ base }}'s [[ {{ field }} ]] value"
+              case FieldPropertyForm.Attribute =>
+                "the value of {{ base }}'s {{ field }} attribute"
           case PropertyReference(base, prop) =>
             "{{ base }} {{ prop }}"
           case AgentRecord() =>

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -84,7 +84,7 @@ class CaseCollector extends UnitWalker {
         val IfStep.ElseConfig(newLine, keyword, comma) = config
 
         val e = thenStep.endingChar
-        val k = if (thenStep.isNextUpper) keyword.toFirstUpper else keyword
+        val k = if (thenStep.isNextLowercase) keyword else keyword.toFirstUpper
         val n = if (newLine) "<NEWLINE> " else ""
         val c = if (comma) "," else ""
 

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -206,8 +206,15 @@ class CaseCollector extends UnitWalker {
         s"{{ expr }} $op {{ expr }}"
       case UnaryExpression(op, expr) =>
         s"$op {{ expr }}"
-      case _: ThisLiteral =>
-        s"*this* value"
+      case ThisLiteral(desc) =>
+        desc match {
+          case None => "*this* value"
+          case Some(desc) =>
+            desc match {
+              case _: String             => s"this Parse Node"
+              case _: NonterminalLiteral => s"this |{{ expr }}|"
+            }
+        }
       case _: NewTargetLiteral =>
         s"NewTarget"
       case HexLiteral(hex, name) =>

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -79,20 +79,14 @@ class CaseCollector extends UnitWalker {
       case AssertStep(cond) =>
         s"assert: {{ cond }}."
       case IfStep(cond, thenStep, elseStep, config) =>
-        val IfStep.ElseConfig(newLine, keyword, isKeywordUpper, comma) = config
+        val IfStep.ElseConfig(newLine, keyword, comma) = config
 
-        val k = if (isKeywordUpper) keyword.toFirstUpper else keyword
-        val end = if (isKeywordUpper) "." else ";"
+        val e = thenStep.endingChar
+        val k = if (thenStep.isNextUpper) keyword.toFirstUpper else keyword
+        val n = if (newLine) "<NEWLINE> " else ""
+        val c = if (comma) "," else ""
 
-        (newLine, comma) match
-          case (true, true) =>
-            s"if {{ cond }}, {{ step }}$end <NEWLINE> $k, {{ step }}."
-          case (true, false) =>
-            s"if {{ cond }}, {{ step }}$end <NEWLINE> $k {{ step }}."
-          case (false, true) =>
-            s"if {{ cond }}, {{ step }}$end $k, {{ step }}."
-          case (false, false) =>
-            s"if {{ cond }}, {{ step }}$end $k {{ step }}."
+        s"if {{ cond }}, {{ step }}$e $n$k$c {{ step }}."
       case RepeatStep(cond, body) =>
         import RepeatStep.LoopCondition.*
         cond match
@@ -241,6 +235,9 @@ class CaseCollector extends UnitWalker {
           case Normal       => "*\"{{ str }}\"*"
           case EmptyString  => "the empty String"
           case EmptyUnicode => "the empty sequence of Unicode code points"
+          case Code         => "<code>{{ str }}</code>"
+          case TypedArrayCtor =>
+            "the String value of the Constructor Name value specified in <emu-xref href=\"#table-the-typedarray-constructors\"></emu-xref> for this {{ str }} constructor"
         }
       case FieldLiteral(name) =>
         s"[[{{ str }}]]"
@@ -346,8 +343,8 @@ class CaseCollector extends UnitWalker {
         s"{{ expr }}"
       case TypeCheckCondition(expr, neg, ty) =>
         s"{{ expr }} is {{ ty }}*"
-      case HasFieldCondition(ref, neg, field) =>
-        s"{{ ref }} has a {{ field }} internal slot"
+      case HasFieldCondition(ref, neg, field, form) =>
+        s"{{ ref }} has a {{ field }} $form"
       case HasBindingCondition(ref, neg, binding) =>
         s"{{ ref }} has a binding for {{ binding }}"
       case ProductionCondition(nt, lhs, rhs) =>

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1249,10 +1249,9 @@ trait Parsers extends IndentParsers {
     ("the List that is" ~> propRef)
   } | {
     // AsyncGeneratorCompleteStep
-    ("the" ~> ordinal <~ "element") ~ (("of" | "from") ~> ref)
+    ("the" ~> ("first" ^^^ true | "last" ^^^ false) <~ "element") ~ ("of" ~> ref)
   } ^^ {
-    case o ~ b =>
-      PropertyReference(b, IndexProperty(DecimalMathValueLiteral(o - 1), true))
+    case p ~ b => PropertyReference(b, PositionalElementProperty(p))
   } | {
     // AgentSignifier or AgentCanSuspend
     "the Agent Record of the surrounding agent" ^^! AgentRecord()

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1498,7 +1498,9 @@ trait Parsers extends IndentParsers {
   private lazy val end: Parser[StepUpdater] =
     val pre =
       "\\(.*\\)".r |
-      "as defined in" ~ withTag("") ^^ { case a ~ b => a + " " + b.tagString } |
+      "as defined in" ~> withTag("") ^^ {
+        case b => " as defined in " + b.tagString
+      } |
       "; that is[^.]*".r |
       ""
     val post = opt {

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1258,18 +1258,17 @@ trait Parsers extends IndentParsers {
   lazy val preProp: PL[Property] = {
     "the" ~> nt <~ "of" ^^ { NonterminalProperty(_) } |||
     "the binding for" ~> expr <~ "in" ^^ { BindingProperty(_) } |||
-    "the" ~> component <~ opt("component") ~ "of" ^^ {
-      ComponentProperty(_, ComponentPropertyForm.Text)
+    "the" ~> component ~ opt("component") <~ "of" ^^ {
+      case c ~ d =>
+        ComponentProperty(c, ComponentPropertyForm.Text(d))
     }
   }.named("lang.Property")
 
   lazy val postProp: PL[Property] = {
+    import ComponentPropertyForm.*
     "[" ~> expr <~ "]" ^^ { IndexProperty(_) } |||
-    ("'s" | ".") ~ camel.filter(validProp(_)) ^^ {
-      case op ~ n =>
-        import ComponentPropertyForm.*
-        val form = if (op == ".") Dot else Apostrophe
-        ComponentProperty(n, form)
+    ("'s" ^^^ Apostrophe | "." ^^^ Dot) ~ camel.filter(validProp(_)) ^^ {
+      case op ~ n => ComponentProperty(n, op)
     } |||
     "." ~ "[[" ~> intr <~ "]]" ^^ { i => IntrinsicProperty(i) } |||
     "." ~> "[[" ~> word <~ "]]" ^^ { FieldProperty(_, FieldPropertyForm.Dot) }

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1002,6 +1002,10 @@ trait Parsers extends IndentParsers {
     ("to" ~> expr)
   } ^^ {
     case l ~ n ~ f ~ t => InclusiveIntervalCondition(l, n.isDefined, f, t)
+  } | {
+    (expr <~ "≤") ~ expr ~ ("≤" ~> expr)
+  } ^^ {
+    case f ~ l ~ t => InclusiveIntervalCondition(l, false, f, t)
   }
 
   // `contains` conditions

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -547,7 +547,7 @@ trait Parsers extends IndentParsers {
     lazy val xrefOp: P[XRefExpressionOperator] =
       "the algorithm steps defined in" ^^^ Algo |
       "the definition specified in" ^^^ Definition |
-      "the ordinary object internal method defined in" ^^^ OrdinaryObjectInternalMethod |
+      "the ordinary object internal method defined in" ^^^ InternalMethod |
       "the internal slots listed in" ^^^ InternalSlots |
       "the number of non-optional parameters of" ~
       "the function definition in" ^^^ ParamLength
@@ -1274,9 +1274,8 @@ trait Parsers extends IndentParsers {
     "[" ~> expr <~ "]" ^^ { IndexProperty(_) } |||
     ("'s" | ".") ~ camel.filter(validProp(_)) ^^ {
       case op ~ n =>
-        val form =
-          if (op == ".") ComponentPropertyForm.Dot
-          else ComponentPropertyForm.Apostrophe
+        import ComponentPropertyForm.*
+        val form = if (op == ".") Dot else Apostrophe
         ComponentProperty(n, form)
     } |||
     "." ~ "[[" ~> intr <~ "]]" ^^ { i => IntrinsicProperty(i) } |||

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1468,7 +1468,7 @@ trait Parsers extends IndentParsers {
     "TypedArray" ^^^ TypedArrayT |
     opt("initialized") ~ "RegExp" ~ opt("instance") ^^^ RegExpT |
     "non-negative integral Number" ^^^ NumberNonNegIntT |
-    "*NaN*" ^^! NaNT |
+    ("*NaN*" | "NaN") ^^! NaNT |
     "integral Number" ^^^ NumberIntT |
     "property key" ^^^ (StrT || SymbolT) |
     "~" ~> "[-+a-zA-Z0-9]+".r <~ "~" ^^ { EnumT(_) }

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1212,16 +1212,16 @@ trait Parsers extends IndentParsers {
   }.named("lang.Reference")
 
   // property references
-  lazy val propRef: PL[PropertyReference] = opt(
-    "the" ~ opt("String") ~ "value" ~ opt("of"),
-  ) ~> {
-    prop ~ baseRef ^^ {
-      case p ~ base => PropertyReference(base, p)
-    } ||| baseRef ~ prop ~ rep(prop) ^^ {
-      case base ~ p ~ ps =>
-        ps.foldLeft(PropertyReference(base, p))(PropertyReference(_, _))
+  lazy val propRef: PL[PropertyReference] =
+    lazy val prefix = opt(("the" ~> opt("String")) ~ ("value" ~> opt("of")) ^^ {
+      case a ~ b => "the" + a.fold("")(" " + _) + " value" + b.fold("")(" " + _)
+    })
+    prefix ~ prop ~ baseRef ^^ {
+      case pre ~ p ~ base => PropertyReference(base, p, pre)
+    } ||| prefix ~ baseRef ~ prop ~ rep(prop) ^^ {
+      case pre ~ base ~ p ~ ps =>
+        ps.foldLeft(PropertyReference(base, p, pre))(PropertyReference(_, _))
     }
-  }
 
   // base references
   lazy val baseRef: PL[Reference] =

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -132,6 +132,7 @@ trait Parsers extends IndentParsers {
     "prepend" ~> expr ~ ("to" ~> ref) ~ end
     ^^ { case e ~ r ~ f => f(PrependStep(e, r)) }
 
+  // insert steps
   lazy val insertStep: PL[InsertStep] =
     "insert" ~> expr ~ ("as the first element of" ~> ref) ~ end
     ^^ { case e ~ r ~ f => f(InsertStep(e, r)) }
@@ -634,11 +635,10 @@ trait Parsers extends IndentParsers {
 
   // code unit literals with hexadecimal numbers
   lazy val hexLiteral: PL[HexLiteral] =
-    opt("the code unit") ~
-    (("0x" | "U+") ~> "[0-9A-F]+".r) ~
+    opt("the code unit") ~ ("0x" ^^^ false | "U+" ^^^ true) ~ "[0-9A-F]+".r ~
     opt("(" ~> "[ A-Z-]+".r <~ ")") ^^ {
-      case c ~ n ~ x =>
-        HexLiteral(Integer.parseInt(n, 16), x, c.isDefined)
+      case c ~ p ~ n ~ x =>
+        HexLiteral(Integer.parseInt(n, 16), c.isDefined, p, x)
     }
   // grammar symboll iterals
   lazy val grammarSymbolLiteral: PL[GrammarSymbolLiteral] =

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -561,8 +561,9 @@ trait Parsers extends IndentParsers {
   // literals
   // GetIdentifierReference uses 'the value'
   lazy val literal: PL[Literal] = opt("the" ~ opt(langType) ~ "value") ~> (
-    opt("the") ~> "*this* value" ^^! ThisLiteral() |
-    "this" ~ ("Parse Node" | ntLiteral) ^^! ThisLiteral() |
+    opt("the") ~> "*this* value" ^^! ThisLiteral(None) |
+    "this Parse Node" ^^! ThisLiteral(Some("Parse Node")) |
+    "this" ~> ntLiteral ^^ { case nt => ThisLiteral(Some(nt)) } |
     "NewTarget" ^^! NewTargetLiteral() |
     hexLiteral |
     "`[^`]+`".r ^^ { case s => CodeLiteral(s.substring(1, s.length - 1)) } |

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1223,9 +1223,6 @@ trait Parsers extends IndentParsers {
 
   // special reference
   lazy val specialRef: P[Reference] = {
-    // IsLessThan
-    "the" ~> variable <~ "flag"
-  } | {
     // GetPrototypeFromConstructor
     (variable <~ "'s intrinsic object named") ~ variable
   } ^^ {
@@ -1244,9 +1241,6 @@ trait Parsers extends IndentParsers {
   } ^^ {
     case b ~ f =>
       PropertyReference(b, FieldProperty(f, FieldPropertyForm.Value))
-  } | {
-    // Set.prototype.add
-    ("the List that is" ~> propRef)
   } | {
     // AsyncGeneratorCompleteStep
     ("the" ~> ("first" ^^^ true | "last" ^^^ false) <~ "element") ~ ("of" ~> ref)

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -862,9 +862,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "the second to top element of the execution context stack"
       case PropertyReference(base, nt: NonterminalProperty) =>
         app >> nt >> " " >> base
-      case PropertyReference(base, ip: IndexProperty) =>
-        if (ip.isTextForm) app >> ip >> " " >> base
-        else app >> base >> ip
+      case PropertyReference(base, pos: PositionalElementProperty) =>
+        app >> pos >> " " >> base
       case PropertyReference(base, cp: ComponentProperty) =>
         if (cp.form == ComponentPropertyForm.Text) app >> cp >> " " >> base
         else app >> base >> cp
@@ -902,10 +901,11 @@ class Stringifier(detail: Boolean, location: Boolean) {
           case Text       => app >> "the " >> name >> " of"
         }
       case BindingProperty(expr) => app >> "the binding for " >> expr >> " in"
-      case IndexProperty(DecimalMathValueLiteral(index), true) =>
-        app >> "the " >> (index.toInt + 1).toOrdinal >> " element of"
-      case IndexProperty(index, _) =>
+      case IndexProperty(index) =>
         app >> "[" >> index >> "]"
+      case PositionalElementProperty(isFirst) =>
+        if (isFirst) app >> "the first element of"
+        else app >> "the last element of"
       case IntrinsicProperty(intr)   => app >> ".[[" >> intr >> "]]"
       case NonterminalProperty(name) => app >> "the |" >> name >> "| of"
     }

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -336,10 +336,16 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> " and " >> right
       case expr: InvokeExpression =>
         invokeExprRule(app, expr)
-      case ListExpression(Nil) => app >> "« »"
-      case ListExpression(entries) =>
-        given Rule[Iterable[Expression]] = iterableRule("« ", ", ", " »")
-        app >> entries
+      case ListExpression(entries, true) =>
+        entries match
+          case Nil    => app >> "a new empty List"
+          case e :: _ => app >> "a List whose sole element is " >> e
+      case ListExpression(entries, false) =>
+        entries match
+          case Nil => app >> "« »"
+          case _ =>
+            given Rule[Iterable[Expression]] = iterableRule("« ", ", ", " »")
+            app >> entries
       case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
         app >> "a List of the integers in the interval from " >> from
         app >> " (" >> (if (isFromInc) "inclusive" else "exclusive") >> ")"

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -137,11 +137,12 @@ class Stringifier(detail: Boolean, location: Boolean) {
         }
       case RepeatStep(cond, body) =>
         import RepeatStep.LoopCondition.*
-        app >> First("repeat, ")
+        app >> First("repeat,")
         cond match
           case NoCondition =>
-          case While(c)    => app >> "while " >> c >> ","
-          case Until(c)    => app >> "until " >> c >> ","
+            if (!body.isInstanceOf[BlockStep]) app >> " "
+          case While(c) => app >> " " >> "while " >> c >> ","
+          case Until(c) => app >> " " >> "until " >> c >> ","
         app >> body
       case ForEachStep(ty, elem, expr, forward, body) =>
         app >> First("for each ")

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -98,7 +98,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case PrependStep(expr, ref) =>
         app >> First("prepend ") >> expr >> " to " >> ref
       case InsertStep(expr, ref) =>
-        app >> First("insert ") >> expr >> " to " >> ref
+        app >> First("insert ") >> expr >> " as the first element of " >> ref
       case AddStep(expr, ref) =>
         app >> First("add ") >> expr >> " to " >> ref
       case RemoveStep(target, prep, list) =>
@@ -557,9 +557,10 @@ class Stringifier(detail: Boolean, location: Boolean) {
           case Some(nt) => app >> "this" >> " " >> nt
         }
       case _: NewTargetLiteral => app >> "NewTarget"
-      case HexLiteral(hex, name, codeUnitDesc) =>
+      case HexLiteral(hex, codeUnitDesc, isUnicodePrefix, name) =>
         if (codeUnitDesc) app >> "the code unit "
-        app >> f"0x$hex%04X"
+        app >> (if (isUnicodePrefix) "U+" else "0x")
+        app >> f"$hex%04X"
         name.map(app >> " (" >> _ >> ")")
         app
       case CodeLiteral(code) => app >> "`" >> code >> "`"

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -863,22 +863,24 @@ class Stringifier(detail: Boolean, location: Boolean) {
         app >> "the running execution context"
       case _: SecondExecutionContext =>
         app >> "the second to top element of the execution context stack"
-      case PropertyReference(base, nt: NonterminalProperty) =>
+      case PropertyReference(base, nt: NonterminalProperty, _) =>
         app >> nt >> " " >> base
-      case PropertyReference(base, pos: PositionalElementProperty) =>
+      case PropertyReference(base, pos: PositionalElementProperty, _) =>
         app >> pos >> " " >> base
-      case PropertyReference(base, cp: ComponentProperty) =>
+      case PropertyReference(base, cp: ComponentProperty, pre) =>
+        app >> pre.fold("")(_ + " ")
         cp.form match
           case ComponentPropertyForm.Text(_) =>
             app >> cp >> " " >> base
           case _ =>
             app >> base >> cp
-      case PropertyReference(base, fp: FieldProperty) =>
+      case PropertyReference(base, fp: FieldProperty, pre) =>
         if (fp.form == FieldPropertyForm.Attribute)
           app >> "the value of " >> base >> fp
-        else app >> base >> fp
-      case PropertyReference(base, prop) =>
-        app >> base >> prop
+        else
+          app >> pre.fold("")(_ + " ") >> base >> fp
+      case PropertyReference(base, prop, pre) =>
+        app >> pre.fold("")(_ + " ") >> base >> prop
       case AgentRecord() =>
         app >> "the Agent Record of the surrounding agent"
     }

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -865,8 +865,11 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case PropertyReference(base, pos: PositionalElementProperty) =>
         app >> pos >> " " >> base
       case PropertyReference(base, cp: ComponentProperty) =>
-        if (cp.form == ComponentPropertyForm.Text) app >> cp >> " " >> base
-        else app >> base >> cp
+        cp.form match
+          case ComponentPropertyForm.Text(_) =>
+            app >> cp >> " " >> base
+          case _ =>
+            app >> base >> cp
       case PropertyReference(base, fp: FieldProperty) =>
         if (fp.form == FieldPropertyForm.Attribute)
           app >> "the value of " >> base >> fp
@@ -890,15 +893,15 @@ class Stringifier(detail: Boolean, location: Boolean) {
             app >> "'s " >> "[[" >> f >> "]]" >> " attribute"
           case Value =>
             app >> "'s " >> "[[" >> f >> "]]" >> " value"
-          case StrictBinding   => ???
-          case IntrinsicObject => ???
-          case InitCond        => ???
       case ComponentProperty(name, form) =>
         import ComponentPropertyForm.*
         form match {
           case Dot        => app >> "." >> name
           case Apostrophe => app >> "'s " >> name
-          case Text       => app >> "the " >> name >> " of"
+          case Text(desc) =>
+            desc match
+              case Some(d) => app >> "the " >> name >> " " >> d >> " of"
+              case None    => app >> "the " >> name >> " of"
         }
       case BindingProperty(expr) => app >> "the binding for " >> expr >> " in"
       case IndexProperty(index) =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -329,7 +329,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
         val o = op match
           case Algo       => "the algorithm steps defined in"
           case Definition => "the definition specified in"
-          case OrdinaryObjectInternalMethod =>
+          case InternalMethod =>
             "the ordinary object internal method defined in"
           case InternalSlots => "the internal slots listed in"
           case ParamLength =>
@@ -536,7 +536,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
     app >> (op match {
       case Definition => "the definition specified in"
       case Algo       => "the algorithm steps defined in"
-      case OrdinaryObjectInternalMethod =>
+      case InternalMethod =>
         "the ordinary object internal method defined in"
       case InternalSlots => "the internal slots listed in"
       case ParamLength =>

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -521,7 +521,15 @@ class Stringifier(detail: Boolean, location: Boolean) {
   // literals
   given litRule: Rule[Literal] = (app, lit) =>
     lit match {
-      case _: ThisLiteral      => app >> "*this* value"
+      case ThisLiteral(desc) =>
+        desc match {
+          case None => app >> "*this* value"
+          case Some(desc) =>
+            desc match {
+              case s: String              => app >> "this" >> " " >> s
+              case nt: NonterminalLiteral => app >> "this" >> " " >> nt
+            }
+        }
       case _: NewTargetLiteral => app >> "NewTarget"
       case HexLiteral(hex, name) =>
         app >> f"0x$hex%04x"

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -360,7 +360,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
             app >> "a List whose sole element is " >> e
           case EmptyList(isNewUsed, typeDesc) =>
             if (isNewUsed) app >> "a new empty List"
-            else app >> s"an empty List of $typeDesc"
+            else app >> s"an empty List of ${typeDesc.get}"
           case IntRange(from, isFromInc, to, isToInc, isInc) =>
             app >> "a List of the integers in the interval from " >> from
             app >> " (" >> (if (isFromInc) "inclusive" else "exclusive") >> ")"

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -1010,10 +1010,19 @@ class Stringifier(detail: Boolean, location: Boolean) {
             m -= "Object"
             tys :+= "constructor".withArticle(article)
         }
-        for ((name, _) <- m) {
-          // split camel case with a space
-          tys :+= name.split("(?=[A-Z])").mkString(" ").withArticle(article)
-        }
+
+        if (!map.isEmpty && m.forall((name, _) => name.isEmpty))
+          // unnamed records
+          for ((_, field) <- m)
+            val fieldStr =
+              field.map.keys.map("[[" + _ + "]]").mkString(" { ", ", ", " }")
+            tys :+= ("Record" + fieldStr).withArticle(article)
+        else
+          // other named records
+          for ((name, _) <- m) {
+            // split camel case with a space
+            tys :+= name.split("(?=[A-Z])").mkString(" ").withArticle(article)
+          }
       }
     }
 
@@ -1055,6 +1064,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
     // numbers
     if (ty.number == NumberTy.Int)
       tys :+= "integral Number".withArticle(article)
+    else if (ty.number == NumberTy.NaN)
+      tys :+= "NaN".withArticle(article)
     else if (!ty.number.isBottom) tys :+= "Number".withArticle(article)
 
     // big integers

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -1033,9 +1033,11 @@ class Stringifier(detail: Boolean, location: Boolean) {
     // closures
     if (!ty.clo.isBottom) tys :+= "Abstract Closure".withArticle(article)
 
-    // TODO more precise
     // math values
-    if (!ty.math.isBottom) tys :+= "math value".withArticle(article)
+    if (ty.math == MathTy.Int)
+      tys :+= "integer".withArticle(article)
+    else if (!ty.math.isBottom)
+      tys :+= "math value".withArticle(article)
 
     // TODO more precise
     // grammar symbol

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -202,7 +202,7 @@ trait UnitWalker extends BasicUnitWalker {
       walk(ref)
     case MathFuncExpression(op, args) =>
       walk(op); walkList(args, walk)
-    case ConversionExpression(op, expr) =>
+    case ConversionExpression(op, expr, form) =>
       walk(op); walk(expr)
     case ExponentiationExpression(base, power) =>
       walk(base); walk(power)

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -124,8 +124,8 @@ trait UnitWalker extends BasicUnitWalker {
     }
 
   def walk(config: IfStep.ElseConfig): Unit =
-    val IfStep.ElseConfig(newLine, keyword, comma) = config
-    walk(newLine); walk(keyword); walk(comma)
+    val IfStep.ElseConfig(newLine, keyword, isKeywordUpper, comma) = config
+    walk(newLine); walk(keyword); walk(isKeywordUpper); walk(comma)
 
   def walk(expr: Expression): Unit = expr match {
     case StringConcatExpression(exprs) =>
@@ -134,8 +134,9 @@ trait UnitWalker extends BasicUnitWalker {
       walkList(exprs, walk)
     case ListCopyExpression(expr) =>
       walk(expr)
-    case RecordExpression(ty, fields) =>
-      walk(ty); walkList(fields, { case (f, e) => walk(f); walk(e) })
+    case RecordExpression(ty, fields, article) =>
+      walk(ty); walkList(fields, { case (f, e) => walk(f); walk(e) });
+      walk(article)
     case LengthExpression(expr) =>
       walk(expr)
     case SubstringExpression(expr, from, to) =>
@@ -233,7 +234,7 @@ trait UnitWalker extends BasicUnitWalker {
       walk(x); walkList(args, walk)
     case InvokeMethodExpression(ref, args) =>
       walk(ref); walkList(args, walk)
-    case InvokeSyntaxDirectedOperationExpression(base, name, args) =>
+    case InvokeSyntaxDirectedOperationExpression(base, name, args, article) =>
       walk(base); walkList(args, walk)
   }
 
@@ -254,8 +255,8 @@ trait UnitWalker extends BasicUnitWalker {
       walkList(ls, walk); walk(neg); walkList(rs, walk)
     case BinaryCondition(left, op, right) =>
       walk(left); walk(op); walk(right)
-    case InclusiveIntervalCondition(left, neg, from, to) =>
-      walk(left); walk(neg); walk(from); walk(to)
+    case InclusiveIntervalCondition(left, neg, from, to, verbose) =>
+      walk(left); walk(neg); walk(from); walk(to); walk(verbose)
     case ContainsCondition(list, neg, target) =>
       walk(list); walk(neg); walk(target)
     case CompoundCondition(left, op, right) =>
@@ -295,7 +296,7 @@ trait UnitWalker extends BasicUnitWalker {
 
   def walk(prop: Property): Unit = prop match {
     case FieldProperty(n)        =>
-    case ComponentProperty(c)    =>
+    case ComponentProperty(c, _) =>
     case BindingProperty(b)      => walk(b)
     case IndexProperty(e)        => walk(e)
     case IntrinsicProperty(intr) => walk(intr)

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -304,7 +304,7 @@ trait UnitWalker extends BasicUnitWalker {
   def walk(x: Variable): Unit = {}
 
   def walk(propRef: PropertyReference): Unit = propRef match {
-    case PropertyReference(base, prop) => walk(base); walk(prop)
+    case PropertyReference(base, prop, _) => walk(base); walk(prop)
   }
 
   def walk(prop: Property): Unit = prop match {

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -58,6 +58,7 @@ trait UnitWalker extends BasicUnitWalker {
     case InvokeShorthandStep(name, args) => walk(name); walkList(args, walk)
     case AppendStep(expr, ref)           => walk(expr); walk(ref)
     case PrependStep(expr, ref)          => walk(expr); walk(ref)
+    case InsertStep(expr, ref)           => walk(expr); walk(ref)
     case AddStep(expr, ref)              => walk(expr); walk(ref)
     case RemoveStep(target, p, list)     => walk(target); walk(p); walk(list)
     case PushContextStep(ref)            => walk(ref)
@@ -134,9 +135,8 @@ trait UnitWalker extends BasicUnitWalker {
       walkList(exprs, walk)
     case ListCopyExpression(expr) =>
       walk(expr)
-    case RecordExpression(ty, fields, article) =>
+    case RecordExpression(ty, fields, _) =>
       walk(ty); walkList(fields, { case (f, e) => walk(f); walk(e) });
-      walk(article)
     case LengthExpression(expr) =>
       walk(expr)
     case SubstringExpression(expr, from, to) =>

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -143,8 +143,8 @@ trait UnitWalker extends BasicUnitWalker {
       walk(expr); walk(from); walkOpt(to, walk)
     case TrimExpression(expr, leading, trailing) =>
       walk(expr); walk(leading); walk(trailing)
-    case NumberOfExpression(name, pre, expr) =>
-      walk(name); walkOpt(pre, walk); walk(expr)
+    case NumberOfExpression(name, pre, expr, exclude) =>
+      walk(name); walkOpt(pre, walk); walk(expr); walkOpt(exclude, walk)
     case SourceTextExpression(expr) =>
       walk(expr)
     case CoveredByExpression(from, to) =>
@@ -163,10 +163,17 @@ trait UnitWalker extends BasicUnitWalker {
       walk(left); walk(op); walk(right)
     case invoke: InvokeExpression =>
       walk(invoke)
-    case ListExpression(entries, _) =>
-      walkList(entries, walk)
-    case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
-      walk(from); walk(to)
+    case ListExpression(form) =>
+      import ListExpressionForm.*
+      form match
+        case LiteralSyntax(entries) =>
+          walkList(entries, walk)
+        case SoleElement(entry) =>
+          walk(entry)
+        case EmptyList(isNewUsed, typeDesc) =>
+          walk(isNewUsed)
+        case IntRange(from, fromInc, to, toInc, asc) =>
+          walk(from); walk(fromInc); walk(to); walk(toInc); walk(asc)
     case XRefExpression(kind, id) =>
       walk(kind);
     case SoleElementExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -311,7 +311,9 @@ trait UnitWalker extends BasicUnitWalker {
     case FieldProperty(n, _)     =>
     case ComponentProperty(c, _) =>
     case BindingProperty(b)      => walk(b)
-    case IndexProperty(e, _)     => walk(e)
+    case IndexProperty(e)        => walk(e)
+    case PositionalElementProperty(isFirst) =>
+      walk(isFirst)
     case IntrinsicProperty(intr) => walk(intr)
     case NonterminalProperty(n)  =>
   }

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -226,15 +226,21 @@ trait UnitWalker extends BasicUnitWalker {
   def walk(lit: Literal): Unit = {}
 
   def walk(invoke: InvokeExpression): Unit = invoke match {
-    case InvokeAbstractOperationExpression(name, args) =>
+    case InvokeAbstractOperationExpression(name, args, tag) =>
       walkList(args, walk)
     case InvokeNumericMethodExpression(ty, name, args) =>
       walk(ty); walkList(args, walk)
     case InvokeAbstractClosureExpression(x, args) =>
       walk(x); walkList(args, walk)
-    case InvokeMethodExpression(ref, args) =>
+    case InvokeMethodExpression(ref, args, tag) =>
       walk(ref); walkList(args, walk)
-    case InvokeSyntaxDirectedOperationExpression(base, name, args, article) =>
+    case InvokeSyntaxDirectedOperationExpression(
+          base,
+          name,
+          args,
+          article,
+          tag,
+        ) =>
       walk(base); walkList(args, walk)
   }
 

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -124,8 +124,8 @@ trait UnitWalker extends BasicUnitWalker {
     }
 
   def walk(config: IfStep.ElseConfig): Unit =
-    val IfStep.ElseConfig(newLine, keyword, isKeywordUpper, comma) = config
-    walk(newLine); walk(keyword); walk(isKeywordUpper); walk(comma)
+    val IfStep.ElseConfig(newLine, keyword, comma) = config
+    walk(newLine); walk(keyword); walk(comma)
 
   def walk(expr: Expression): Unit = expr match {
     case StringConcatExpression(exprs) =>
@@ -243,7 +243,7 @@ trait UnitWalker extends BasicUnitWalker {
       walk(expr)
     case TypeCheckCondition(expr, neg, ty) =>
       walk(expr); walk(neg); walkList(ty, walk)
-    case HasFieldCondition(ref, neg, field) =>
+    case HasFieldCondition(ref, neg, field, _) =>
       walk(ref); walk(neg); walk(field)
     case HasBindingCondition(ref, neg, binding) =>
       walk(ref); walk(neg); walk(binding)
@@ -295,10 +295,10 @@ trait UnitWalker extends BasicUnitWalker {
   }
 
   def walk(prop: Property): Unit = prop match {
-    case FieldProperty(n)        =>
+    case FieldProperty(n, _)     =>
     case ComponentProperty(c, _) =>
     case BindingProperty(b)      => walk(b)
-    case IndexProperty(e)        => walk(e)
+    case IndexProperty(e, _)     => walk(e)
     case IntrinsicProperty(intr) => walk(intr)
     case NonterminalProperty(n)  =>
   }

--- a/src/main/scala/esmeta/lang/util/UnitWalker.scala
+++ b/src/main/scala/esmeta/lang/util/UnitWalker.scala
@@ -162,7 +162,7 @@ trait UnitWalker extends BasicUnitWalker {
       walk(left); walk(op); walk(right)
     case invoke: InvokeExpression =>
       walk(invoke)
-    case ListExpression(entries) =>
+    case ListExpression(entries, _) =>
       walkList(entries, walk)
     case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
       walk(from); walk(to)

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -58,6 +58,7 @@ trait Walker extends BasicWalker {
     case InvokeShorthandStep(x, a)  => InvokeShorthandStep(x, walkList(a, walk))
     case AppendStep(expr, ref)      => AppendStep(walk(expr), walk(ref))
     case PrependStep(expr, ref)     => PrependStep(walk(expr), walk(ref))
+    case InsertStep(expr, ref)      => InsertStep(walk(expr), walk(ref))
     case AddStep(expr, ref)         => AddStep(walk(expr), walk(ref))
     case RemoveStep(t, p, l)        => RemoveStep(walk(t), walk(p), walk(l))
     case PushContextStep(ref)       => PushContextStep(walk(ref))
@@ -166,10 +167,10 @@ trait Walker extends BasicWalker {
       ListConcatExpression(walkList(exprs, walk))
     case ListCopyExpression(expr) =>
       ListCopyExpression(walk(expr))
-    case RecordExpression(ty, fields, article) =>
+    case RecordExpression(ty, fields, form) =>
       lazy val newFields =
         walkList(fields, { case (f, e) => (walk(f), walk(e)) })
-      RecordExpression(walk(ty), newFields, walk(article))
+      RecordExpression(walk(ty), newFields, form)
     case LengthExpression(expr) =>
       LengthExpression(walk(expr))
     case SubstringExpression(expr, from, to) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -371,7 +371,9 @@ trait Walker extends BasicWalker {
     case FieldProperty(n, f)     => FieldProperty(n, f)
     case ComponentProperty(c, f) => ComponentProperty(c, f)
     case BindingProperty(b)      => BindingProperty(walk(b))
-    case IndexProperty(e, t)     => IndexProperty(walk(e), t)
+    case IndexProperty(e)        => IndexProperty(walk(e))
+    case PositionalElementProperty(isFirst) =>
+      PositionalElementProperty(walk(isFirst))
     case IntrinsicProperty(intr) => IntrinsicProperty(walk(intr))
     case NonterminalProperty(n)  => NonterminalProperty(n)
   }

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -265,20 +265,27 @@ trait Walker extends BasicWalker {
   def walk(flit: FieldLiteral): FieldLiteral = flit
 
   def walk(invoke: InvokeExpression): InvokeExpression = invoke match {
-    case InvokeAbstractOperationExpression(name, args) =>
-      InvokeAbstractOperationExpression(name, walkList(args, walk))
+    case InvokeAbstractOperationExpression(name, args, tag) =>
+      InvokeAbstractOperationExpression(name, walkList(args, walk), tag)
     case InvokeNumericMethodExpression(ty, name, args) =>
       InvokeNumericMethodExpression(walk(ty), name, walkList(args, walk))
     case InvokeAbstractClosureExpression(x, args) =>
       InvokeAbstractClosureExpression(walk(x), walkList(args, walk))
-    case InvokeMethodExpression(ref, args) =>
-      InvokeMethodExpression(walk(ref), walkList(args, walk))
-    case InvokeSyntaxDirectedOperationExpression(base, name, args, article) =>
+    case InvokeMethodExpression(ref, args, tag) =>
+      InvokeMethodExpression(walk(ref), walkList(args, walk), tag)
+    case InvokeSyntaxDirectedOperationExpression(
+          base,
+          name,
+          args,
+          article,
+          tag,
+        ) =>
       InvokeSyntaxDirectedOperationExpression(
         walk(base),
         name,
         walkList(args, walk),
         None,
+        tag,
       )
   }
 

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -248,8 +248,8 @@ trait Walker extends BasicWalker {
       walk(lit)
     case MathFuncExpression(op, args) =>
       MathFuncExpression(walk(op), walkList(args, walk))
-    case ConversionExpression(op, expr) =>
-      ConversionExpression(walk(op), walk(expr))
+    case ConversionExpression(op, expr, form) =>
+      ConversionExpression(walk(op), walk(expr), form)
     case ExponentiationExpression(base, power) =>
       ExponentiationExpression(walk(base), walk(power))
     case BinaryExpression(left, op, right) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -177,8 +177,13 @@ trait Walker extends BasicWalker {
       SubstringExpression(walk(expr), walk(from), walkOpt(to, walk))
     case TrimExpression(expr, leading, trailing) =>
       TrimExpression(walk(expr), walk(leading), walk(trailing))
-    case NumberOfExpression(name, pre, expr) =>
-      NumberOfExpression(walk(name), walkOpt(pre, walk), walk(expr))
+    case NumberOfExpression(name, pre, expr, exclude) =>
+      NumberOfExpression(
+        walk(name),
+        walkOpt(pre, walk),
+        walk(expr),
+        walkOpt(exclude, walk),
+      )
     case SourceTextExpression(expr) =>
       SourceTextExpression(walk(expr))
     case CoveredByExpression(code, rule) =>
@@ -197,10 +202,19 @@ trait Walker extends BasicWalker {
       BitwiseExpression(walk(left), walk(op), walk(right))
     case invoke: InvokeExpression =>
       walk(invoke)
-    case ListExpression(entries, verbose) =>
-      ListExpression(walkList(entries, walk), verbose)
-    case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
-      IntListExpression(walk(from), isFromInc, walk(to), isToInc, isInc)
+    case ListExpression(form) =>
+      import ListExpressionForm.*
+      ListExpression(
+        form match
+          case LiteralSyntax(entries) =>
+            LiteralSyntax(walkList(entries, walk))
+          case SoleElement(entry) =>
+            SoleElement(walk(entry))
+          case EmptyList(isNewUsed, typeDesc) =>
+            EmptyList(isNewUsed, typeDesc)
+          case IntRange(from, fromInc, to, toInc, asc) =>
+            IntRange(walk(from), fromInc, walk(to), toInc, asc),
+      )
     case XRefExpression(kind, id) =>
       XRefExpression(walk(kind), id)
     case SoleElementExpression(expr) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -196,8 +196,8 @@ trait Walker extends BasicWalker {
       BitwiseExpression(walk(left), walk(op), walk(right))
     case invoke: InvokeExpression =>
       walk(invoke)
-    case ListExpression(entries) =>
-      ListExpression(walkList(entries, walk))
+    case ListExpression(entries, verbose) =>
+      ListExpression(walkList(entries, walk), verbose)
     case IntListExpression(from, isFromInc, to, isToInc, isInc) =>
       IntListExpression(walk(from), isFromInc, walk(to), isToInc, isInc)
     case XRefExpression(kind, id) =>

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -363,8 +363,8 @@ trait Walker extends BasicWalker {
   def walk(x: Variable): Variable = Variable(x.name)
 
   def walk(propRef: PropertyReference): PropertyReference = propRef match {
-    case PropertyReference(base, prop) =>
-      PropertyReference(walk(base), walk(prop))
+    case PropertyReference(base, prop, pre) =>
+      PropertyReference(walk(base), walk(prop), pre)
   }
 
   def walk(prop: Property): Property = prop match {

--- a/src/main/scala/esmeta/lang/util/Walker.scala
+++ b/src/main/scala/esmeta/lang/util/Walker.scala
@@ -156,13 +156,8 @@ trait Walker extends BasicWalker {
       case Until(cond) => Until(walk(cond))
 
   def walk(config: IfStep.ElseConfig): IfStep.ElseConfig =
-    val IfStep.ElseConfig(newLine, keyword, isKeywordUpper, comma) = config
-    IfStep.ElseConfig(
-      walk(newLine),
-      walk(keyword),
-      walk(isKeywordUpper),
-      walk(comma),
-    )
+    val IfStep.ElseConfig(newLine, keyword, comma) = config
+    IfStep.ElseConfig(walk(newLine), walk(keyword), walk(comma))
 
   def walk(expr: Expression): Expression = expr match {
     case StringConcatExpression(exprs) =>
@@ -292,8 +287,8 @@ trait Walker extends BasicWalker {
       ExpressionCondition(walk(expr))
     case TypeCheckCondition(expr, neg, ty) =>
       TypeCheckCondition(walk(expr), walk(neg), walkList(ty, walk))
-    case HasFieldCondition(ref, neg, field) =>
-      HasFieldCondition(walk(ref), walk(neg), walk(field))
+    case HasFieldCondition(ref, neg, field, form) =>
+      HasFieldCondition(walk(ref), walk(neg), walk(field), form)
     case HasBindingCondition(ref, neg, binding) =>
       HasBindingCondition(walk(ref), walk(neg), walk(binding))
     case ProductionCondition(nt, lhs, rhs) =>
@@ -351,10 +346,10 @@ trait Walker extends BasicWalker {
   }
 
   def walk(prop: Property): Property = prop match {
-    case FieldProperty(n)        => FieldProperty(n)
+    case FieldProperty(n, f)     => FieldProperty(n, f)
     case ComponentProperty(c, f) => ComponentProperty(c, f)
     case BindingProperty(b)      => BindingProperty(walk(b))
-    case IndexProperty(e)        => IndexProperty(walk(e))
+    case IndexProperty(e, t)     => IndexProperty(walk(e), t)
     case IntrinsicProperty(intr) => IntrinsicProperty(walk(intr))
     case NonterminalProperty(n)  => NonterminalProperty(n)
   }

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -128,14 +128,12 @@ case object Extract extends Phase[Unit, Spec] {
       getName = algo => s"${algo.normalizedName}.algo",
     )
 
-    dumpFile(
-      name = "algorithms whose string form is not equal to the original prose",
-      data = spec.algorithms
-        .filter(algo => algo.normalizedCode != algo.body.toString)
-        .map(algo => s"$EXTRACT_LOG_DIR/algos/${algo.normalizedName}.algo")
-        .sorted
-        .mkString(LINE_SEP),
-      filename = s"$EXTRACT_LOG_DIR/yet-equal-algos",
+    dumpDir(
+      name = "yet-equal-algos",
+      iterable = spec.algorithms.filter(!_.equals),
+      getData = algo => algo.lineDiffStr,
+      dirname = s"$EXTRACT_LOG_DIR/yet-equal-algos",
+      getName = algo => s"${algo.normalizedName}.diff",
     )
 
     dumpFile(

--- a/src/main/scala/esmeta/spec/Algorithm.scala
+++ b/src/main/scala/esmeta/spec/Algorithm.scala
@@ -41,7 +41,21 @@ case class Algorithm(
 
   /** normalized code */
   lazy val normalizedCode = Algorithm.normalizeCode(code)
+
+  /** parsed result equals with spec before parsing */
+  lazy val equals = normalizedCode == body.toString
+
+  lazy val lineDiff =
+    val codeList = normalizedCode.split("\n")
+    val bodyList = body.toString.split("\n")
+
+    codeList.zip(bodyList).filter(_ != _)
+
+  lazy val lineDiffStr = lineDiff
+    .map((l, r) => s"spec\t>> $l\nparsed\t<< $r")
+    .mkString("\n\n")
 }
+
 object Algorithm {
 
   /** normalize code by removing unnecessary indents and trailing spaces */

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -103,9 +103,9 @@ case class Spec(
 
   /** get an algorithm by id attribute */
   def getAlgoById(id: String): Algorithm =
-    algorithms.filter(_.elem.getId == id) match
-      case algo :: Nil => algo
-      case _           => raise(s"no algorithms found for $id")
+    algorithms.find(_.elem.getId == id) match
+      case Some(algo) => algo
+      case None       => raise(s"no algorithms found for $id")
 
   /** empty check */
   def isEmpty: Boolean =

--- a/src/main/scala/esmeta/spec/Summary.scala
+++ b/src/main/scala/esmeta/spec/Summary.scala
@@ -24,6 +24,7 @@ object Summary extends Parser.From[Summary](Parser.summary) {
     val prodsBy = prods.groupBy(_.kind)
     val completeAlgos = spec.completeAlgorithms.length
     val completeSteps = spec.completeSteps.length
+    val equalAlgos = spec.algorithms.filter(_.equals).length
     val knownTypes = spec.knownTypes.length
     val yetTypes = spec.yetTypes.length
     Summary(
@@ -35,16 +36,17 @@ object Summary extends Parser.From[Summary](Parser.summary) {
         web = grammar.prodsForWeb.length,
       ),
       algos = AlgorithmSummary(
+        total = algos.length,
         complete = completeAlgos,
-        incomplete = algos.length - completeAlgos,
+        equal = equalAlgos,
       ),
       steps = StepSummary(
+        total = spec.allSteps.length,
         complete = completeSteps,
-        incomplete = spec.allSteps.length - completeSteps,
       ),
       types = TypeSummary(
+        total = spec.types.length,
         known = knownTypes,
-        unknown = spec.types.length - knownTypes - yetTypes,
         yet = yetTypes,
       ),
       tables = tables.size,
@@ -67,28 +69,32 @@ case class GrammarSummary(
 
 /** algorithm element */
 case class AlgorithmSummary(
+  total: Int = 0,
   complete: Int = 0,
-  incomplete: Int = 0,
+  equal: Int = 0,
 ) {
-  def total: Int = complete + incomplete
-  def ratioString: String = percentString(complete, total)
+  def incomplete: Int = total - complete
+  def inequal: Int = total - equal
+  def completeRatio: String = percentString(complete, total)
+  def equalRatio: String = percentString(equal, total)
 }
 
 /** algorithm step element */
 case class StepSummary(
+  total: Int = 0,
   complete: Int = 0,
-  incomplete: Int = 0,
 ) {
-  def total: Int = complete + incomplete
-  def ratioString: String = percentString(complete, total)
+  def incomplete: Int = total - complete
+  def completeRatio: String = percentString(complete, total)
 }
 
 /** type element */
 case class TypeSummary(
+  total: Int = 0,
   known: Int = 0,
   yet: Int = 0,
-  unknown: Int = 0,
 ) {
-  def total: Int = known + yet
-  def ratioString: String = percentString(known, total)
+  def unknown: Int = total - known - yet
+  def completeRatio: String = percentString(known, total)
+  def yetRatio: String = percentString(yet, total)
 }

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -309,21 +309,19 @@ trait Parsers extends LangParsers {
       (empty ~ "- extended productions for web:" ~> int)
     } ^^ { case l ~ n ~ s ~ w => GrammarSummary(l, n, s, w) }
     val algos = {
-      (empty ~ "- algorithms:" ~ ".*".r) ~>
-      (empty ~ "- complete:" ~> int) ~
-      (empty ~ "- incomplete:" ~> int)
-    } ^^ { case c ~ i => AlgorithmSummary(c, i) }
+      (empty ~ "- algorithms:" ~> int) ~
+      (empty ~ "- complete:" ~> int <~ ".*".r) ~
+      (empty ~ "- equals:" ~> int <~ ".*".r)
+    } ^^ { case t ~ c ~ e => AlgorithmSummary(t, c, e) }
     val steps = {
-      (empty ~ "- algorithm steps:" ~ ".*".r) ~>
-      (empty ~ "- complete:" ~> int) ~
-      (empty ~ "- incomplete:" ~> int)
-    } ^^ { case c ~ i => StepSummary(c, i) }
+      (empty ~ "- algorithm steps:" ~> int) ~
+      (empty ~ "- complete:" ~> int <~ ".*".r)
+    } ^^ { case t ~ c => StepSummary(t, c) }
     val types = {
-      (empty ~ "- types:" ~ ".*".r) ~>
-      (empty ~ "- known:" ~> int) ~
-      (empty ~ "- yet:" ~> int) ~
-      (empty ~ "- unknown:" ~> int)
-    } ^^ { case c ~ u ~ n => TypeSummary(c, u, n) }
+      (empty ~ "- types:" ~> int) ~
+      (empty ~ "- known:" ~> int <~ ".*".r) ~
+      (empty ~ "- yet:" ~> int <~ ".*".r)
+    } ^^ { case t ~ k ~ y => TypeSummary(t, k, y) }
     val tables = empty ~ "- tables:" ~> int
     val tyModel = empty ~ "- type model:" ~> int <~ empty
     val intr = empty ~ "- intrinsics:" ~> int <~ empty

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -47,8 +47,16 @@ object Stringifier {
   // for specification summaries
   given summaryRule: Rule[Summary] = (app, summary) =>
     import ProductionKind.*
-    val Summary(version, grammar, algos, steps, types, tables, tyModel, intr) =
-      summary
+    val Summary(
+      version,
+      grammar,
+      algos,
+      steps,
+      types,
+      tables,
+      tyModel,
+      intr,
+    ) = summary
     version.map(app >> "- version: " >> _.toString >> LINE_SEP)
     app >> "- grammar:"
     app :> "  - productions: " >> grammar.productions
@@ -56,16 +64,14 @@ object Stringifier {
     app :> "    - numeric string: " >> grammar.numeric
     app :> "    - syntactic: " >> grammar.syntactic
     app :> "  - extended productions for web: " >> grammar.web
-    app :> "- algorithms: " >> algos.total >> " " >> algos.ratioString
-    app :> "  - complete: " >> algos.complete
-    app :> "  - incomplete: " >> algos.incomplete
-    app :> "- algorithm steps: " >> steps.total >> " " >> steps.ratioString
-    app :> "  - complete: " >> steps.complete
-    app :> "  - incomplete: " >> steps.incomplete
-    app :> "- types: " >> types.total >> " " >> types.ratioString
-    app :> "  - known: " >> types.known
-    app :> "  - yet: " >> types.yet
-    app :> "  - unknown: " >> types.unknown
+    app :> "- algorithms: " >> algos.total
+    app :> "  - complete: " >> algos.complete >> " " >> algos.completeRatio
+    app :> "  - equals: " >> algos.equal >> " " >> algos.equalRatio
+    app :> "- algorithm steps: " >> steps.total
+    app :> "  - complete: " >> steps.complete >> " " >> steps.completeRatio
+    app :> "- types: " >> types.total
+    app :> "  - known: " >> types.known >> " " >> types.completeRatio
+    app :> "  - yet: " >> types.yet >> " " >> types.yetRatio
     app :> "- tables: " >> tables
     app :> "- type model: " >> tyModel
     app :> "- intrinsics: " >> intr

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -327,8 +327,8 @@ object LangTest {
     )
 
   // algorithm literals
-  lazy val hex = HexLiteral(0x0024, None, false)
-  lazy val hexWithName = HexLiteral(0x0024, Some("DOLLAR SIGN"), false)
+  lazy val hex = HexLiteral(0x0024, false, false, None)
+  lazy val hexWithName = HexLiteral(0x0024, false, false, Some("DOLLAR SIGN"))
   lazy val code = CodeLiteral("|")
   lazy val grSym = GrammarSymbolLiteral("A", Nil)
   lazy val grSymIdx = GrammarSymbolLiteral("A", List("~Yield", "+Await"))

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -61,17 +61,11 @@ object LangTest {
   import IfStep.ElseConfig
   lazy val ifStep = IfStep(exprCond, letStep, None)
   lazy val ifElseInlineStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", T, T))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", T))
   lazy val ifOtherwiseInlineStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T, T))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T))
   lazy val ifOtherwiseInlineNoCommaStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T, F))
-  lazy val ifElseInlineSemicolonStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", F, T))
-  lazy val ifOtherwiseInlineSemicolonStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F, T))
-  lazy val ifOtherwiseInlineNoCommaSemicolonStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F, F))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F))
   lazy val ifBlockStep =
     IfStep(exprCond, blockStep, None)
   lazy val ifElseStep =
@@ -321,8 +315,10 @@ object LangTest {
     TypeCheckCondition(refExpr, F, List(ty, ty, ty))
   lazy val neitherTypeCheckCond =
     TypeCheckCondition(refExpr, T, List(ty, ty))
-  lazy val hasFieldCond = HasFieldCondition(x, F, fieldLit)
-  lazy val noHasFieldCond = HasFieldCondition(x, T, fieldLit)
+  lazy val hasFieldCond =
+    HasFieldCondition(x, F, fieldLit, HasFieldConditionForm.InternalSlot)
+  lazy val noHasFieldCond =
+    HasFieldCondition(x, T, fieldLit, HasFieldConditionForm.InternalSlot)
   lazy val hasBindingCond = HasBindingCondition(x, F, refExpr)
   lazy val noHasBindingCond = HasBindingCondition(x, T, refExpr)
   lazy val prodCond = ProductionCondition(nt, "Identifier", "Identifier")

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -164,7 +164,11 @@ object LangTest {
   lazy val getItemsExpr = GetItemsExpression(nt, refExpr)
   lazy val intrExpr = IntrinsicExpression(intr)
   lazy val invokeAOExpr =
-    InvokeAbstractOperationExpression("ToObject", List(addExpr, unExpr))
+    InvokeAbstractOperationExpression(
+      "ToObject",
+      List(addExpr, unExpr),
+      HtmlTag.None,
+    )
   lazy val invokeNumericExpr =
     InvokeNumericMethodExpression(
       "Number",
@@ -174,15 +178,22 @@ object LangTest {
   lazy val invokeClosureExpr =
     InvokeAbstractClosureExpression(x, List(refExpr))
   lazy val invokeMethodExpr =
-    InvokeMethodExpression(fieldRef, List(addExpr, unExpr))
+    InvokeMethodExpression(fieldRef, List(addExpr, unExpr), HtmlTag.None)
   lazy val invokeSDOExprZero =
-    InvokeSyntaxDirectedOperationExpression(nt, "StringValue", Nil, None)
+    InvokeSyntaxDirectedOperationExpression(
+      nt,
+      "StringValue",
+      Nil,
+      None,
+      HtmlTag.None,
+    )
   lazy val invokeSDOExprSingle =
     InvokeSyntaxDirectedOperationExpression(
       nt,
       "StringValue",
       List(nt),
       None,
+      HtmlTag.None,
     )
   lazy val invokeSDOExprMulti =
     InvokeSyntaxDirectedOperationExpression(
@@ -190,6 +201,7 @@ object LangTest {
       "StringValue",
       List(nt, refExpr),
       None,
+      HtmlTag.None,
     )
   lazy val invokeSDOExprEval =
     InvokeSyntaxDirectedOperationExpression(
@@ -197,6 +209,7 @@ object LangTest {
       "Evaluation",
       Nil,
       None,
+      HtmlTag.None,
     )
   lazy val invokeSDOExprContains =
     InvokeSyntaxDirectedOperationExpression(
@@ -204,12 +217,16 @@ object LangTest {
       "Contains",
       List(refExpr),
       None,
+      HtmlTag.None,
     )
   lazy val riaCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, T)
   lazy val riaNoCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, F)
   lazy val emptyListExpr = ListExpression(Nil, false)
   lazy val listExpr = ListExpression(List(refExpr, refExpr), false)
-  lazy val xrefAlgoExpr = XRefExpression(XRefExpressionOperator.Algo, "sec-x")
+  lazy val xrefAlgoExpr = XRefExpression(
+    XRefExpressionOperator.Algo("the definition specified in"),
+    "sec-x",
+  )
   lazy val xrefSlotsExpr =
     XRefExpression(XRefExpressionOperator.InternalSlots, "sec-x")
   lazy val xrefLenExpr =

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -146,9 +146,13 @@ object LangTest {
     ListConcatExpression(List(refExpr, refExpr, refExpr))
   lazy val listCopyExpr = ListCopyExpression(refExpr)
   lazy val recordEmptyExpr =
-    RecordExpression("Object", Nil)
+    RecordExpression("Object", Nil, RecordExpressionForm.Normal(false))
   lazy val recordExpr =
-    RecordExpression("Object", List(fieldLit -> refExpr))
+    RecordExpression(
+      "Object",
+      List(fieldLit -> refExpr),
+      RecordExpressionForm.Normal(false),
+    )
   lazy val lengthExpr = LengthExpression(refExpr)
   lazy val substrExpr = SubstringExpression(refExpr, refExpr, None)
   lazy val substrExprTo = SubstringExpression(refExpr, refExpr, Some(refExpr))
@@ -223,10 +227,8 @@ object LangTest {
   lazy val riaNoCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, F)
   lazy val emptyListExpr = ListExpression(Nil, false)
   lazy val listExpr = ListExpression(List(refExpr, refExpr), false)
-  lazy val xrefAlgoExpr = XRefExpression(
-    XRefExpressionOperator.Algo("the definition specified in"),
-    "sec-x",
-  )
+  lazy val xrefAlgoExpr =
+    XRefExpression(XRefExpressionOperator.Definition, "sec-x")
   lazy val xrefSlotsExpr =
     XRefExpression(XRefExpressionOperator.InternalSlots, "sec-x")
   lazy val xrefLenExpr =

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -323,10 +323,11 @@ object LangTest {
   lazy val ntFlags =
     NonterminalLiteral(None, "A", List("~Yield", "+Await"), false)
   lazy val empty = EnumLiteral("empty")
-  lazy val emptyStr = StringLiteral("")
-  lazy val str = StringLiteral("abc")
-  lazy val strWithStar = StringLiteral("abc*")
-  lazy val strWithBasckSlash = StringLiteral("abc\\")
+  lazy val emptyStr = StringLiteral("", StringLiteralForm.SyntaxLiteral)
+  lazy val str = StringLiteral("abc", StringLiteralForm.SyntaxLiteral)
+  lazy val strWithStar = StringLiteral("abc*", StringLiteralForm.SyntaxLiteral)
+  lazy val strWithBasckSlash =
+    StringLiteral("abc\\", StringLiteralForm.SyntaxLiteral)
   lazy val fieldLit = FieldLiteral("Value")
   lazy val sym = SymbolLiteral("iterator")
   lazy val errObj = ErrorObjectLiteral("TypeError")
@@ -361,9 +362,9 @@ object LangTest {
   lazy val neitherTypeCheckCond =
     TypeCheckCondition(refExpr, T, List(ty, ty))
   lazy val hasFieldCond =
-    HasFieldCondition(x, F, fieldLit, HasFieldConditionForm.InternalSlot)
+    HasFieldCondition(x, F, fieldLit, HasFieldConditionOperator.InternalSlot)
   lazy val noHasFieldCond =
-    HasFieldCondition(x, T, fieldLit, HasFieldConditionForm.InternalSlot)
+    HasFieldCondition(x, T, fieldLit, HasFieldConditionOperator.InternalSlot)
   lazy val hasBindingCond = HasBindingCondition(x, F, refExpr)
   lazy val noHasBindingCond = HasBindingCondition(x, T, refExpr)
   lazy val prodCond = ProductionCondition(nt, "Identifier", "Identifier")
@@ -440,7 +441,7 @@ object LangTest {
   lazy val ntRef = PropertyReference(x, NonterminalProperty("Arguments"))
 
   // algorithm references
-  lazy val fieldProp = FieldProperty("Value")
+  lazy val fieldProp = FieldProperty("Value", FieldPropertyForm.Dot)
   lazy val componentProp = ComponentProperty("Realm", ComponentPropertyForm.Dot)
   lazy val bindingProp = BindingProperty(refExpr)
   lazy val indexProp = IndexProperty(refExpr)

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -61,11 +61,17 @@ object LangTest {
   import IfStep.ElseConfig
   lazy val ifStep = IfStep(exprCond, letStep, None)
   lazy val ifElseInlineStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", T))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", T, T))
   lazy val ifOtherwiseInlineStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T, T))
   lazy val ifOtherwiseInlineNoCommaStep =
-    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F))
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T, F))
+  lazy val ifElseInlineSemicolonStep =
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", F, T))
+  lazy val ifOtherwiseInlineSemicolonStep =
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F, T))
+  lazy val ifOtherwiseInlineNoCommaSemicolonStep =
+    IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", F, F))
   lazy val ifBlockStep =
     IfStep(exprCond, blockStep, None)
   lazy val ifElseStep =
@@ -176,30 +182,34 @@ object LangTest {
   lazy val invokeMethodExpr =
     InvokeMethodExpression(fieldRef, List(addExpr, unExpr))
   lazy val invokeSDOExprZero =
-    InvokeSyntaxDirectedOperationExpression(nt, "StringValue", Nil)
+    InvokeSyntaxDirectedOperationExpression(nt, "StringValue", Nil, None)
   lazy val invokeSDOExprSingle =
     InvokeSyntaxDirectedOperationExpression(
       nt,
       "StringValue",
       List(nt),
+      None,
     )
   lazy val invokeSDOExprMulti =
     InvokeSyntaxDirectedOperationExpression(
       nt,
       "StringValue",
       List(nt, refExpr),
+      None,
     )
   lazy val invokeSDOExprEval =
     InvokeSyntaxDirectedOperationExpression(
       nt,
       "Evaluation",
       Nil,
+      None,
     )
   lazy val invokeSDOExprContains =
     InvokeSyntaxDirectedOperationExpression(
       nt,
       "Contains",
       List(refExpr),
+      None,
     )
   lazy val riaCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, T)
   lazy val riaNoCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, F)
@@ -259,15 +269,20 @@ object LangTest {
     ConversionExpression(ConversionExpressionOperator.ToMath, refExpr)
 
   // algorithm literals
-  lazy val hex = HexLiteral(0x0024, None)
-  lazy val hexWithName = HexLiteral(0x0024, Some("DOLLAR SIGN"))
+  lazy val hex = HexLiteral(0x0024, None, false)
+  lazy val hexWithName = HexLiteral(0x0024, Some("DOLLAR SIGN"), false)
   lazy val code = CodeLiteral("|")
   lazy val grSym = GrammarSymbolLiteral("A", Nil)
   lazy val grSymIdx = GrammarSymbolLiteral("A", List("~Yield", "+Await"))
-  lazy val nt = NonterminalLiteral(None, "Identifier", Nil)
-  lazy val firstNt = NonterminalLiteral(Some(1), "Identifier", Nil)
-  lazy val secondNt = NonterminalLiteral(Some(2), "Identifier", Nil)
-  lazy val ntFlags = NonterminalLiteral(None, "A", List("~Yield", "+Await"))
+  lazy val nt = NonterminalLiteral(None, "Identifier", Nil, false)
+  lazy val firstNt = NonterminalLiteral(Some(1), "Identifier", Nil, false)
+  lazy val firstNtWithArticle =
+    NonterminalLiteral(Some(1), "Identifier", Nil, true)
+  lazy val secondNt = NonterminalLiteral(Some(2), "Identifier", Nil, false)
+  lazy val secondNtWithArticle =
+    NonterminalLiteral(Some(2), "Identifier", Nil, true)
+  lazy val ntFlags =
+    NonterminalLiteral(None, "A", List("~Yield", "+Await"), false)
   lazy val empty = EnumLiteral("empty")
   lazy val emptyStr = StringLiteral("")
   lazy val str = StringLiteral("abc")
@@ -336,12 +351,21 @@ object LangTest {
     IsAreCondition(List(refExpr), T, List(TrueLiteral(), FalseLiteral()))
   lazy val binaryCondLt =
     BinaryCondition(refExpr, BinaryConditionOperator.LessThan, addExpr)
+  lazy val inclusiveIntervalCondShort =
+    InclusiveIntervalCondition(
+      refExpr,
+      F,
+      DecimalMathValueLiteral(BigDecimal(2)),
+      DecimalMathValueLiteral(BigDecimal(32)),
+      false,
+    )
   lazy val inclusiveIntervalCond =
     InclusiveIntervalCondition(
       refExpr,
       F,
       DecimalMathValueLiteral(BigDecimal(2)),
       DecimalMathValueLiteral(BigDecimal(32)),
+      true,
     )
   lazy val notInclusiveIntervalCond =
     inclusiveIntervalCond.copy(negation = T)
@@ -376,7 +400,7 @@ object LangTest {
 
   // algorithm references
   lazy val fieldProp = FieldProperty("Value")
-  lazy val componentProp = ComponentProperty("Realm")
+  lazy val componentProp = ComponentProperty("Realm", ComponentPropertyForm.Dot)
   lazy val bindingProp = BindingProperty(refExpr)
   lazy val indexProp = IndexProperty(refExpr)
   lazy val intrProp = IntrinsicProperty(intr)

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -287,25 +287,44 @@ object LangTest {
     ConversionExpression(
       ConversionExpressionOperator.ToApproxNumber,
       refExpr,
+      ConversionExpressionForm.Text("an", "representing", None),
     )
   lazy val convToNumberTextExpr =
     ConversionExpression(
       ConversionExpressionOperator.ToNumber,
       codeUnitAtExpr,
+      ConversionExpressionForm.Text("the", "of", None),
     )
   lazy val convToBigIntTextExpr =
     ConversionExpression(
       ConversionExpressionOperator.ToBigInt,
       codeUnitAtExpr,
+      ConversionExpressionForm.Text("the", "of", None),
     )
   lazy val convToMathTextExpr =
-    ConversionExpression(ConversionExpressionOperator.ToMath, codeUnitAtExpr)
+    ConversionExpression(
+      ConversionExpressionOperator.ToMath,
+      codeUnitAtExpr,
+      ConversionExpressionForm.Text("the", "of", None),
+    )
   lazy val convToNumberExpr =
-    ConversionExpression(ConversionExpressionOperator.ToNumber, refExpr)
+    ConversionExpression(
+      ConversionExpressionOperator.ToNumber,
+      refExpr,
+      ConversionExpressionForm.SyntaxLiteral,
+    )
   lazy val convToBigIntExpr =
-    ConversionExpression(ConversionExpressionOperator.ToBigInt, refExpr)
+    ConversionExpression(
+      ConversionExpressionOperator.ToBigInt,
+      refExpr,
+      ConversionExpressionForm.SyntaxLiteral,
+    )
   lazy val convToMathExpr =
-    ConversionExpression(ConversionExpressionOperator.ToMath, refExpr)
+    ConversionExpression(
+      ConversionExpressionOperator.ToMath,
+      refExpr,
+      ConversionExpressionForm.SyntaxLiteral,
+    )
 
   // algorithm literals
   lazy val hex = HexLiteral(0x0024, None, false)

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -28,40 +28,58 @@ object LangTest {
   // ---------------------------------------------------------------------------
   // algorithm steps
   // ---------------------------------------------------------------------------
-  lazy val letStep = LetStep(x, refExpr)
+  trait StepUpdater { def apply[T <: Step](s: T): T }
+
+  def genStepEnder(punctuation: String): StepUpdater =
+    new StepUpdater {
+      def apply[T <: Step](s: T): T =
+        s.endingChar = punctuation
+        s
+    }
+  lazy val dot = genStepEnder(".")
+  lazy val semicolon = genStepEnder(";")
+
+  lazy val letStep = dot(LetStep(x, refExpr))
+  lazy val letStepSemicolon = semicolon(LetStep(x, refExpr))
   lazy val letStepClosure =
     LetStep(x, AbstractClosureExpression(List(x, x), List(x), blockStep))
-  lazy val setStep = SetStep(x, addExpr)
-  lazy val setAsStep = SetAsStep(x, "specified", "id")
+  lazy val setStep = dot(SetStep(x, addExpr))
+  lazy val setAsStep = dot(SetAsStep(x, "specified", "id"))
   lazy val setEvalStateStep = SetEvaluationStateStep(x, x, Nil)
   lazy val setEvalStateArgStep = SetEvaluationStateStep(x, x, List(refExpr))
   lazy val setEvalStateArgsStep =
     SetEvaluationStateStep(x, x, List(refExpr, refExpr))
-  lazy val performStep = PerformStep(invokeAOExpr)
-  lazy val invokeShorthandStep = InvokeShorthandStep(
-    "IfAbruptCloseIterator",
-    List(refExpr, refExpr),
+  lazy val performStep = dot(PerformStep(invokeAOExpr))
+  lazy val invokeShorthandStep = dot(
+    InvokeShorthandStep(
+      "IfAbruptCloseIterator",
+      List(refExpr, refExpr),
+    ),
   )
-  lazy val appendStep = AppendStep(refExpr, fieldRef)
-  lazy val prependStep = PrependStep(refExpr, fieldRef)
-  lazy val addStep = AddStep(refExpr, fieldRef)
+  lazy val appendStep = dot(AppendStep(refExpr, fieldRef))
+  lazy val prependStep = dot(PrependStep(refExpr, fieldRef))
+  lazy val addStep = dot(AddStep(refExpr, fieldRef))
   import RemoveStep.Target.*
-  lazy val removeStep = RemoveStep(Element(refExpr), "from", refExpr)
-  lazy val removeFirstStep = RemoveStep(First(Some(refExpr)), "from", refExpr)
-  lazy val removeLastStep = RemoveStep(Last(None), "of", refExpr)
-  lazy val pushCtxtStep = PushContextStep(x)
-  lazy val suspendStep = SuspendStep(None, F)
-  lazy val suspendRefStep = SuspendStep(Some(x), F)
-  lazy val suspendAndRemoveStep = SuspendStep(Some(x), T)
+  lazy val removeStep = dot(RemoveStep(Element(refExpr), "from", refExpr))
+  lazy val removeFirstStep = dot(
+    RemoveStep(First(Some(refExpr)), "from", refExpr),
+  )
+  lazy val removeLastStep = dot(RemoveStep(Last(None), "of", refExpr))
+  lazy val pushCtxtStep = dot(PushContextStep(x))
+  lazy val suspendStep = dot(SuspendStep(None, F))
+  lazy val suspendRefStep = dot(SuspendStep(Some(x), F))
+  lazy val suspendAndRemoveStep = dot(SuspendStep(Some(x), T))
   import RemoveContextStep.RestoreTarget.*
-  lazy val removeCtxtStep = RemoveContextStep(x, NoRestore)
-  lazy val removeCtxtRestoreTopStep = RemoveContextStep(x, StackTop)
-  lazy val removeCtxtRestoreStep = RemoveContextStep(x, Context(x))
-  lazy val assertStep = AssertStep(compCond)
+  lazy val removeCtxtStep = dot(RemoveContextStep(x, NoRestore))
+  lazy val removeCtxtRestoreTopStep = dot(RemoveContextStep(x, StackTop))
+  lazy val removeCtxtRestoreStep = dot(RemoveContextStep(x, Context(x)))
+  lazy val assertStep = dot(AssertStep(compCond))
   import IfStep.ElseConfig
   lazy val ifStep = IfStep(exprCond, letStep, None)
   lazy val ifElseInlineStep =
     IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "else", T))
+  lazy val ifElseInlineSemicolonStep =
+    IfStep(exprCond, letStepSemicolon, Some(letStep), ElseConfig(F, "else", T))
   lazy val ifOtherwiseInlineStep =
     IfStep(exprCond, letStep, Some(letStep), ElseConfig(F, "otherwise", T))
   lazy val ifOtherwiseInlineNoCommaStep =
@@ -105,8 +123,8 @@ object LangTest {
     ForEachOwnPropertyKeyStepOrder.ChronologicalOrder,
     letStep,
   )
-  lazy val returnStep = ReturnStep(refExpr)
-  lazy val throwStep = ThrowStep("ReferenceError")
+  lazy val returnStep = dot(ReturnStep(refExpr))
+  lazy val throwStep = dot(ThrowStep("ReferenceError"))
   lazy val resumeStep = ResumeStep(x, refExpr, x, x, List(subStep))
   lazy val resumeEvalStep = ResumeEvaluationStep(x, None, None, List(subStep))
   lazy val resumeEvalArgStep =

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -203,8 +203,8 @@ object LangTest {
     )
   lazy val riaCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, T)
   lazy val riaNoCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, F)
-  lazy val emptyListExpr = ListExpression(Nil)
-  lazy val listExpr = ListExpression(List(refExpr, refExpr))
+  lazy val emptyListExpr = ListExpression(Nil, false)
+  lazy val listExpr = ListExpression(List(refExpr, refExpr), false)
   lazy val xrefAlgoExpr = XRefExpression(XRefExpressionOperator.Algo, "sec-x")
   lazy val xrefSlotsExpr =
     XRefExpression(XRefExpressionOperator.InternalSlots, "sec-x")

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -146,12 +146,16 @@ object LangTest {
     ListConcatExpression(List(refExpr, refExpr, refExpr))
   lazy val listCopyExpr = ListCopyExpression(refExpr)
   lazy val recordEmptyExpr =
-    RecordExpression("Object", Nil, RecordExpressionForm.Normal(false))
+    RecordExpression(
+      "Object",
+      Nil,
+      RecordExpressionForm.SyntaxLiteral(None),
+    )
   lazy val recordExpr =
     RecordExpression(
       "Object",
       List(fieldLit -> refExpr),
-      RecordExpressionForm.Normal(false),
+      RecordExpressionForm.SyntaxLiteral(None),
     )
   lazy val lengthExpr = LengthExpression(refExpr)
   lazy val substrExpr = SubstringExpression(refExpr, refExpr, None)
@@ -159,10 +163,10 @@ object LangTest {
   lazy val trim = TrimExpression(refExpr, T, T)
   lazy val trimStart = TrimExpression(refExpr, T, F)
   lazy val trimEnd = TrimExpression(refExpr, F, T)
-  lazy val numberOfExpr = NumberOfExpression("elements", None, refExpr)
-  lazy val numberOfBytesExpr = NumberOfExpression("bytes", None, refExpr)
+  lazy val numberOfExpr = NumberOfExpression("elements", None, refExpr, None)
+  lazy val numberOfBytesExpr = NumberOfExpression("bytes", None, refExpr, None)
   lazy val numberOfListExpr =
-    NumberOfExpression("elements", Some("List"), refExpr)
+    NumberOfExpression("elements", Some("List"), refExpr, None)
   lazy val sourceTextExpr = SourceTextExpression(nt)
   lazy val coveredByExpr = CoveredByExpression(nt, nt)
   lazy val getItemsExpr = GetItemsExpression(nt, refExpr)
@@ -225,8 +229,12 @@ object LangTest {
     )
   lazy val riaCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, T)
   lazy val riaNoCheckExpr = ReturnIfAbruptExpression(invokeAOExpr, F)
-  lazy val emptyListExpr = ListExpression(Nil, false)
-  lazy val listExpr = ListExpression(List(refExpr, refExpr), false)
+  lazy val emptyListExpr = ListExpression(
+    ListExpressionForm.LiteralSyntax(Nil),
+  )
+  lazy val listExpr = ListExpression(
+    ListExpressionForm.LiteralSyntax(List(refExpr, refExpr)),
+  )
   lazy val xrefAlgoExpr =
     XRefExpression(XRefExpressionOperator.Definition, "sec-x")
   lazy val xrefSlotsExpr =

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -67,9 +67,6 @@ class StringifyTinyTest extends LangTest {
       ifElseInlineStep -> "if _x_, let _x_ be _x_. Else, let _x_ be _x_.",
       ifOtherwiseInlineStep -> "if _x_, let _x_ be _x_. Otherwise, let _x_ be _x_.",
       ifOtherwiseInlineNoCommaStep -> "if _x_, let _x_ be _x_. Otherwise let _x_ be _x_.",
-      ifElseInlineSemicolonStep -> "if _x_, let _x_ be _x_; else, let _x_ be _x_.",
-      ifOtherwiseInlineSemicolonStep -> "if _x_, let _x_ be _x_; otherwise, let _x_ be _x_.",
-      ifOtherwiseInlineNoCommaSemicolonStep -> "if _x_, let _x_ be _x_; otherwise let _x_ be _x_.",
       toBlockStep(ifBlockStep) -> """
       |  1. If _x_, then
       |    1. Let _x_ be _x_.""".stripMargin,

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -313,7 +313,7 @@ class StringifyTinyTest extends LangTest {
     // algorithm literals
     // -------------------------------------------------------------------------
     checkParseAndStringify("Literal", Expression)(
-      ThisLiteral() -> "*this* value",
+      ThisLiteral(None) -> "*this* value",
       NewTargetLiteral() -> "NewTarget",
       hex -> "0x0024",
       hexWithName -> "0x0024 (DOLLAR SIGN)",

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -65,6 +65,7 @@ class StringifyTinyTest extends LangTest {
       assertStep -> "assert: _x_ and _x_.",
       ifStep -> "if _x_, let _x_ be _x_.",
       ifElseInlineStep -> "if _x_, let _x_ be _x_. Else, let _x_ be _x_.",
+      ifElseInlineSemicolonStep -> "if _x_, let _x_ be _x_; else, let _x_ be _x_.",
       ifOtherwiseInlineStep -> "if _x_, let _x_ be _x_. Otherwise, let _x_ be _x_.",
       ifOtherwiseInlineNoCommaStep -> "if _x_, let _x_ be _x_. Otherwise let _x_ be _x_.",
       toBlockStep(ifBlockStep) -> """

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -87,7 +87,7 @@ class StringifyTinyTest extends LangTest {
       |    1. Let _x_ be _x_.
       |  1. Else,
       |    1. Let _x_ be _x_.""".stripMargin,
-      repeatStep -> "repeat, let _x_ be _x_.",
+      // repeatStep -> "repeat, let _x_ be _x_.",
       repeatWhileStep -> """repeat, while _x_ and _x_,
       |  1. Let _x_ be _x_.""".stripMargin,
       repeatUntilStep -> """repeat, until _x_ and _x_,

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -67,6 +67,9 @@ class StringifyTinyTest extends LangTest {
       ifElseInlineStep -> "if _x_, let _x_ be _x_. Else, let _x_ be _x_.",
       ifOtherwiseInlineStep -> "if _x_, let _x_ be _x_. Otherwise, let _x_ be _x_.",
       ifOtherwiseInlineNoCommaStep -> "if _x_, let _x_ be _x_. Otherwise let _x_ be _x_.",
+      ifElseInlineSemicolonStep -> "if _x_, let _x_ be _x_; else, let _x_ be _x_.",
+      ifOtherwiseInlineSemicolonStep -> "if _x_, let _x_ be _x_; otherwise, let _x_ be _x_.",
+      ifOtherwiseInlineNoCommaSemicolonStep -> "if _x_, let _x_ be _x_; otherwise let _x_ be _x_.",
       toBlockStep(ifBlockStep) -> """
       |  1. If _x_, then
       |    1. Let _x_ be _x_.""".stripMargin,
@@ -87,7 +90,7 @@ class StringifyTinyTest extends LangTest {
       |    1. Let _x_ be _x_.
       |  1. Else,
       |    1. Let _x_ be _x_.""".stripMargin,
-      // repeatStep -> "repeat, let _x_ be _x_.",
+      repeatStep -> "repeat, let _x_ be _x_.",
       repeatWhileStep -> """repeat, while _x_ and _x_,
       |  1. Let _x_ be _x_.""".stripMargin,
       repeatUntilStep -> """repeat, until _x_ and _x_,
@@ -165,7 +168,7 @@ class StringifyTinyTest extends LangTest {
       invokeSDOExprZero -> "StringValue of |Identifier|",
       invokeSDOExprSingle -> ("StringValue of |Identifier| with argument |Identifier|"),
       invokeSDOExprMulti -> ("StringValue of |Identifier| with arguments |Identifier| and _x_"),
-      invokeSDOExprEval -> "the result of evaluating |Identifier|",
+      invokeSDOExprEval -> "Evaluation of |Identifier|",
       invokeSDOExprContains -> "|Identifier| Contains _x_",
       riaCheckExpr -> "? ToObject(_x_ + _x_, -_x_)",
       riaNoCheckExpr -> "! ToObject(_x_ + _x_, -_x_)",
@@ -313,14 +316,18 @@ class StringifyTinyTest extends LangTest {
     // algorithm literals
     // -------------------------------------------------------------------------
     checkParseAndStringify("Literal", Expression)(
-      ThisLiteral(None) -> "*this* value",
+      ThisLiteral(false) -> "*this* value",
+      ThisLiteral(true) -> "the *this* value",
+      ThisParseNodeLiteral(None) -> "this Parse Node",
       NewTargetLiteral() -> "NewTarget",
       hex -> "0x0024",
       hexWithName -> "0x0024 (DOLLAR SIGN)",
       code -> "`|`",
       nt -> "|Identifier|",
-      firstNt -> "the first |Identifier|",
-      secondNt -> "the second |Identifier|",
+      firstNt -> "first |Identifier|",
+      firstNtWithArticle -> "the first |Identifier|",
+      secondNt -> "second |Identifier|",
+      secondNtWithArticle -> "the second |Identifier|",
       ntFlags -> "|A[~Yield, +Await]|",
       empty -> "~empty~",
       emptyStr -> """*""*""",
@@ -399,6 +406,7 @@ class StringifyTinyTest extends LangTest {
       isEitherCond -> "_x_ is either *true* or *false*",
       isNeitherCond -> "_x_ is neither *true* nor *false*",
       binaryCondLt -> "_x_ < _x_ + _x_",
+      inclusiveIntervalCondShort -> "2 ≤ _x_ ≤ 32",
       inclusiveIntervalCond -> "_x_ is in the inclusive interval from 2 to 32",
       notInclusiveIntervalCond -> "_x_ is not in the inclusive interval from 2 to 32",
       containsCond -> "_x_ contains _x_",

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -23,9 +23,9 @@ class StringifyTinyTest extends SpecTest {
       Summary(
         Some(version),
         GrammarSummary(145, 16, 195, 28),
-        AlgorithmSummary(2258, 365),
-        StepSummary(18307, 754),
-        TypeSummary(5469, 439, 1543),
+        AlgorithmSummary(2623, 2258, 0),
+        StepSummary(19061, 18307),
+        TypeSummary(5908, 5469, 439),
         89,
         58,
         101,
@@ -37,14 +37,14 @@ class StringifyTinyTest extends SpecTest {
          |    - numeric string: 16
          |    - syntactic: 195
          |  - extended productions for web: 28
-         |- algorithms: 2258
-         |  - complete: 365 (16.16%)
+         |- algorithms: 2623
+         |  - complete: 2258 (86.08%)
          |  - equals: 0 (0.00%)
-         |- algorithm steps: 18307
-         |  - complete: 754 (4.12%)
-         |- types: 5469
-         |  - known: 439 (8.03%)
-         |  - yet: 1543 (28.21%)
+         |- algorithm steps: 19061
+         |  - complete: 18307 (96.04%)
+         |- types: 5908
+         |  - known: 5469 (92.57%)
+         |  - yet: 439 (7.43%)
          |- tables: 89
          |- type model: 58
          |- intrinsics: 101""".stripMargin,

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -37,16 +37,14 @@ class StringifyTinyTest extends SpecTest {
          |    - numeric string: 16
          |    - syntactic: 195
          |  - extended productions for web: 28
-         |- algorithms: 2623 (86.08%)
-         |  - complete: 2258
-         |  - incomplete: 365
-         |- algorithm steps: 19061 (96.04%)
-         |  - complete: 18307
-         |  - incomplete: 754
-         |- types: 5908 (92.57%)
-         |  - known: 5469
-         |  - yet: 439
-         |  - unknown: 1543
+         |- algorithms: 2258
+         |  - complete: 365 (16.16%)
+         |  - equals: 0 (0.00%)
+         |- algorithm steps: 18307
+         |  - complete: 754 (4.12%)
+         |- types: 5469
+         |  - known: 439 (8.03%)
+         |  - yet: 1543 (28.21%)
          |- tables: 89
          |- type model: 58
          |- intrinsics: 101""".stripMargin,


### PR DESCRIPTION
This PR contains fixes on esmeta.lang to support idempotency of extraction. (The body of algorithm should not change after applying Parser -> Stringifier)

- LangElem (Condition, Expression, and Step) uses '*Form' to store various forms of the same element.
```scala
case class StringLiteral(s: String, form: StringLiteralForm) extends Literal

// Normal: "{{ string value }}"
// EmptyString: "the empty String"
// EmptyUnicode: "the empty sequence of Unicode code points"
// Code: <code>{{ string value }}</code>
enum StringLiteralForm:
  case SyntaxLiteral, EmptyString, EmptyUnicode, Code
```
- '*Form' are not used in simple cases where each variation could be expressed as Boolean or String value. 
	- Cases distinguished only by the **presence of** articles, postpositions, etc.
	- Cases where only String values such as prefixes and postfixes change.
```scala
// syntax-directed operation (SDO) invocation expressions
case class InvokeSyntaxDirectedOperationExpression(
  ...
  prefix: Option[
    String,
  ], // `the result of performing`, `the result of` or `the`
  tag: HtmlTag,
) extends InvokeExpression
```
- Minor fixes on Parser to support latest version of spec. (Add new parsing rules / remove unused parsing rules)
- Updates on components of esmeta.lang (especially Stringifier & CaseCollector), Compiler, and LangTest to reflect the changes above.
- The logging mode of extractor now outputs `./logs/extract/yet-equal-algos/*.diff` for each algorithms whose original form is not maintained.
- The `./logs/extract/summary` now displays the number of equal algorithms.

With above changes, the number of equal algorithms has increased to 2,529/2,867 (88.21%) from 1,357/2,852 (47.58%).