### PR TITLE
Refactoring for Occurrence Typing Implementation

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -8,7 +8,6 @@
   "FinishLoadingImportedModule",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
-  "INTRINSICS.Atomics.compareExchange",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "Record[SourceTextModuleRecord].GetExportedNames",
   "Record[SourceTextModuleRecord].InitializeEnvironment",

--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -9,7 +9,6 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "INTRINSICS.Atomics.compareExchange",
-  "INTRINSICS.Atomics.notify",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "Record[SourceTextModuleRecord].GetExportedNames",
   "Record[SourceTextModuleRecord].InitializeEnvironment",

--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -9,8 +9,5 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "Record[SourceTextModuleRecord].GetExportedNames",
-  "Record[SourceTextModuleRecord].InitializeEnvironment",
-  "Record[SourceTextModuleRecord].ResolveExport",
   "TypedArrayLength"
 ]

--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -5,7 +5,6 @@
   "CompareTypedArrayElements",
   "DoWait",
   "EvaluateImportCall",
-  "FinishLoadingImportedModule",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "GetViewByteLength",
   "Record[SourceTextModuleRecord].ExecuteModule",

--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -551,7 +551,7 @@ type RealmRecord {
   GlobalObject: Record[Object];
   GlobalEnv: Record[GlobalEnvironmentRecord];
   TemplateMap: List[Record[{ Site: Ast[TemplateLiteral], Array: Record[Array] }]];
-  LoadedModules: List[Record[{ Specifier: String, Module: Record[ModuleRecord] }]];
+  LoadedModules: List[Record[LoadedModuleRequestRecord]];
   HostDefined: Undefined;
 }
 

--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -661,8 +661,27 @@ type Iterator extends Object
 type ScriptRecord {
   Realm: Record[RealmRecord];
   ECMAScriptCode: Ast[Script];
-  LoadedModules: List[Record[{ Specifier: String, Module: Record[ModuleRecord] }]];
+  LoadedModules: List[Record[LoadedModuleRequestRecord]];
   HostDefined: Enum[~empty~];
+}
+
+// https://tc39.es/ecma262/#modulerequest-record
+type ModuleRequestRecord {
+  Specifier: String;
+  Attributes: List[Record[ImportAttributeRecord]];
+}
+
+// https://tc39.es/ecma262/#loadedmodulerequest-record
+type LoadedModuleRequestRecord {
+  Specifier: String;
+  Attributes:	List[Record[ImportAttributeRecord]];
+  Module: Record[ModuleRecord];
+}
+
+// https://tc39.es/ecma262/#importattribute-record
+type ImportAttributeRecord {
+  Key: String;
+  Value: String;
 }
 
 // https://tc39.es/ecma262/#sec-abstract-module-records
@@ -695,8 +714,8 @@ type CyclicModuleRecord extends ModuleRecord {
   EvaluationError: Abrupt[throw] | Enum[~empty~];
   DFSIndex: Enum[~empty~] | Int;
   DFSAncestorIndex: Enum[~empty~] | Int;
-  RequestedModules: List[String];
-  LoadedModules: List[Record[{ Specifier: String, Module: Record[ModuleRecordN] }]];
+  RequestedModules: List[Record[ModuleRequestRecord]];
+  LoadedModules: List[Record[LoadedModuleRequestRecord]];
   CycleRoot: Record[CyclicModuleRecord] | Enum[~empty~];
   HasTLA: Boolean;
   AsyncEvaluation: Boolean;
@@ -737,7 +756,7 @@ type ResolvedBindingRecord {
 
 // https://tc39.es/ecma262/#importentry-record
 type ImportEntryRecord {
-  ModuleRequest: String;
+  ModuleRequest: Record[ModuleRequestRecord];
   ImportName: String | Enum[~namespace-object~];
   LocalName: String;
 }
@@ -745,7 +764,7 @@ type ImportEntryRecord {
 // https://tc39.es/ecma262/#exportentry-record
 type ExportEntryRecord {
   ExportName: String | Null;
-  ModuleRequest: String | Null;
+  ModuleRequest: Record[ModuleRequestRecord] | Null;
   ImportName: String | Null | Enum[~all~, ~all-but-default~];
   LocalName: String | Null;
 }

--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -440,18 +440,54 @@ type TypedArray extends ExoticObject {
 }
 
 // https://tc39.es/ecma262/#table-the-typedarray-constructors
-type Int8Array extends TypedArray { TypedArrayName: String["Int8Array"]; }
-type Uint8Array extends TypedArray { TypedArrayName: String["Uint8Array"]; }
-type Uint8ClampedArray extends TypedArray { TypedArrayName: String["Uint8ClampedArray"]; }
-type Int16Array extends TypedArray { TypedArrayName: String["Int16Array"]; }
-type Uint16Array extends TypedArray { TypedArrayName: String["Uint16Array"]; }
-type Int32Array extends TypedArray { TypedArrayName: String["Int32Array"]; }
-type Uint32Array extends TypedArray { TypedArrayName: String["Uint32Array"]; }
-type BigInt64Array extends TypedArray { TypedArrayName: String["BigInt64Array"]; }
-type BigUint64Array extends TypedArray { TypedArrayName: String["BigUint64Array"]; }
-type Float16Array extends TypedArray { TypedArrayName: String["Float16Array"]; }
-type Float32Array extends TypedArray { TypedArrayName: String["Float32Array"]; }
-type Float64Array extends TypedArray { TypedArrayName: String["Float64Array"]; }
+type Int8Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Int8Array"];
+}
+type Uint8Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Uint8Array"];
+}
+type Uint8ClampedArray extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Uint8ClampedArray"];
+}
+type Int16Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Int16Array"];
+}
+type Uint16Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Uint16Array"];
+}
+type Int32Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Int32Array"];
+}
+type Uint32Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Uint32Array"];
+}
+type BigInt64Array extends TypedArray {
+  ContentType: Enum[~bigint~];
+  TypedArrayName: String["BigInt64Array"];
+}
+type BigUint64Array extends TypedArray {
+  ContentType: Enum[~bigint~];
+  TypedArrayName: String["BigUint64Array"];
+}
+type Float16Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Float16Array"];
+}
+type Float32Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Float32Array"];
+}
+type Float64Array extends TypedArray {
+  ContentType: Enum[~number~];
+  TypedArrayName: String["Float64Array"];
+}
 
 // https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
 type ModuleNamespaceExoticObject extends ExoticObject {

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -14,5 +14,5 @@
   - known: 7395 (89.53%)
   - yet: 191 (2.31%)
 - tables: 99
-- type model: 109
+- type model: 112
 - intrinsics: 101

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsRet.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsRet.scala
@@ -12,7 +12,8 @@ trait AbsRetDecl { self: TyChecker =>
     def isBottom: Boolean = value.isBottom
 
     /** partial order */
-    def ⊑(that: AbsRet)(using AbsState): Boolean = this.value ⊑ that.value
+    def ⊑(that: AbsRet)(using AbsState): Boolean =
+      this.value ⊑ that.value
 
     /** not partial order */
     def !⊑(that: AbsRet)(using AbsState): Boolean = !(this ⊑ that)

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -65,8 +65,13 @@ trait AbsStateDecl { self: TyChecker =>
             (this.kill(lxs, update = false), that.kill(rxs, update = false))
           else (this, that)
         val newLocals = (for {
-          x <- (l.locals.keySet ++ r.locals.keySet).toList
-          v = AbsValue.joinHelper(l.get(x), l, r.get(x), r)
+          x <- (this.locals.keySet ++ that.locals.keySet).toList
+          v = {
+            val lv = this.get(x)
+            val rv = that.get(x)
+            if (lv == rv) lv
+            else AbsValue.joinHelper(l.get(x), l, r.get(x), r)
+          }
         } yield x -> v).toMap
         val newSymEnv = (for {
           sym <- (l.symEnv.keySet ++ r.symEnv.keySet).toList

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -254,7 +254,10 @@ trait AbsStateDecl { self: TyChecker =>
     def update(x: Var, value: AbsValue, refine: Boolean): AbsState = x match
       case x: Local =>
         val newSt = if (refine) this else this.kill(Set(x), update = true)
-        val newV = if (refine) value else value.kill(Set(x), update = true)
+        val newV =
+          if (!refine) value.kill(Set(x), update = true)
+          else if (value.hasLocalBase(x)) value.kill(Set(x), update = false)
+          else value
         newSt.copy(locals = newSt.locals + (x -> newV), constr = newSt.constr)
       case x: Global => this
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -16,7 +16,7 @@ trait AbsStateDecl { self: TyChecker =>
     reachable: Boolean,
     locals: Map[Local, AbsValue],
     symEnv: Map[Sym, ValueTy],
-    pred: SymPred,
+    constr: TypeConstr,
   ) extends AbsStateLike {
     import AbsState.*
 
@@ -33,11 +33,11 @@ trait AbsStateDecl { self: TyChecker =>
       case _ if this.isBottom => true
       case _ if that.isBottom => false
       case (
-            AbsState(_, llocals, lsymEnv, lpred),
-            AbsState(_, rlocals, rsymEnv, rpred),
+            AbsState(_, llocals, lsymEnv, lconstr),
+            AbsState(_, rlocals, rsymEnv, rconstr),
           ) =>
-        val SymPred(lmap, lexpr) = lpred
-        val SymPred(rmap, rexpr) = rpred
+        val TypeConstr(lmap, lexpr) = lconstr
+        val TypeConstr(rmap, rexpr) = rconstr
         llocals.forall { (x, lv) =>
           rlocals.get(x).fold(false) { rv =>
             AbsValue.orderHelper(lv, this, rv, that)
@@ -59,7 +59,7 @@ trait AbsStateDecl { self: TyChecker =>
       case _ if that.isBottom => this
       case _ =>
         val (l, r) =
-          if (this.pred != that.pred)
+          if (this.constr != that.constr)
             val lxs = this.getImprecBases(that)
             val rxs = that.getImprecBases(this)
             (this.kill(lxs, update = false), that.kill(rxs, update = false))
@@ -70,13 +70,13 @@ trait AbsStateDecl { self: TyChecker =>
         } yield x -> v).toMap
         val newSymEnv = (for {
           sym <- (l.symEnv.keySet ++ r.symEnv.keySet).toList
-          ty = l.getTy(sym) || r.getTy(sym)
+          ty = l.get(sym) || r.get(sym)
         } yield sym -> ty).toMap
-        val newPred = l.pred || r.pred
-        AbsState(true, newLocals, newSymEnv, newPred)
+        val newConstr = l.constr || r.constr
+        AbsState(true, newLocals, newSymEnv, newConstr)
 
     /** get imprecise bases compared with another state */
-    def getImprecBases(that: AbsState): Set[SymBase] =
+    def getImprecBases(that: AbsState): Set[Base] =
       val locals = (for {
         (x, lv) <- this.locals
         if that.locals.get(x) match
@@ -101,16 +101,16 @@ trait AbsStateDecl { self: TyChecker =>
         } yield x -> v).toMap
         val newSymEnv = (for {
           sym <- (l.symEnv.keySet intersect r.symEnv.keySet).toList
-          ty = l.getTy(sym) ⊓ r.getTy(sym)
+          ty = l.get(sym) ⊓ r.get(sym)
         } yield sym -> ty).toMap
-        val newPred = l.pred && r.pred
-        AbsState(true, newLocals, newSymEnv, newPred)
+        val newConstr = l.constr && r.constr
+        AbsState(true, newLocals, newSymEnv, newConstr)
 
     /** kill bases */
-    def kill(bases: Set[SymBase], update: Boolean): AbsState =
+    def kill(bases: Set[Base], update: Boolean): AbsState =
       val newLocals = for { (x, v) <- locals } yield x -> v.kill(bases, update)
-      val newPred = if (update) pred.kill(bases) else pred
-      AbsState(reachable, newLocals, symEnv, newPred)
+      val newConstr = if (update) constr.kill(bases) else constr
+      AbsState(reachable, newLocals, symEnv, newConstr)
 
     /** has imprecise elements */
     def hasImprec: Boolean = locals.values.exists(_.ty.isImprec)
@@ -119,6 +119,16 @@ trait AbsStateDecl { self: TyChecker =>
     def get(x: Var): AbsValue = x match
       case x: Global => base.getOrElse(x, AbsValue.Bot)
       case x: Local  => locals.getOrElse(x, AbsValue.Bot)
+
+    def get(sym: Sym): ValueTy = symEnv.getOrElse(sym, BotT)
+
+    def get(sty: SymTy): AbsValue = AbsValue(sty)
+
+    def getTy(sty: SymTy): ValueTy = sty.ty
+
+    def getTy(base: Base): ValueTy = base match
+      case l: Local => get(l).ty
+      case s: Sym   => get(s)
 
     /** getter for symbolic expressions */
     def getTy(expr: SymExpr): ValueTy = {
@@ -130,33 +140,15 @@ trait AbsStateDecl { self: TyChecker =>
         case SETypeCheck(base, ty) => BoolT
         case SETypeOf(base)        => BoolT
         case SEEq(left, right)     => BoolT
-        case SEOr(left, right)     => BoolT
-        case SEAnd(left, right)    => BoolT
-        case SENot(expr)           => BoolT
     }
-
-    /** getter for symbolic references */
-    def getTy(ref: SymRef): ValueTy = {
-      import SymRef.*
-      ref match
-        case SBase(x)            => getTy(x)
-        case SField(base, field) => get(getTy(base), getTy(field))
-    }
-
-    /** getter for symbolic bases */
-    def getTy(x: SymBase): ValueTy = x match
-      case x: Sym   => symEnv.getOrElse(x, BotT)
-      case x: Local => get(x).ty
-
-    def getTy(x: SymTy): ValueTy = x.ty(using this)
 
     /** getter */
     def get(base: AbsValue, field: AbsValue)(using AbsState): AbsValue = {
-      import SymExpr.*, SymRef.*, SymTy.*
+      import SymExpr.*, SymTy.*
       val guard = lookupGuard(base.guard, field)
       (base.symty, field.ty.getSingle) match
-        case (SRef(ref), One(Str(f))) =>
-          AbsValue(SRef(SField(ref, STy(StrT(f)))), guard)
+        case (ref: SymRef, One(Str(f))) =>
+          AbsValue(SField(ref, STy(StrT(f))), guard)
         case _ =>
           AbsValue(STy(get(base.ty, field.ty)), guard)
     }
@@ -206,7 +198,7 @@ trait AbsStateDecl { self: TyChecker =>
       if (str.isBottom) BotT
       else {
         var res = BotT
-        if (field.str contains "length") res ||= NonNegIntT
+        if (field.str.contains("length")) res ||= NonNegIntT
         if (!field.math.isBottom) res ||= CodeUnitT
         res
       }
@@ -241,14 +233,14 @@ trait AbsStateDecl { self: TyChecker =>
       guard: TypeGuard,
       field: AbsValue,
     )(using AbsState): TypeGuard = {
-      import RefinementKind.*
+      import DemandType.*
       field.ty.str.getSingle match
         case One("Value") =>
           TypeGuard(guard.map.collect {
-            case (RefinementKind(ty), map) if ty == NormalT(TrueT) =>
-              RefinementKind(TrueT) -> map
-            case (RefinementKind(ty), map) if ty == NormalT(FalseT) =>
-              RefinementKind(FalseT) -> map
+            case (DemandType(ty), map) if ty == NormalT(TrueT) =>
+              DemandType(TrueT) -> map
+            case (DemandType(ty), map) if ty == NormalT(FalseT) =>
+              DemandType(FalseT) -> map
           })
         case _ => TypeGuard.Empty
     }
@@ -263,7 +255,7 @@ trait AbsStateDecl { self: TyChecker =>
       case x: Local =>
         val newSt = if (refine) this else this.kill(Set(x), update = true)
         val newV = if (refine) value else value.kill(Set(x), update = true)
-        newSt.copy(locals = newSt.locals + (x -> newV), pred = newSt.pred)
+        newSt.copy(locals = newSt.locals + (x -> newV), constr = newSt.constr)
       case x: Global => this
 
     /** type check */
@@ -332,27 +324,27 @@ trait AbsStateDecl { self: TyChecker =>
     lazy val Top: AbsState = exploded("top abstract state")
 
     /** bottom element */
-    lazy val Bot: AbsState = AbsState(false, Map(), Map(), SymPred())
+    lazy val Bot: AbsState =
+      AbsState(false, Map(), Map(), TypeConstr())
 
     /** empty element */
-    lazy val Empty: AbsState = AbsState(true, Map(), Map(), SymPred())
+    lazy val Empty: AbsState =
+      AbsState(true, Map(), Map(), TypeConstr())
 
     /** appender */
     given rule: Rule[AbsState] = mkRule(true)
 
     // appender generator
     private def mkRule(detail: Boolean): Rule[AbsState] = (app, elem) =>
-      import esmeta.ir.given
+      import SymTy.given
       if (!elem.isBottom) {
-        val AbsState(reachable, locals, symEnv, pred) = elem
+        val AbsState(reachable, locals, symEnv, constr) = elem
         given localsRule: Rule[Map[Local, AbsValue]] = sortedMapRule(sep = ": ")
         given symEnvRule: Rule[Map[Sym, ValueTy]] = sortedMapRule(sep = ": ")
-        given predRule: Rule[Map[SymBase, ValueTy]] =
-          sortedMapRule(sep = " <: ")
+        given constrRule: Rule[Map[Base, ValueTy]] = sortedMapRule(sep = " <: ")
         if (locals.nonEmpty) app >> locals
         if (symEnv.nonEmpty) app >> symEnv
-        app >> pred
-        app
+        app >> constr
       } else app >> "⊥"
   }
 }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -82,6 +82,9 @@ trait AbsValueDecl { self: TyChecker =>
     def lift(using st: AbsState): AbsValue =
       AbsValue(symty, guard.lift(this.ty))
 
+    /** check whether it has a local variable as a base */
+    def hasLocalBase(x: Local): Boolean = bases.exists(_ == x)
+
     /** check whether it has a type guard */
     def hasTypeGuard(entrySt: AbsState): Boolean =
       import SymTy.*, SymExpr.*

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -54,14 +54,14 @@ trait AbsValueDecl { self: TyChecker =>
       this.copy(guard = (this.guard && guard).filter(this.ty))
 
     /** kill bases */
-    def kill(bases: Set[SymBase], update: Boolean)(using AbsState): AbsValue =
+    def kill(bases: Set[Base], update: Boolean)(using AbsState): AbsValue =
       val ty = this.symty.bases.exists(bases.contains) match
         case true  => STy(this.ty)
         case false => this.symty
       val guard = if (update) this.guard.kill(bases) else this.guard
       AbsValue(ty, guard)
 
-    /** normalize abstract values for return */
+    /** remove non-parameter local variables */
     def forReturn(
       givenSt: AbsState,
       func: Func,
@@ -70,40 +70,32 @@ trait AbsValueDecl { self: TyChecker =>
       given AbsState = givenSt
       if (isTypeGuardCandidate(func)) {
         val xs = givenSt.getImprecBases(entrySt)
-        this.forReturn(entrySt).kill(xs, update = false)
+        this.kill(xs, update = false)
       } else AbsValue(this.ty)
 
-    /** normalize abstract values for return */
-    def forReturn(entrySt: AbsState): AbsValue =
-      copy(guard = guard.forReturn(entrySt.symEnv))
-
     /** get symbols */
-    def bases: Set[SymBase] =
+    def bases: Set[Base] =
       val inSymty = symty.bases
       val inGuard = guard.bases
       inSymty ++ inGuard
 
-    /** get symbolic expression when it only has a symbolic expression */
-    // TODO: Erase this
-    // def getSymExpr: Option[SymExpr] = expr match
-    //   case One(expr) if lowerTy.isBottom => Some(expr)
-    //   case _                             => None
-
-    /** introduce a new type guard */
-    def getTypeGuard(using st: AbsState): TypeGuard = TypeGuard((for {
-      kind <- RefinementKind.from(this.ty).toList
-      pred = st.pred
-      if pred.nonTop
-    } yield kind -> pred).toMap)
+    def lift(using st: AbsState): AbsValue =
+      AbsValue(symty, guard.lift(this.ty))
 
     /** check whether it has a type guard */
     def hasTypeGuard(entrySt: AbsState): Boolean =
-      guard.map.exists { (kind, pred) =>
-        pred.map.exists {
-          case (x: Sym, (ty, _)) => !(entrySt.getTy(x) <= ty)
+      import SymTy.*, SymExpr.*
+      guard.map.exists { (kind, constr) =>
+        constr.map.exists {
+          case (x: Sym, (ty, _)) => !(entrySt.getTy(SERef(SSym(x))) <= ty)
           case _                 => false
         }
       }
+
+    def killMutable(using np: NodePoint[_], st: AbsState) =
+      this.copy(guard = this.guard.kill(np.func.mutableLocals))
+
+    def isSymbolic: Boolean = symty.isSymbolic
 
     /** get lexical result */
     def getLexical(method: String)(using AbsState): AbsValue = {
@@ -474,8 +466,8 @@ trait AbsValueDecl { self: TyChecker =>
     given rule: Rule[AbsValue] = (app, elem) =>
       val irStringifier = IRElem.getStringifier(true, false)
       import irStringifier.given
-      given Rule[Map[Local, ValueTy]] = sortedMapRule("[", "]", " <: ")
       given Ordering[Local] = Ordering.by(_.toString)
+      given Rule[Map[Local, ValueTy]] = sortedMapRule("[", "]", " <: ")
       val AbsValue(symty, guard) = elem
       app >> symty
       if (guard.nonEmpty) app >> " " >> guard

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -6,183 +6,227 @@ import esmeta.ty.*
 import esmeta.util.{*, given}
 import esmeta.util.Appender.*
 import esmeta.util.BaseUtils.*
+import esmeta.util.SystemUtils.exists
 
 /** type guards */
 trait TypeGuardDecl { self: TyChecker =>
 
   /** type guard */
-  case class TypeGuard(map: Map[RefinementKind, SymPred] = Map()) {
+  case class TypeGuard(map: Map[DemandType, TypeConstr] = Map()) {
     def isEmpty: Boolean = map.isEmpty
     def nonEmpty: Boolean = !isEmpty
-    def kinds: Set[RefinementKind] = map.keySet
-    def get(kind: RefinementKind): Option[SymPred] = map.get(kind)
-    def apply(kind: RefinementKind): SymPred = map.getOrElse(kind, SymPred())
-    def bases: Set[SymBase] = map.values.flatMap(_.bases).toSet
-    def kill(bases: Set[SymBase])(using AbsState): TypeGuard = TypeGuard(for {
-      (kind, pred) <- map
-      newPred = pred.kill(bases)
-      if newPred.nonTop
-    } yield kind -> newPred)
+    def dtys: Set[DemandType] = map.keySet
+    def get(dty: DemandType): Option[TypeConstr] = map.get(dty)
+
+    def apply(dty: DemandType): TypeConstr =
+      map.getOrElse(dty, TypeConstr())
+
+    def bases: Set[Base] = map.values.flatMap(_.bases).toSet
+
+    def kill(bases: Set[Base])(using AbsState): TypeGuard = TypeGuard(for {
+      (dty, constr) <- map
+      newConstr = constr.kill(bases)
+      if newConstr.nonTop
+    } yield dty -> newConstr)
+
     def forReturn(symEnv: Map[Sym, ValueTy]): TypeGuard = TypeGuard(for {
-      (kind, pred) <- map
-      newPred = pred.forReturn(symEnv)
-      if newPred.nonTop
-    } yield kind -> newPred)
+      (dty, constr) <- map
+      newConstr = constr.forReturn(symEnv)
+      if newConstr.nonTop
+    } yield dty -> newConstr)
+
     def filter(ty: ValueTy): TypeGuard =
-      TypeGuard(map.filter { (kind, _) => !(kind.ty && ty).isBottom })
-    def has(x: SymBase): Boolean = map.values.exists(_.has(x))
-    def <=(that: TypeGuard): Boolean = that.map.forall { (kind, r) =>
-      this.map.get(kind) match
+      TypeGuard(map.filter { (dty, _) => !(dty.ty && ty).isBottom })
+
+    def lift(ty: ValueTy = ValueTy.Top)(using st: AbsState): TypeGuard =
+      this && TypeGuard((for {
+        kind <- DemandType.from(ty).toList
+        constr = TypeConstr().lift
+        if constr.nonTop
+      } yield kind -> constr).toMap)
+
+    def has(x: Base): Boolean = map.values.exists(_.has(x))
+
+    def <=(that: TypeGuard): Boolean = that.map.forall { (dty, r) =>
+      this.map.get(dty) match
         case Some(l) => l <= r
         case None    => false
     }
+
     def ||(that: TypeGuard)(lty: ValueTy, rty: ValueTy): TypeGuard =
-      val (lkinds, rkinds) = (this.kinds, that.kinds)
-      val kinds =
-        lkinds.filter(k => (k.ty && rty).isBottom || rkinds.contains(k)) ++
-        rkinds.filter(k => (k.ty && lty).isBottom || lkinds.contains(k))
+      val (ldtys, rdtys) = (this.dtys, that.dtys)
+      val dtys =
+        ldtys.filter(k => (k.ty && rty).isBottom || rdtys.contains(k)) ++
+        rdtys.filter(k => (k.ty && lty).isBottom || ldtys.contains(k))
       TypeGuard((for {
-        kind <- kinds.toList
-        pred = (this.get(kind), that.get(kind)) match
-          case (Some(l), Some(r)) => l || r
-          case (Some(l), None)    => l
-          case (None, Some(r))    => r
-          case _                  => SymPred()
-        if !pred.isTop
-      } yield kind -> pred).toMap)
+        dty <- dtys.toList
+        ty = lty || rty
+        constr = (this.evaluate(ty, dty.ty), that.evaluate(ty, dty.ty)) match
+          case (l, r) if (lty && dty.ty).isBottom => r
+          case (l, r) if (rty && dty.ty).isBottom => l
+          case (l, r)                             => l || r
+        if !constr.isTop
+      } yield dty -> constr).toMap)
+
     def &&(that: TypeGuard): TypeGuard = TypeGuard((for {
-      kind <- (this.kinds ++ that.kinds).toList
-      pred = this(kind) && that(kind)
-      if !pred.isTop
-    } yield kind -> pred).toMap)
+      dty <- (this.dtys ++ that.dtys).toList
+      constr = this(dty) && that(dty)
+      if !constr.isTop
+    } yield dty -> constr).toMap)
+
+    def evaluate(lty: ValueTy, rty: ValueTy): TypeConstr =
+      if (lty && rty).isBottom then TypeConstr()
+      else {
+        val constrs = for {
+          (dty, constr) <- map
+          if rty <= dty.ty
+        } yield constr
+        if constrs.isEmpty then TypeConstr()
+        else constrs.reduce(_ && _)
+      }
+
+    def simple: TypeGuard =
+      TypeGuard(map.filterNot { (dty, constr) =>
+        map.exists { (tdty, tconstr) =>
+          (dty.ty != tdty.ty && dty.ty <= tdty.ty && tconstr <= constr)
+        }
+      })
+
     override def toString: String = (new Appender >> this).toString
   }
   object TypeGuard {
     val Empty: TypeGuard = TypeGuard()
-    def apply(ps: (RefinementKind, SymPred)*): TypeGuard = TypeGuard(ps.toMap)
+    def apply(ps: (DemandType, TypeConstr)*): TypeGuard = TypeGuard(
+      ps.toMap,
+    )
   }
 
   /** type refinement target */
   enum RefinementTarget:
     case BranchTarget(branch: Branch, isTrue: Boolean)
     case AssertTarget(block: Block, idx: Int)
+    case NodeTarget(nd: Node)
     def node: Node = this match
       case BranchTarget(branch, _) => branch
       case AssertTarget(block, _)  => block
+      case NodeTarget(nd)          => nd
     def func: Func = cfg.funcOf(node)
 
-  case class RefinementKind(private val _ty: ValueTy) {
+  case class DemandType(private val _ty: ValueTy) {
     def ty: ValueTy = _ty
   }
-  object RefinementKind {
+
+  object DemandType {
     val set: Set[ValueTy] =
-      Set(
-        TrueT,
-        FalseT,
-        NormalT,
-        AbruptT,
-        NormalT(TrueT),
-        NormalT(FalseT),
-        ENUMT_SYNC,
-        ENUMT_ASYNC,
-      )
+      if (useBooleanGuard) Set(TrueT, FalseT)
+      else
+        Set(
+          TrueT,
+          FalseT,
+          NormalT,
+          AbruptT,
+          NormalT(TrueT),
+          NormalT(FalseT),
+          ENUMT_SYNC,
+          ENUMT_ASYNC,
+        )
 
-    def apply(ty: ValueTy): RefinementKind =
-      if (RefinementKind.set.contains(ty)) new RefinementKind(ty)
-      else throw notSupported(s"Unsupported RefinementKind: $ty")
+    def apply(ty: ValueTy): DemandType =
+      if (DemandType.set.contains(ty)) new DemandType(ty)
+      else {
+        Thread.dumpStack()
+        throw notSupported(s"Unsupported DemandType: $ty")
+      }
 
-    def from(givenTy: ValueTy): Set[RefinementKind] =
-      RefinementKind.set
+    def from(givenTy: ValueTy): Set[DemandType] =
+      DemandType.set
         .filter(ty => !(givenTy && ty).isBottom)
-        .map(RefinementKind(_))
+        .map(DemandType(_))
   }
 
-  /** Symbol */
-  type Sym = Int
-  case class Provenance(map: Map[Func, List[Call]] = Map()) {
-    def depth: Int = map.values.map(_.length).max
-    def join(that: Provenance): Provenance = Provenance((for {
-      key <- (this.map.keySet union that.map.keySet).toList
-      calls <- (this.map.get(key), that.map.get(key)) match
-        case (Some(lcalls), Some(rcalls)) =>
-          Some(if (lcalls.length < rcalls.length) lcalls else rcalls)
-        case (Some(lcalls), None) => Some(lcalls)
-        case (None, Some(rcalls)) => Some(rcalls)
-        case (None, None)         => None
-    } yield key -> calls).toMap)
-    def forReturn(call: Call): Provenance = Provenance(
-      map.map { case (key, calls) => key -> (call :: calls) },
-    )
-    override def toString: String = (new Appender >> this).toString
-  }
-  object Provenance {
-    def apply(funcs: Func*): Provenance =
-      Provenance(funcs.map(_ -> Nil).toMap)
-  }
-
-  /** symbolic predicates */
-  case class SymPred(
-    map: Map[SymBase, (ValueTy, Provenance)] = Map(),
-    sexpr: Option[(SymExpr, Provenance)] = None,
+  /** type constraints */
+  case class TypeConstr(
+    map: Map[Base, (ValueTy, Provenance)] = Map(),
+    sexpr: Option[SymExpr] = None,
   ) {
     def isTop: Boolean = map.isEmpty && sexpr.isEmpty
+
     def nonTop: Boolean = !isTop
-    def <=(that: SymPred): Boolean =
+
+    def <=(that: TypeConstr): Boolean =
       that.map.forall {
-        case (x, (rty, _)) =>
-          this.map.get(x).fold(false) { case (lty, _) => lty <= rty }
+        case (x, (rty, rprov)) =>
+          this.map.get(x).fold(false) {
+            case (lty, lprov) =>
+              if (lty == rty) lprov <= rprov
+              else lty <= rty
+          }
       } && (this.sexpr == that.sexpr)
-    def ||(that: SymPred): SymPred = SymPred(
-      map = (for {
-        x <- (this.map.keySet intersect that.map.keySet).toList
-        (lty, lprov) = this.map(x)
-        (rty, rprov) = that.map(x)
-        ty = lty || rty
-        prov = lprov join rprov
-      } yield x -> (ty, prov)).toMap,
-      sexpr = this.sexpr || that.sexpr,
-    )
-    def &&(that: SymPred): SymPred = SymPred(
-      map = (for {
-        x <- (this.map.keySet ++ that.map.keySet).toList
-        (lty, lprov) = this.map.getOrElse(x, (AnyT, Provenance()))
-        (rty, rprov) = that.map.getOrElse(x, (AnyT, Provenance()))
-        ty = lty && rty
-        prov = lprov join rprov
-      } yield x -> (ty, prov)).toMap,
-      sexpr = this.sexpr && that.sexpr,
-    )
-    def has(x: SymBase): Boolean =
-      map.contains(x) || sexpr.fold(false) { case (sexpr, _) => sexpr.has(x) }
-    def bases: Set[SymBase] =
+
+    def ||(that: TypeConstr): TypeConstr =
+      TypeConstr(
+        map = (for {
+          x <- (this.map.keySet intersect that.map.keySet).toList
+          (lty, lprov) = this.map(x)
+          (rty, rprov) = that.map(x)
+          pair = {
+            if (lty <= rty) (rty, rprov)
+            else if (rty <= lty) (lty, lprov)
+            else (lty || rty, lprov || rprov)
+          }
+        } yield x -> pair).toMap,
+        sexpr = this.sexpr || that.sexpr,
+      )
+
+    def &&(that: TypeConstr): TypeConstr =
+      TypeConstr(
+        map = (for {
+          x <- (this.map.keySet ++ that.map.keySet).toList
+          (lty, lprov) = this.map.getOrElse(x, (ValueTy.Top, Provenance.Top))
+          (rty, rprov) = that.map.getOrElse(x, (ValueTy.Top, Provenance.Top))
+          pair = {
+            if (lty <= rty) (lty, lprov)
+            else if (rty <= lty) (rty, rprov)
+            else (lty && rty, lprov && rprov)
+          }
+        } yield x -> pair).toMap,
+        sexpr = this.sexpr && that.sexpr,
+      )
+
+    def has(x: Base): Boolean =
+      map.contains(x) || sexpr.fold(false)(_.has(x))
+
+    def bases: Set[Base] =
       map.keySet.collect { case s: Sym => s } ++
-      sexpr.fold(Set[SymBase]()) { (sexpr, _) => sexpr.bases }
-    def kill(bases: Set[SymBase])(using AbsState): SymPred =
+      sexpr.fold(Set[Base]())(_.bases)
+
+    def kill(bases: Set[Base])(using AbsState): TypeConstr =
       this.copy(
         map.filter { case (x, _) => !bases.contains(x) },
-        sexpr.fold(None)((e, p) => e.kill(bases).map(_ -> p)),
+        sexpr.fold(None)(_.kill(bases)),
       )
-    def forReturn(symEnv: Map[Sym, ValueTy]): SymPred = SymPred(
+
+    def forReturn(symEnv: Map[Sym, ValueTy]): TypeConstr = TypeConstr(
       map = for {
         case (x: Sym, (ty, prov)) <- map
         origTy = symEnv.getOrElse(x, BotT)
       } yield x -> (origTy && ty, prov),
       sexpr = None,
     )
-    def depth: Int =
-      val provs = map.values.map(_._2).toList
-      sexpr.fold(provs)(_._2 :: provs).map(_.depth).max
+
+    def depth: Int = map.values.map(_._2).map(_.depth).max
+
+    def lift(using st: AbsState): TypeConstr =
+      this && st.constr
+
     override def toString: String = (new Appender >> this).toString
   }
-  object SymPred {
-    def apply(pair: (SymExpr, Provenance)): SymPred =
-      SymPred(sexpr = Some(pair))
-    def apply(pairs: (SymBase, (ValueTy, Provenance))*): SymPred =
-      SymPred(pairs.toMap, None)
+  object TypeConstr {
+    def apply(sexpr: SymExpr): TypeConstr =
+      TypeConstr(sexpr = Some(sexpr))
+    def apply(pairs: (Base, (ValueTy, Provenance))*): TypeConstr =
+      TypeConstr(pairs.toMap, None)
   }
-
-  /** symbolic bases */
-  type SymBase = Sym | Local
 
   /** symbolic expressions */
   enum SymExpr {
@@ -192,45 +236,37 @@ trait TypeGuardDecl { self: TyChecker =>
     case SETypeCheck(base: SymExpr, ty: ValueTy)
     case SETypeOf(base: SymExpr)
     case SEEq(left: SymExpr, right: SymExpr)
-    case SEOr(left: SymExpr, right: SymExpr)
-    case SEAnd(left: SymExpr, right: SymExpr)
-    case SENot(expr: SymExpr)
     def ||(that: SymExpr): SymExpr = (this, that) match
       case _ if this == that                     => this
       case (SEBool(false), _)                    => that
       case (_, SEBool(false))                    => this
       case (SEBool(true), _) | (_, SEBool(true)) => SEBool(true)
-      case _                                     => SEOr(this, that)
+      case _                                     => SEBool(true)
     def &&(that: SymExpr): SymExpr = (this, that) match
       case _ if this == that                       => this
       case (SEBool(true), _)                       => that
       case (_, SEBool(true))                       => this
       case (SEBool(false), _) | (_, SEBool(false)) => SEBool(false)
-      case _                                       => SEAnd(this, that)
-    def has(x: SymBase): Boolean = this match
+      case _                                       => SEBool(true)
+    def has(x: Base): Boolean = this match
       case SEBool(b)             => false
       case SERef(ref)            => ref.has(x)
       case SEExists(ref)         => ref.has(x)
       case SETypeCheck(base, ty) => base.has(x)
       case SETypeOf(base)        => base.has(x)
       case SEEq(left, right)     => left.has(x) || right.has(x)
-      case SEOr(left, right)     => left.has(x) || right.has(x)
-      case SEAnd(left, right)    => left.has(x) || right.has(x)
-      case SENot(expr)           => expr.has(x)
-    def bases: Set[SymBase] = this match
+    def bases: Set[Base] = this match
       case SEBool(b)             => Set()
       case SERef(ref)            => ref.bases
       case SEExists(ref)         => ref.bases
       case SETypeCheck(base, ty) => base.bases
       case SETypeOf(base)        => base.bases
       case SEEq(left, right)     => left.bases ++ right.bases
-      case SEOr(left, right)     => left.bases ++ right.bases
-      case SEAnd(left, right)    => left.bases ++ right.bases
-      case SENot(expr)           => expr.bases
-    def kill(bases: Set[SymBase]): Option[SymExpr] = this match
-      case SEBool(b)             => Some(this)
-      case SERef(ref)            => ref.kill(bases).map(SERef(_))
-      case SEExists(ref)         => ref.kill(bases).map(SEExists(_))
+    def kill(bases: Set[Base]): Option[SymExpr] = this match
+      case SEBool(b) => Some(this)
+      case SERef(ref) =>
+        ref.killRef(ref, bases, true).map(SERef(_)) // FIXME: check later
+      case SEExists(ref) => ref.killRef(ref, bases, true).map(SEExists(_))
       case SETypeCheck(base, ty) => base.kill(bases).map(SETypeCheck(_, ty))
       case SETypeOf(base)        => base.kill(bases).map(SETypeOf(_))
       case SEEq(left, right) =>
@@ -238,122 +274,419 @@ trait TypeGuardDecl { self: TyChecker =>
           l <- left.kill(bases)
           r <- right.kill(bases)
         } yield SEEq(l, r)
-      case SEOr(left, right) =>
-        for {
-          l <- left.kill(bases)
-          r <- right.kill(bases)
-        } yield SEOr(l, r)
-      case SEAnd(left, right) =>
-        (left.kill(bases), right.kill(bases)) match
-          case (Some(l), Some(r)) => Some(l && r)
-          case (Some(l), None)    => Some(l)
-          case (None, Some(r))    => Some(r)
-          case _                  => None
-      case SENot(expr) => expr.kill(bases).map(SENot(_))
     override def toString: String = (new Appender >> this).toString
   }
   object SymExpr {
-    val T: SymExpr = SEBool(true)
-    val F: SymExpr = SEBool(false)
-    extension (l: Option[(SymExpr, Provenance)])
+    // val T: SymExpr = SEBool(true)
+    // val F: SymExpr = SEBool(false)
+    extension (l: Option[SymExpr])
       def &&(
-        r: Option[(SymExpr, Provenance)],
-      ): Option[(SymExpr, Provenance)] = (l, r) match
-        case (Some(le, lp), Some(re, rp)) => Some(le && re, lp join rp)
-        case (Some(l), None)              => Some(l)
-        case (None, Some(r))              => Some(r)
-        case _                            => None
+        r: Option[SymExpr],
+      ): Option[SymExpr] = (l, r) match
+        case (Some(le), Some(re)) => Some(le && re)
+        case (Some(l), None)      => Some(l)
+        case (None, Some(r))      => Some(r)
+        case _                    => None
       def ||(
-        r: Option[(SymExpr, Provenance)],
-      ): Option[(SymExpr, Provenance)] = (l, r) match
-        case (Some(le, lp), Some(re, rp)) => Some(le || re, lp join rp)
-        case _                            => None
+        r: Option[SymExpr],
+      ): Option[SymExpr] = (l, r) match
+        case (Some(le), Some(re)) => Some(le || re)
+        case _                    => None
   }
 
-  /** symbolic references */
-  enum SymRef {
-    case SBase(base: SymBase)
-    case SField(base: SymRef, field: SymTy)
-    def getBase: SymBase = this match
-      case SBase(s)        => s
-      case SField(base, f) => base.getBase
-    def has(x: SymBase): Boolean = this match
-      case SBase(y)        => x == y
-      case SField(base, f) => base.has(x) || f.has(x)
-    def bases: Set[SymBase] = this match
-      case SBase(x)        => Set(x)
-      case SField(base, f) => base.bases ++ f.bases
-    def kill(bases: Set[SymBase]): Option[SymRef] = this match
-      case SBase(x) => if (bases contains x) None else Some(this)
-      case SField(base, f) =>
-        for {
-          b <- base.kill(bases)
-          f <- f.kill(bases)
-        } yield SField(b, f)
-    override def toString: String = (new Appender >> this).toString
+  /** Provenance */
+
+  sealed trait Provenance {
+    import Provenance.*
+
+    def ty: ValueTy
+    def size: Int
+    def depth: Int
+    def leafCnt: Int
+
+    // Infer a consistent boolean truth value from leaves, when available.
+    // Returns Some(true/false) only if all annotated leaves agree; otherwise None.
+    final def truthOpt: Option[Boolean] = this match
+      case Leaf(_, _, _, truth)  => truth
+      case CallPath(_, _, child) => child.truthOpt
+      case Join(children) =>
+        val ts = children.flatMap(_.truthOpt)
+        if (ts.isEmpty) None
+        else if (ts.forall(_ == ts.head)) Some(ts.head)
+        else None
+      case Meet(children) =>
+        val ts = children.flatMap(_.truthOpt)
+        if (ts.isEmpty) None
+        else if (ts.forall(_ == ts.head)) Some(ts.head)
+        else None
+      case RefinePoint(_, child, _, _, _, _) => child.truthOpt
+      case Provenance.Bot | Provenance.Top   => None
+      case Placeholder(_)                    => ???
+
+    // simple explanation is bigger (imprecise)
+    def <=(that: Provenance): Boolean = {
+      if this == Bot then true
+      else if that == Bot then false
+      else if this == Top then false
+      else if that == Top then true
+      else // this and that are not Bot or Top
+        (this, that) match
+          case (Leaf(lnode, _, lty, _), Leaf(rnode, _, rty, _)) =>
+            if lty == rty then lnode == rnode
+            else lty <= rty
+          case (CallPath(lcall, lty, lchild), CallPath(rcall, rty, rchild)) =>
+            if lty == rty then lcall == rcall && lchild <= rchild
+            else lty <= rty
+          case (l @ Join(lchild), r @ Join(rchild)) =>
+            if l.ty == r.ty then rchild.forall(l => lchild.exists(l <= _))
+            else l.ty <= r.ty
+          case (l @ Meet(lchild), r @ Meet(rchild)) =>
+            if l.ty == r.ty then rchild.forall(l => lchild.exists(l <= _))
+            else l.ty <= r.ty
+          case _ => false
+    }
+
+    def ||(that: Provenance): Provenance = {
+      if this == Bot then return that
+      else if that == Bot then return this
+      else if this == Top || that == Top then return Top
+      else // this and that are not Bot or Top
+      if this.ty <= that.ty then return that
+      else if that.ty <= this.ty then return this
+
+      // this and that are not subsumption of each other
+      (this, that) match
+        case (
+              Leaf(lnode, lbase, lty, ltruth),
+              Leaf(rnode, rbase, rty, rtruth),
+            ) =>
+          if lnode == rnode then
+            val base = if (lbase == rbase) lbase else None
+            val truth = if (ltruth == rtruth) ltruth else None
+            Leaf(lnode, base, lty || rty, truth)
+          else Join(Set(this, that)).canonical
+        case (CallPath(lcall, lty, lchild), CallPath(rcall, rty, rchild)) =>
+          if lcall == rcall then CallPath(lcall, lty || rty, lchild || rchild)
+          else Join(Set(this, that)).canonical
+        case (prov: (Leaf | CallPath), Join(child)) =>
+          Join(child + prov).canonical
+        case (Join(child), prov: (Leaf | CallPath)) =>
+          Join(child + prov).canonical
+        case (Join(lchild), Join(rchild)) =>
+          Join(lchild ++ rchild).canonical
+        case _ => Join(Set(this, that)).canonical
+    }
+
+    def &&(that: Provenance): Provenance = {
+      if this == Bot || that == Bot then return Bot
+      else if this == Top then return that
+      else if that == Top then return this
+      else // this and that are not Bot or Top
+      if this.ty <= that.ty then return this
+      else if that.ty <= this.ty then return that
+
+      // this and that are not subsumption of each other
+      (this, that) match
+        case (
+              Leaf(lnode, lbase, lty, ltruth),
+              Leaf(rnode, rbase, rty, rtruth),
+            ) =>
+          if lnode == rnode then
+            val base = if (lbase == rbase) lbase else None
+            val truth = if (ltruth == rtruth) ltruth else None
+            Leaf(lnode, base, lty && rty, truth)
+          else Meet(Set(this, that)).canonical
+        case (CallPath(lcall, lty, lchild), CallPath(rcall, rty, rchild)) =>
+          if lcall == rcall then CallPath(lcall, lty && rty, lchild && rchild)
+          else Meet(Set(this, that)).canonical
+        case (prov: (Leaf | CallPath), Meet(child)) =>
+          Meet(child + prov).canonical
+        case (Meet(child), prov: (Leaf | CallPath)) =>
+          Meet(child + prov).canonical
+        case (Meet(lchild), Meet(rchild)) =>
+          Meet(lchild ++ rchild).canonical
+        case _ => Meet(Set(this, that)).canonical
+    }
+
+    def existsDuplicateCall(c: Call): Boolean =
+      this match
+        case CallPath(call, _, child) =>
+          if call == c then true
+          else child.existsDuplicateCall(c)
+        case Join(child) => child.exists(_.existsDuplicateCall(c))
+        case Meet(child) => child.exists(_.existsDuplicateCall(c))
+        case _           => false
+
+    def replaceCall(
+      call: Call,
+      ty: ValueTy,
+    ): Provenance = // ONLY WORKS WITH NO VIEW
+      this match
+        case CallPath(c, _, child) =>
+          if c == call then CallPath(c, ty, child)
+          else CallPath(c, ty, child.replaceCall(call, ty))
+        case Join(child) => Join(child.map(_.replaceCall(call, ty)))
+        case Meet(child) => Meet(child.map(_.replaceCall(call, ty)))
+        case _           => this
+
+    def canonical: Provenance =
+      this match
+        case Join(set) =>
+          val group = set
+            .groupBy(_.ty)
+            .map {
+              case (ty, dupl) =>
+                ty -> dupl.minBy(_.depth)
+            }
+            .toMap
+          Join(
+            group
+              .filterNot {
+                case (ty, _) =>
+                  group.keySet.exists(otherTy =>
+                    (ty <= otherTy && otherTy != ty),
+                  )
+              }
+              .values
+              .toSet,
+          )
+        case Meet(set) =>
+          val group = set
+            .groupBy(_.ty)
+            .map {
+              case (ty, dupl) =>
+                ty -> dupl.minBy(_.depth)
+            }
+            .toMap
+          Meet(
+            group
+              .filterNot {
+                case (ty, _) =>
+                  group.keySet.exists(otherTy =>
+                    (otherTy <= ty && otherTy != ty),
+                  )
+              }
+              .values
+              .toSet,
+          )
+        case _ => this
+
+    def forReturn(call: Call, ty: ValueTy): Provenance =
+      if this == Bot then Bot
+      else if this == Top then Top
+      else if this.existsDuplicateCall(call) then this.replaceCall(call, ty)
+      else CallPath(call, ty, this)
+
+    def usedForRefine(
+      target: RefinementTarget,
+      base: Base,
+      refinedTo: ValueTy,
+      refinedVarTy: ValueTy,
+    ): Provenance =
+      val branch: Option[Boolean] = target match
+        case RefinementTarget.BranchTarget(_, isTrue) => Some(isTrue)
+        case _                                        => None
+      RefinePoint(
+        target = target,
+        child = this,
+        base = Some(base),
+        branch = branch,
+        refined = Some(refinedTo),
+        varRefined = Some(refinedVarTy),
+      )
+
+    def toTree(indent: Int): String
+    def toTree: String = toTree(0)
   }
 
+  // Provenance placeholder used to mask complex functions like GetFunctionRealm
+  case class Placeholder(name: String) extends Provenance {
+    lazy val ty: ValueTy = BotT
+    def size: Int = 0
+    def depth: Int = 0
+    def leafCnt: Int = 0
+    override def toString: String =
+      s"$name: No explanation provided (too complex)"
+    def toTree(indent: Int): String = s"${"  " * indent}$toString"
+  }
+
+  // Leaf provenance: attach base and node to recover spec text later
+  case class Leaf(
+    node: Node,
+    base: Option[Base],
+    ty: ValueTy,
+    truth: Option[Boolean] = None,
+  ) extends Provenance {
+    def size: Int = 0
+    def depth: Int = 0
+    def leafCnt: Int = 1
+
+    override def toString =
+      s"Leaf(${cfg.funcOf(node).nameWithId}:${node.id}, $ty)"
+    def toTree(indent: Int): String = s"${"  " * indent}$this"
+  }
+  case class CallPath(call: Call, ty: ValueTy, child: Provenance)
+    extends Provenance {
+    def size: Int = child.size + 1
+    def depth: Int = child.depth + 1
+    def leafCnt: Int = child.leafCnt
+
+    override def toString =
+      s"CallPath(${cfg.funcOf(call).nameWithId}:${call.id}, $ty, ${child.toString})"
+    def toTree(indent: Int): String =
+      s"${"  " * indent}CallPath(${cfg.funcOf(call).nameWithId}:${call.id}, $ty)\n${child
+        .toTree(indent + 1)}"
+  }
+  case class Join(child: Set[Provenance]) extends Provenance {
+    lazy val ty: ValueTy = child.toList.map(_.ty).reduce(_ || _)
+    def size: Int = child.toList.map(_.size).sum + 1
+    def depth: Int = child.toList.map(_.depth).max + 1
+    def leafCnt: Int = child.toList.map(_.leafCnt).sum
+
+    override def toString = s"Join(${child.toList.map(_.toString)})"
+    def toTree(indent: Int): String =
+      s"${"  " * indent}Join($ty)\n${child.toList.map(_.toTree(indent + 1)).mkString("\n")}"
+  }
+
+  case class Meet(child: Set[Provenance]) extends Provenance {
+    lazy val ty: ValueTy = child.toList.map(_.ty).reduce(_ && _)
+    def size: Int = child.toList.map(_.size).sum + 1
+    def depth: Int = child.toList.map(_.depth).max + 1
+    def leafCnt: Int = child.toList.map(_.leafCnt).sum
+
+    override def toString = s"Meet(${child.toList.map(_.toString)})"
+    def toTree(indent: Int): String =
+      s"${"  " * indent}Meet($ty)\n${child.toList.map(_.toTree(indent + 1)).mkString("\n")}"
+  }
+
+  case class RefinePoint(
+    target: RefinementTarget,
+    child: Provenance,
+    base: Option[Base] = None,
+    branch: Option[Boolean] = None,
+    refined: Option[ValueTy] = None, // e.g., True/False for branch condition
+    varRefined: Option[ValueTy] =
+      None, // refined variable type to show in header
+  ) extends Provenance {
+    lazy val ty: ValueTy = child.ty
+    def size: Int = child.size
+    def depth: Int = child.depth
+    def leafCnt: Int = child.leafCnt
+
+    override def toString = s"RefinePoint($target, $child)"
+    def toTree(indent: Int): String =
+      s"${"  " * indent}RefinePoint($target)\n${child.toTree(indent + 1)}"
+  }
+  object Provenance {
+    case object Bot extends Provenance {
+      lazy val ty: ValueTy = BotT
+      val INF = 1e8.toInt
+      def size: Int = INF
+      def depth: Int = INF
+      def leafCnt: Int = INF
+
+      override def toString = "Bot"
+      def toTree(indent: Int): String = s"${"  " * indent}$this"
+    }
+    case object Top extends Provenance {
+      lazy val ty: ValueTy = BotT
+      def size: Int = 0
+      def depth: Int = 0
+      def leafCnt: Int = 0
+
+      override def toString = "Top"
+      def toTree(indent: Int): String = s"${"  " * indent}$this"
+    }
+
+    // Create a leaf provenance without base information
+    def apply(ty: ValueTy)(using nd: Node): Provenance =
+      if useProvenance then Leaf(nd, None, ty, None) else Bot
+
+    // Overloaded constructor that requires a base
+    def apply(
+      base: Base,
+      ty: ValueTy,
+      truth: Option[Boolean] = None,
+    )(using nd: Node): Provenance =
+      if useProvenance then Leaf(nd, Some(base), ty, truth) else Bot
+
+    // Check whether a provenance tree involves a function by name
+    def involvesFunc(prov: Provenance, fname: String): Boolean = prov match
+      case Leaf(node, _, _, _) =>
+        val f = cfg.funcOf(node)
+        f.name == fname || f.irFunc.name == fname
+      case CallPath(call, _, child) =>
+        // Detect direct calls to a target algorithm by closure name or SDO method
+        val direct = call.callInst match
+          case ICall(_, fexpr, _) =>
+            fexpr match
+              case EClo(fn, _) => fn == fname
+              case ECont(_)    => false
+              case _           => false
+          case ISdoCall(_, _, method, _) => method == fname
+        direct || involvesFunc(child, fname)
+      case Join(children) => children.exists(involvesFunc(_, fname))
+      case Meet(children) => children.exists(involvesFunc(_, fname))
+      case RefinePoint(target, child, _, _, _, _) =>
+        val f = target.func
+        f.name == fname || f.irFunc.name == fname || involvesFunc(child, fname)
+      case Bot | Top      => false
+      case Placeholder(_) => ???
+
+    // Mask provenance tree with a placeholder if it involves an exception function
+    private val ExceptionFuncs: Set[String] = Set("GetFunctionRealm")
+    def isExceptionName(name: String): Boolean = ExceptionFuncs.contains(name)
+    def maskExceptions(prov: Provenance): Provenance =
+      ExceptionFuncs.collectFirst { case n if involvesFunc(prov, n) => n } match
+        case Some(name) => Placeholder(name)
+        case None       => prov
+  }
   // -----------------------------------------------------------------------------
   // helpers
   // -----------------------------------------------------------------------------
   import tyStringifier.given
-  given Rule[SymBase] = (app, base) =>
-    base match
-      case sym: Sym     => app >> "#" >> sym.toString
-      case local: Local => app >> local.toString
-  given Ordering[SymBase] = Ordering.by(_.toString)
-  given Rule[SymExpr] = (app, expr) =>
+
+  /** SymExpr */
+  private def symExprRule(app: Appender, expr: SymExpr): Appender =
     import SymExpr.*
     expr match
       case SEBool(bool)  => app >> bool
       case SERef(ref)    => app >> ref
       case SEExists(ref) => app >> "(exists " >> ref >> ")"
-      case SETypeCheck(expr, ty) =>
-        app >> "(? " >> expr >> ": " >> ty >> ")"
+      case SETypeCheck(e, ty) =>
+        symExprRule(app >> "(? ", e) >> ": " >> ty >> ")"
       case SETypeOf(base) =>
-        app >> "(typeof " >> base >> ")"
+        symExprRule(app >> "(typeof ", base) >> ")"
       case SEEq(left, right) =>
-        app >> "(=" >> " " >> left >> " " >> right >> ")"
-      case SEOr(left, right) =>
-        app >> "(|| " >> left >> " " >> right >> ")"
-      case SEAnd(left, right) =>
-        app >> "(&& " >> left >> " " >> right >> ")"
-      case SENot(expr) =>
-        app >> "(! " >> expr >> ")"
-  given Rule[SymRef] = (app, ref) =>
-    import SymExpr.*, SymRef.*, SymTy.*
-    lazy val inlineField = "([_a-zA-Z][_a-zA-Z0-9]*)".r
-    ref match
-      case SBase(x) => app >> x
-      case SField(base, STy(x)) if !x.isBottom =>
-        x.getSingle match
-          case One(f: String) => app >> base >> "." >> f
-          case _              => app >> base >> "[" >> x >> "]"
-      case SField(base, field) => app >> base >> "[" >> field >> "]"
-  given Rule[Provenance] = (app, prov) =>
-    val Provenance(map) = prov
-    if (map.nonEmpty) (app >> " <from> ").wrap("{", "}") {
-      for ((func, calls) <- map.toList.sortBy(_._1)) {
-        app :> func.nameWithId
-        if (calls.nonEmpty) {
-          for (call <- calls.reverse)
-            app :> "<- " >> call.name >> " @ " >> cfg.funcOf(call).nameWithId
-        }
-      }
-    }
-    app
-  given Rule[SymPred] = (app, pred) =>
-    import SymPred.*
+        val a = symExprRule(app >> "(= ", left)
+        symExprRule(a >> " ", right) >> ")"
+
+  // Expose the helper as the given instance, avoiding self-referential implicit search issues.
+  given Rule[SymExpr] = symExprRule
+
+  /** Provenance pretty printer (spec-like) */
+  given Rule[Provenance] = (app, prov) => ProvTextPrinter.print(app, prov)
+
+  /** TypeConstr */
+  given Rule[TypeConstr] = (app, constr) =>
+    import TypeConstr.*
     given Rule[(ValueTy, Provenance)] =
-      case (app, (ty, prov)) => app >> ty >> prov
-    given Rule[Map[SymBase, (ValueTy, Provenance)]] = sortedMapRule(sep = ": ")
-    if (pred.map.nonEmpty) app >> pred.map
-    pred.sexpr.fold(app) { (sexpr, prov) => app >> sexpr >> prov }
+      case (app, (ty, prov)) if useProvenance => app >> ty >> " ~~\n" >> prov
+      case (app, (ty, prov))                  => app >> ty
+    import SymTy.given
+    given Rule[Map[Base, (ValueTy, Provenance)]] = sortedMapRule(sep = ": ")
+    if (constr.map.nonEmpty) app >> constr.map
+    constr.sexpr.fold(app) { app >> _ }
+
+  /** TypeGuard */
   given Rule[TypeGuard] = (app, guard) =>
-    given Ordering[RefinementKind] = Ordering.by(_.toString)
-    given Rule[RefinementKind] = (app, kind) => app >> kind.ty
-    given Rule[Map[RefinementKind, SymPred]] = sortedMapRule("{", "}", " => ")
-    app >> guard.map
+    given Ordering[DemandType] = Ordering.by(_.toString)
+    given Rule[DemandType] = (app, dty) => app >> dty.ty
+    given Rule[Map[DemandType, TypeConstr]] =
+      sortedMapRule("{", "}", " => ")
+    app >> guard.simple.map
+
+  /** RefinementTarget */
   given Rule[RefinementTarget] = (app, target) =>
     import RefinementTarget.*
     val node = target.node
@@ -364,10 +697,255 @@ trait TypeGuardDecl { self: TyChecker =>
         app >> (if (isTrue) "T" else "F")
       case AssertTarget(block, idx) =>
         app >> idx
+      case NodeTarget(nd) => app
   given Ordering[RefinementTarget] = Ordering.by { target =>
     import RefinementTarget.*
     target match
       case BranchTarget(branch, isTrue) => (branch.id, if (isTrue) 1 else 0)
       case AssertTarget(block, idx)     => (block.id, idx)
+      case NodeTarget(nd)               => (nd.id, 0)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Provenance Text Printer
+  // ---------------------------------------------------------------------------
+  object ProvTextPrinter {
+    import Provenance.*
+    import RefinementTarget.*
+    import SymTy.*
+
+    private def humanizeRecordNames(s: String): String =
+      s.replaceAll("""\bRecord\[([A-Za-z0-9_]+)\]""", "$1")
+    private def showTy(ty: ValueTy): String = humanizeRecordNames(ty.toString)
+
+    // -----------------------------------------------------------------------
+    // Ordering helpers for consistent printing
+    // -----------------------------------------------------------------------
+    private def stepSeqOf(node: Node): Option[List[Int]] = node.loc.map(_.steps)
+    private def stepSeqOf(prov: Provenance): Option[List[Int]] = prov match
+      case RefinePoint(target, child, _, _, _, _) => stepSeqOf(target.node)
+      case Leaf(node, _, _, _)                    => stepSeqOf(node)
+      case CallPath(call, _, child) => stepSeqOf(call).orElse(stepSeqOf(child))
+      case Join(children) =>
+        val seqs = children.toList.flatMap(stepSeqOf)
+        if seqs.isEmpty then None else Some(seqs.minBy(stepsCode))
+      case Meet(children) =>
+        val seqs = children.toList.flatMap(stepSeqOf)
+        if seqs.isEmpty then None else Some(seqs.minBy(stepsCode))
+      case Provenance.Bot | Provenance.Top => None
+      case Placeholder(_)                  => ???
+    private def stepsCode(steps: List[Int]): BigInt =
+      steps.foldLeft(BigInt(0))((acc, s) => acc * 1000 + BigInt(s))
+    private def stepRankOf(prov: Provenance): BigInt =
+      stepSeqOf(prov).map(stepsCode).getOrElse(BigInt(Long.MaxValue))
+
+    def print(app: Appender, prov: Provenance): Appender =
+      // Short-circuit for masked exception functions
+      prov match
+        case Placeholder(name) =>
+          app :> s"$name: No explanation provided (too complex)"
+        case rp: RefinePoint if containsPlaceholder(rp) =>
+          // If inner provenance was masked, print placeholder only
+          findPlaceholderName(rp).foreach { name =>
+            app :> s"$name: No explanation provided (too complex)"
+          }
+        case rp: RefinePoint =>
+          val func = cfg.funcOf(rp.target.node)
+          val params = func.irFunc.params.map(_.lhs.toString).mkString(", ")
+          app :> s"${func.irFunc.name} ( $params )"
+          render(app, prov, 1)
+        case _ =>
+          // Unexpected, but render without header to be robust
+          render(app, prov, 0)
+      app
+
+    private def indent(depth: Int): String =
+      if depth <= 0 then "" else ("| " * depth)
+
+    private def prettyBase(base: Base, node: Node): String = base match
+      case x: Local => x.toString
+      case s: Sym =>
+        val func = cfg.funcOf(node)
+        val entrySt = getResult(NodePoint(func, func.entry, emptyView))
+        val opt = entrySt.locals.collectFirst {
+          case (lx, v) if (v.symty match
+                case SSym(ss) if ss == s => true
+                case _                   => false
+              ) =>
+            lx
+        }
+        opt.map(_.toString).getOrElse("#" + s.toString)
+
+    // Optionally carry header (node, base) to render concise summaries
+    // inside conjunction blocks.
+    private def render(
+      app: Appender,
+      prov: Provenance,
+      depth: Int,
+      baseCtx: Option[(Node, Base)] = None,
+    ): Unit =
+      prov match
+        case Placeholder(name) =>
+          app :> s"${indent(depth)}$name: No explanation provided (too complex)"
+        case RefinePoint(
+              target,
+              child,
+              baseOpt,
+              branchOpt,
+              refinedOpt,
+              varRefinedOpt,
+            ) =>
+          val baseStr =
+            baseOpt.map(b => s"`${prettyBase(b, target.node)}`").getOrElse("<>")
+          val refinedStr =
+            varRefinedOpt
+              .orElse(refinedOpt)
+              .fold(showTy(child.ty))(showTy)
+          val branchStr = branchOpt.map(b => if b then "true" else "false")
+          val stepStr = target.node.loc.map(_.stepString)
+          val head =
+            (indent(depth) + s"$baseStr is $refinedStr" +
+            stepStr
+              .map(s =>
+                s" in the ${branchStr.getOrElse("?")} branch of step $s",
+              )
+              .getOrElse(""))
+          app :> head
+          // Print spec excerpt as a comment
+          specLine(target.node)
+            .map { line =>
+              app :> s"${indent(depth)}  // $line"
+            }
+            .getOrElse(())
+          // Pass base context down so Meet can show concise summaries
+          render(app, child, depth, baseOpt.map(b => (target.node, b)))
+
+        case Meet(children) =>
+          app :> s"${indent(depth)}All the following statements hold:"
+          val ordered = children.toList.sortBy(stepRankOf)
+          ordered.foreach(render(app, _, depth, baseCtx))
+
+        case Join(children) =>
+          app :> s"${indent(depth)}Either of the following statements hold:"
+          val ordered = children.toList.sortBy(stepRankOf)
+          ordered.foreach(render(app, _, depth, baseCtx))
+
+        case cp @ CallPath(call, cty, child) =>
+          baseCtx.foreach { (nd, base) =>
+            cp.truthOpt.foreach { b =>
+              val baseStr = s"`${prettyBase(base, nd)}`"
+              val truthWord = if b then "True" else "False"
+              app :> s"${indent(depth)}* $baseStr is ${showTy(cty)} because `${callSig(call)}` is $truthWord"
+              specLine(call)
+                .map { line =>
+                  app :> s"${indent(depth)}  // $line"
+                }
+                .getOrElse(())
+            }
+          }
+          val callLine = callSig(call)
+          app :> s"${indent(depth)}  $callLine"
+          render(app, child, depth + 1, baseCtx)
+
+        case Leaf(node, baseOpt, ty, truthOpt) =>
+          val baseStr =
+            baseOpt.map(b => s"`${prettyBase(b, node)}`").getOrElse("<>")
+          val line = specLine(node)
+          val reason = originSnippet(node)
+            .orElse(
+              line.flatMap(extractCond).orElse(line.map(Loc.dropStepPrefix)),
+            )
+          val suffix = truthOpt
+            .map(b => if b then " is True" else " is False")
+            .getOrElse("")
+          val because = reason.map(c => s" because `$c`$suffix").getOrElse("")
+          app :> s"${indent(depth)}* [ORIGIN] $baseStr is ${showTy(ty)}$because"
+          // spec comment
+          line
+            .map { line =>
+              app :> s"${indent(depth)}  // $line"
+            }
+            .getOrElse(())
+
+        case _ => ()
+
+    private def containsPlaceholder(prov: Provenance): Boolean = prov match
+      case Placeholder(_)                    => true
+      case RefinePoint(_, child, _, _, _, _) => containsPlaceholder(child)
+      case CallPath(_, _, child)             => containsPlaceholder(child)
+      case Join(children) => children.exists(containsPlaceholder)
+      case Meet(children) => children.exists(containsPlaceholder)
+      case _              => false
+
+    private def findPlaceholderName(prov: Provenance): Option[String] =
+      prov match
+        case Placeholder(name)                 => Some(name)
+        case RefinePoint(_, child, _, _, _, _) => findPlaceholderName(child)
+        case CallPath(_, _, child)             => findPlaceholderName(child)
+        case Join(children) =>
+          children.toList.flatMap(findPlaceholderName).headOption
+        case Meet(children) =>
+          children.toList.flatMap(findPlaceholderName).headOption
+        case _ => None
+
+    private def algoCode(func: Func): Option[String] =
+      // Prefer raw spec text to preserve wording like "If ... then".
+      cfg.spec.fnameMap
+        .get(func.irFunc.name)
+        .map(_.code)
+        .orElse(func.irFunc.algo.map(_.code))
+
+    // Remove ecmarkup decorations (e.g., [id="..."], <emu-...> wrappers) while preserving inner text
+    private def sanitizeSpec(s: String): String =
+      var t = s
+      // Remove bracketed id labels like [id="..."]
+      t = t.replaceAll("""\s*\[id\s*=\s*(['"]).*?\1\s*]""", "")
+      // Unwrap <emu-...>...</emu-...> while keeping inner text
+      t = t.replaceAll(
+        """<emu-[A-Za-z0-9\-]+(?:\s[^>]*?)?>(.*?)</emu-[A-Za-z0-9\-]+>""",
+        "$1",
+      )
+      // Remove self-closing or stray emu tags
+      t = t.replaceAll("""<emu-[A-Za-z0-9\-]+(?:\s[^>]*?)?/>""", "")
+      t = t.replaceAll("""</?emu-[A-Za-z0-9\-]+(?:\s[^>]*?)?>""", "")
+      // Remove empty references like "(see )" possibly left by empty xrefs
+      t = t.replaceAll("""\(\s*see\s*\)""", "")
+      // Normalize whitespace and punctuation spacing
+      t = t.replaceAll("""\s+([.,;:])""", "$1").replaceAll("""\s+""", " ").trim
+      t
+
+    private def specLine(node: Node): Option[String] = for {
+      loc <- node.loc
+      func = cfg.funcOf(node)
+      code <- algoCode(func)
+      line <- loc.findStepFullLine(code)
+    } yield sanitizeSpec(line)
+
+    private def originSnippet(node: Node): Option[String] = for {
+      loc <- node.loc
+      func = cfg.funcOf(node)
+      code <- algoCode(func)
+    } yield sanitizeSpec(Loc.oneLine(loc.getString(code)))
+
+    // Try to extract the condition from an "If <cond>, ..." line
+    private def extractCond(s: String): Option[String] =
+      val IfCond = "(?is).*?If\\s+(.+?)(?:,\\s*(?:then|return)|\\.)".r
+      s match
+        case IfCond(cond) => Some(cond.trim)
+        case _            => None
+
+    // Show a concise call signature from a call node
+    private def callSig(call: Call): String = call.callInst match
+      case ICall(_, fexpr, args) =>
+        val as = args.map(_.toString).mkString(", ")
+        // Prefer readable function name for closures/continuations
+        val fname = fexpr match
+          case EClo(fn, _) => fn
+          case ECont(fn)   => fn
+          case _           => fexpr.toString
+        s"$fname ( $as )"
+      case ISdoCall(_, base, method, args) =>
+        val as = (base :: args).map(_.toString).mkString(", ")
+        s"$method ( $as )"
   }
 }

--- a/src/main/scala/esmeta/ty/RecordTy.scala
+++ b/src/main/scala/esmeta/ty/RecordTy.scala
@@ -183,7 +183,7 @@ object RecordTy extends Parser.From(Parser.recordTy) {
 
   lazy val Bot: RecordTy = Elem(Map.empty)
 
-  lazy val maxFieldDepth: Int = 2
+  lazy val maxFieldDepth: Int = 3
 
   def apply(names: String*): RecordTy =
     apply(names.toSet)

--- a/src/main/scala/esmeta/ty/util/Stringifier.scala
+++ b/src/main/scala/esmeta/ty/util/Stringifier.scala
@@ -368,10 +368,10 @@ class Stringifier(
         app >> field >> " in " >> func.name >> field.langOpt
       case UnaryOpPoint(func, node, unary) =>
         app >> "unary operation (" >> unary.uop >> ") in " >> func.name
-        app >> unary
+        app >> unary.langOpt
       case BinaryOpPoint(func, node, binary) =>
         app >> "binary operation (" >> binary.bop >> ") in " >> func.name
-        app >> binary
+        app >> binary.langOpt
 
   // appender rule for TypeErrorCollector
   def collectorRule(


### PR DESCRIPTION
We introduced occurrence typing in the type checker for ECMA-262 in https://github.com/es-meta/esmeta/pull/261. We refactored this implementation and support the following features:
* A more readable provenance information for each type refinement
* Local variables as bases for symbolic types to infer more alias information between variable types
* Optimized join operator for abstract states