### PR TITLE
Fix errors in handling edge case for lang parser for IfStep

### DIFF
--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -182,8 +182,10 @@ trait Parsers extends IndentParsers {
   // if-then-else steps
   lazy val ifStep: PL[IfStep] =
     val ifPart = "if" ~> (
-      (cond <~ ",") <~ opt("then") |
-      yetCond(", then")
+      // if <cond>, then\n<block>
+      guard(".+, then".r) ~> (cond <~ "," ~ "then" | yetCond(", then")) |
+      // if <cond>, <step>
+      (cond <~ ",")
     ) ~ (step | yetStep)
     val elsePart =
       exists(subStepPrefix) ~

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -183,7 +183,7 @@ trait Parsers extends IndentParsers {
   lazy val ifStep: PL[IfStep] =
     val ifPart = "if" ~> (
       // if <cond>, then\n<block>
-      guard(".+, then".r) ~> (cond <~ "," ~ "then" | yetCond(", then")) |
+      cond <~ ", then" | yetCond(", then") |
       // if <cond>, <step>
       (cond <~ ",")
     ) ~ (step | yetStep)
@@ -1108,7 +1108,7 @@ trait Parsers extends IndentParsers {
   } ^^! getExprCond(FalseLiteral())
 
   // not yet supported conditions
-  def yetCond(post: String): PL[Condition] = ".+".r ^^ { str =>
+  def yetCond(post: String): PL[Condition] = s".+$post".r ^^ { str =>
     val s = str.replaceAll(post + "$", "")
     ExpressionCondition(YetExpression(s, None))
   }


### PR DESCRIPTION
This PR contains fixes on IfStep to support proper parsing of yet conditions and its then-part body.

If any of the elements in a compound condition fails to be parsed, the entire condition is parsed with yetCond.

This allows the remaining body of ifPart to be parsed normally, which handles problem proposed on #314 