### PR TITLE
Fix a bug in `__IS_ARRAY_INDEX__` modeling in IR

### DIFF
--- a/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
+++ b/src/main/resources/manuals/funcs/__IS_ARRAY_INDEX__.ir
@@ -4,7 +4,10 @@ def <AUX>:__IS_ARRAY_INDEX__(
   if (= (typeof P) @String) {
     call n = clo<"CanonicalNumericIndexString">(P)
     if (? n: NumberInt) {
-      return (&& (< -1.0f n) (< n (- (** 2.0f 32.0f) 1.0f)))
+      return (&&
+        (! (= n -0.0f))
+        (&& (< -1.0f n) (< n (- (** 2.0f 32.0f) 1.0f)))
+      )
     }
   }
   return false

--- a/tests/es/object4.ir
+++ b/tests/es/object4.ir
@@ -1,0 +1,5 @@
+assert (= @REALM.GlobalObject.__MAP__.keys.Value.__MAP__.length.Value 4.0f)
+assert (= @REALM.GlobalObject.__MAP__.keys.Value.__MAP__[0].Value "0")
+assert (= @REALM.GlobalObject.__MAP__.keys.Value.__MAP__[0].Value "1")
+assert (= @REALM.GlobalObject.__MAP__.keys.Value.__MAP__[0].Value "-0")
+assert (= @REALM.GlobalObject.__MAP__.keys.Value.__MAP__[0].Value "x")

--- a/tests/es/object4.js
+++ b/tests/es/object4.js
@@ -1,0 +1,8 @@
+var obj = { "-0": 42, "0": 42, "1": 42, "x": 44 };
+var keys = Reflect.ownKeys(obj);
+print(keys);
+print(keys.length);
+print(keys[0]);
+print(keys[1]);
+print(keys[2]);
+print(keys[3]);

--- a/tests/result/es/EvalSmallTest
+++ b/tests/result/es/EvalSmallTest
@@ -1,1 +1,1 @@
-es.EvalSmallTest: 107 / 107
+es.EvalSmallTest: 108 / 108

--- a/tests/result/es/EvalSmallTest.json
+++ b/tests/result/es/EvalSmallTest.json
@@ -83,6 +83,7 @@
   "object1.js" : true,
   "object2.js" : true,
   "object3.js" : true,
+  "object4.js" : true,
   "promise1.js" : true,
   "read-property1.js" : true,
   "semicolon-insertion1.js" : true,

--- a/tests/result/es/ParseSmallTest
+++ b/tests/result/es/ParseSmallTest
@@ -1,1 +1,1 @@
-es.ParseSmallTest: 107 / 107
+es.ParseSmallTest: 108 / 108

--- a/tests/result/es/ParseSmallTest.json
+++ b/tests/result/es/ParseSmallTest.json
@@ -83,6 +83,7 @@
   "object1.js" : true,
   "object2.js" : true,
   "object3.js" : true,
+  "object4.js" : true,
   "promise1.js" : true,
   "read-property1.js" : true,
   "semicolon-insertion1.js" : true,


### PR DESCRIPTION
As mentioned in https://github.com/es-meta/esmeta/issues/317, there is a bug in the modeling of `__IS_ARRAY_INDEX__` related to the `"-0"`. While "-0" is not an [_array index_](https://tc39.es/ecma262/2025/multipage/ecmascript-data-types-and-values.html#array-index), the `__IS_ARRAY_INDEX__("-0")` returns `true` instead of `false`.

To resolve this problem, we add an explicit check of this case as follows:
```diff
   if (= (typeof P) @String) {
     call n = clo<"CanonicalNumericIndexString">(P)
     if (? n: NumberInt) {
-      return (&& (< -1.0f n) (< n (- (** 2.0f 32.0f) 1.0f)))
+      return (&&
+        (! (= n -0.0f))
+        (&& (< -1.0f n) (< n (- (** 2.0f 32.0f) 1.0f)))
+      )
     }
   }
   return false
```

I believe that this also resolves the problem in https://github.com/tc39/test262/pull/4603.