### PR TITLE
No Status Mode for NotSupported Error

### DIFF
--- a/src/main/scala/esmeta/ESMeta.scala
+++ b/src/main/scala/esmeta/ESMeta.scala
@@ -19,6 +19,10 @@ object ESMeta extends Git(BASE_DIR) {
           case None      => throw NoCmdError(str)
         }
   catch
+    // NotSupported: print only the error message and no status mode.
+    case e: NotSupported =>
+      Console.err.println(getMessage(e))
+      if (ERROR_MODE) throw e
     // ESMetaError: print only the error message.
     case e: ESMetaError =>
       Console.err.println(getMessage(e))


### PR DESCRIPTION
If we turn on the `-status` option, ESMeta exits with status even when it meets the intended `ESMetaError`.

However, I think it is better to exit without a status for the `NotSupported` error because it is actually not an error but a warning. For instance, in https://github.com/tc39/test262/pull/4623#issuecomment-3523487990, this [test](https://github.com/tc39/test262/actions/runs/18957730032/job/54138279811?pr=4623) fails because it exists with the status because of the `NotSupported` error for a single test file.