### PR TITLE
Support More Accurate Re-Parsing

### DIFF
--- a/src/main/scala/esmeta/cfg/Node.scala
+++ b/src/main/scala/esmeta/cfg/Node.scala
@@ -41,7 +41,7 @@ sealed trait Node extends CFGElem with UId {
         headLoc <- head.loc
         last <- block.insts.lastOption
         lastLoc <- last.loc
-      } yield Loc(headLoc.start, lastLoc.end, None, headLoc.steps)
+      } yield Loc(headLoc.start, lastLoc.end, None, None, headLoc.steps)
     case call: Call     => call.callInst.loc
     case branch: Branch => branch.cond.loc
 

--- a/src/main/scala/esmeta/es/Ast.scala
+++ b/src/main/scala/esmeta/es/Ast.scala
@@ -69,33 +69,15 @@ sealed trait Ast extends ESElem with Locational {
         syn.loc = None; syn
       case lex: Lexical => lex.loc = None; lex
 
-  /** rebase location by an offset Pos (applies recursively to children) */
-  def rebaseLoc(offset: Pos, originTextOpt: Option[String]): Ast = this match
+  /** rebase location based on a given Pos (applies recursively to children) */
+  def rebaseLoc(base: Loc): Ast = this match
     case syn: Syntactic =>
-      for { child <- syn.children.flatten }
-        child.rebaseLoc(offset, originTextOpt)
-      syn.loc = syn.loc.map(l =>
-        l.copy(
-          start = l.start + offset,
-          end = l.end + offset,
-          originText = originTextOpt,
-        ),
-      ); syn
+      for { child <- syn.children.flatten } child.rebaseLoc(base)
+      syn.loc = syn.loc.map(_.rebase(base))
+      syn
     case lex: Lexical =>
-      lex.loc = lex.loc.map(l =>
-        l.copy(
-          start = l.start + offset,
-          end = l.end + offset,
-          originText = originTextOpt,
-        ),
-      ); lex
-
-  /** set location including children */
-  def setChildLoc(locOpt: Option[Loc]): Ast = this match
-    case syn: Syntactic =>
-      for { child <- syn.children.flatten } child.setChildLoc(locOpt)
-      syn.loc = locOpt; syn
-    case lex: Lexical => lex.loc = locOpt; lex
+      lex.loc = lex.loc.map(_.rebase(base))
+      lex
 
   /** safe getter */
   def get(field: Value)(using cfg: CFG): Option[Ast] = (this, field) match

--- a/src/main/scala/esmeta/es/Ast.scala
+++ b/src/main/scala/esmeta/es/Ast.scala
@@ -69,6 +69,27 @@ sealed trait Ast extends ESElem with Locational {
         syn.loc = None; syn
       case lex: Lexical => lex.loc = None; lex
 
+  /** rebase location by an offset Pos (applies recursively to children) */
+  def rebaseLoc(offset: Pos, originTextOpt: Option[String]): Ast = this match
+    case syn: Syntactic =>
+      for { child <- syn.children.flatten }
+        child.rebaseLoc(offset, originTextOpt)
+      syn.loc = syn.loc.map(l =>
+        l.copy(
+          start = l.start + offset,
+          end = l.end + offset,
+          originText = originTextOpt,
+        ),
+      ); syn
+    case lex: Lexical =>
+      lex.loc = lex.loc.map(l =>
+        l.copy(
+          start = l.start + offset,
+          end = l.end + offset,
+          originText = originTextOpt,
+        ),
+      ); lex
+
   /** set location including children */
   def setChildLoc(locOpt: Option[Loc]): Ast = this match
     case syn: Syntactic =>

--- a/src/main/scala/esmeta/es/Ast.scala
+++ b/src/main/scala/esmeta/es/Ast.scala
@@ -69,7 +69,7 @@ sealed trait Ast extends ESElem with Locational {
         syn.loc = None; syn
       case lex: Lexical => lex.loc = None; lex
 
-  /** rebase location based on a given Pos (applies recursively to children) */
+  /** rebase location based on a given Loc (applies recursively to children) */
   def rebaseLoc(base: Loc): Ast = this match
     case syn: Syntactic =>
       for { child <- syn.children.flatten } child.rebaseLoc(base)

--- a/src/main/scala/esmeta/es/util/Stringifier.scala
+++ b/src/main/scala/esmeta/es/util/Stringifier.scala
@@ -54,7 +54,15 @@ class Stringifier(
             if (symbol.getNt.isDefined) cs.headOption match
               case Some(hd) => hd.map(aux); cs = cs.tail
               case _        => raise(s"invalid AST: $origAst")
-    aux(origAst)
+    origAst match
+      case syn: Syntactic =>
+        (for {
+          loc <- syn.loc
+          text <- loc.originText
+        } yield loc.getString(text)) match
+          case Some(s) => app >> s
+          case None    => aux(origAst)
+      case lex: Lexical => app >> lex.str
     app
 
   lazy val basicAstRule: Rule[Ast] = (app, ast) =>

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -215,9 +215,9 @@ class Interpreter(
           case (x, GrammarSymbol(name, params), _, _) =>
             val ast =
               esParser(name, if (params.isEmpty) args else params).from(x)
-            orig match
-              case Some(originText) =>
-                ast.rebaseLoc(locOpt.get.start, Some(originText))
+            (orig zip locOpt) match
+              case Some((originText, loc)) =>
+                ast.rebaseLoc(loc.start, Some(originText))
               case None =>
                 ast.clearLoc
                 ast.setChildLoc(locOpt)

--- a/src/main/scala/esmeta/interpreter/Interpreter.scala
+++ b/src/main/scala/esmeta/interpreter/Interpreter.scala
@@ -198,14 +198,9 @@ class Interpreter(
     case EParse(code, rule) =>
       val (str, args, locOpt) = eval(code) match
         case Str(s) => (s, List(), None)
-        case AstValue(syn: Syntactic) =>
-          syn.loc.flatMap(l => l.originText.map(l -> _)) match
-            case Some(loc -> originText) =>
-              (loc.getString(originText), syn.args, syn.loc)
-            case _ =>
-              (syn.toString(grammar = Some(grammar)), syn.args, syn.loc)
-        case AstValue(lex: Lexical) => (lex.str, List(), lex.loc)
-        case v                      => throw InvalidParseSource(code, v)
+        case AstValue(ast) =>
+          (ast.toString(grammar = Some(grammar)), ast.getArgs, ast.loc)
+        case v => throw InvalidParseSource(code, v)
       try {
         (str, eval(rule).asGrammarSymbol, st.sourceText, st.cachedAst) match
           // optimize the initial parsing using the given cached AST

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -13,8 +13,9 @@ trait Locational {
     start: Pos,
     end: Pos,
     filename: Option[String] = None,
+    originText: Option[String] = None,
     steps: List[Int] = Nil,
-  ): this.type = setLoc(Some(Loc(start, end, filename, steps)))
+  ): this.type = setLoc(Some(Loc(start, end, filename, originText, steps)))
 
   /** set source location if not already set */
   def setLoc(locOpt: Option[Loc]): this.type =
@@ -36,9 +37,10 @@ trait Locational {
   *   (3:2-4:7 @ path) for `Loc(Pos(3,2), Pos(4,7), Some("path"), Nil)`
   */
 case class Loc(
-  var start: Pos,
-  var end: Pos,
+  start: Pos,
+  end: Pos,
   var filename: Option[String] = None,
+  var originText: Option[String] = None,
   var steps: List[Int] = Nil,
 ) {
 
@@ -107,10 +109,10 @@ case class Loc(
 
   /** merge locations */
   def merge(that: Loc): Option[Loc] =
-    val Loc(start, _, lname, lsteps) = this
-    val Loc(_, end, rname, rsteps) = that
-    if (lname != rname || lsteps != rsteps) return None
-    Some(Loc(start, end, lname, lsteps))
+    val Loc(start, _, lname, ltext, lsteps) = this
+    val Loc(_, end, rname, rtext, rsteps) = that
+    if (lname != rname || ltext != rtext || lsteps != rsteps) return None
+    Some(Loc(start, end, lname, ltext, lsteps))
 
   /** conversion to string */
   override def toString: String =
@@ -141,10 +143,17 @@ object Loc {
   *   3:2(5) for `Pos(3,2,5)` -- line 3, column 2, offset 5
   */
 case class Pos(
-  var line: Int,
-  var column: Int,
-  var offset: Int,
+  line: Int,
+  column: Int,
+  offset: Int,
 ) {
+
+  final def +(that: Pos): Pos =
+    Pos(
+      this.line + that.line,
+      this.column + that.column,
+      this.offset + that.offset,
+    )
 
   /** conversion to string */
   override def toString: String = s"$line:$column($offset)"

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -114,6 +114,13 @@ case class Loc(
     if (lname != rname || ltext != rtext || lsteps != rsteps) return None
     Some(Loc(start, end, lname, ltext, lsteps))
 
+  /** rebase a location by another location */
+  def rebase(base: Loc): Loc = this.copy(
+    start = start.rebase(base.start),
+    end = end.rebase(base.start),
+    originText = base.originText,
+  )
+
   /** conversion to string */
   override def toString: String =
     val app = new Appender
@@ -151,12 +158,12 @@ case class Pos(
   offset: Int,
 ) {
 
-  final def +(that: Pos): Pos =
+  /** rebase this position by another position */
+  final def rebase(base: Pos): Pos =
     Pos(
-      this.line + that.line - 1,
-      if (that.line == 1) this.column + that.column - 1 else that.column,
-      0,
-      this.offset + that.offset,
+      base.line + this.line - 1,
+      if (this.line == 1) base.column + this.column - 1 else this.column,
+      base.offset + this.offset,
     )
 
   /** conversion to string */

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -154,7 +154,7 @@ case class Pos(
   final def +(that: Pos): Pos =
     Pos(
       this.line + that.line - 1,
-      // TODO fix column addition, which cannot be simply added
+      if (that.line == 1) this.column + that.column - 1 else that.column,
       0,
       this.offset + that.offset,
     )

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -138,6 +138,9 @@ object Loc {
 }
 
 /** positions in algorithms
+  * - `line`   starts from 1
+  * - `column` starts from 1
+  * - `offset` starts from 0
   *
   * @example
   *   3:2(5) for `Pos(3,2,5)` -- line 3, column 2, offset 5
@@ -150,8 +153,9 @@ case class Pos(
 
   final def +(that: Pos): Pos =
     Pos(
-      this.line + that.line,
-      this.column + that.column,
+      this.line + that.line - 1,
+      // TODO fix column addition, which cannot be simply added
+      0,
       this.offset + that.offset,
     )
 

--- a/src/main/scala/esmeta/util/Loc.scala
+++ b/src/main/scala/esmeta/util/Loc.scala
@@ -138,9 +138,9 @@ object Loc {
 }
 
 /** positions in algorithms
-  * - `line`   starts from 1
-  * - `column` starts from 1
-  * - `offset` starts from 0
+  *   - `line` starts from 1
+  *   - `column` starts from 1
+  *   - `offset` starts from 0
   *
   * @example
   *   3:2(5) for `Pos(3,2,5)` -- line 3, column 2, offset 5


### PR DESCRIPTION
This PR fixes an issue where, during re-parsing (e.g., Cover-* productions), the AST is reconstructed from a stringified representation rather than from the original source substring. This caused less accurate AST location data.

This resolves: https://github.com/es-meta/esmeta/issues/326

With this change, several cases now produce more precise location information. For example:

* More accurate locations for IIFEs [debugger](https://es-meta.github.io/playground/?prog=var+k+%3D+%28function+%28%29+%7B%0A++var+a+%3D+1%3B%0A++var+b+%3D+2%3B%0A%7D%29%28%29%3B%0A%0Afunction+f%28a%2Cb%2Cc%29+%7B%0A++return+a+%2B+b+%2B+c%3B%0A%7D%0A%0Af%281%2B2%2C+3%2B4%2C+5%2B6%29%3B&iter=2046):

<img width="1512" height="412" alt="스크린샷 2025-11-29 04 38 10" src="https://github.com/user-attachments/assets/0d5be945-6806-48b0-9eea-d953da4c0c6e" />

* More accurate locations inside argument lists of function calls [debugger](https://es-meta.github.io/playground/?prog=var+k+%3D+%28function+%28%29+%7B%0A++var+a+%3D+1%3B%0A++var+b+%3D+2%3B%0A%7D%29%28%29%3B%0A%0Afunction+f%28a%2Cb%2Cc%29+%7B%0A++return+a+%2B+b+%2B+c%3B%0A%7D%0A%0Af%281%2B2%2C+3%2B4%2C+5%2B6%29%3B&iter=2621):

<img width="1512" height="416" alt="스크린샷 2025-11-29 04 36 53" src="https://github.com/user-attachments/assets/ef0b4975-f462-4b0f-8587-94508a8e7ffb" />

You can see this change in the linked examples by running this branch’s ESMeta and setting it as the API provider.

