### PR TITLE
Fix a bug in evaluating variadic operators in Interpreter

### DIFF
--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -678,9 +678,8 @@ object Interpreter {
         else {
           val filtered = vs.filter(_ != NEG_INF)
           if (filtered.isEmpty) NEG_INF
-          else vopEval(_.asMath, _ min _, Math(_), filtered)
+          else vopEval(_.asMath, _ max _, Math(_), filtered)
         }
-        vopEval(_.asMath, _ max _, Math(_), vs)
       case Concat =>
         def toString(v: Value): String = v match
           case Str(s)      => s

--- a/tests/ir/expr/variadic.ir
+++ b/tests/ir/expr/variadic.ir
@@ -2,6 +2,12 @@
   // mathematical values
   assert (= (min 1 2 3) 1)
   assert (= (min 3.2 2.4 3.3) 2.4)
+  assert (= (min -INF 0 1) -INF)
+  assert (= (min +INF 0 1) 0)
+  assert (= (min +INF +INF +INF) +INF)
   assert (= (max 1 2 3) 3)
   assert (= (max 3.2 2.4 3.3) 3.3)
+  assert (= (max -INF 0 1) 1)
+  assert (= (max +INF 0 1) +INF)
+  assert (= (max -INF -INF -INF) -INF)
 }


### PR DESCRIPTION
There is a bug in evaluating variadic operators in Interpreter. This PR removes dead / incorrect code in the `Max` branch so that the implementation matches the intended semantics. Also, the Test262 test suite still passes 100% without any issues.