### PR TITLE
Fix: correctly handle whitespace in locationed parser

### DIFF
--- a/src/main/scala/esmeta/parser/LAParsers.scala
+++ b/src/main/scala/esmeta/parser/LAParsers.scala
@@ -146,18 +146,7 @@ trait LAParsers extends Lexer {
   // location
   // handle whitespace in span info
   override def locationed[T <: Locational](p: => Parser[T]): Parser[T] =
-    new Parser[T] {
-      def apply(in: Input) =
-        // TODO handle white space
-        val trimmed = trimInput(in)
-        p(in) match
-          case s @ Success(res, rest) =>
-            new Success(
-              res.setLoc(trimmed, rest),
-              rest,
-            )
-          case ns: NoSuccess => ns
-    }
+    new Parser[T] { def apply(in: Input) = p(Skip(in).next) }
   def locationed[T <: Locational](p: LAParser[T]): LAParser[T] = new LAParser(
     follow => locationed(p.parser(follow)),
     p.first,


### PR DESCRIPTION
After merging the following PR, the `dev` branch fails the following Test262 tests.
* https://github.com/es-meta/esmeta/pull/327
```
{
  "[InterpreterError] unknown variable: operation" : [
    "language/expressions/division/S11.5.2_A1.js",
    "language/expressions/division/no-magic-asi-from-block-eval.js",
    "language/expressions/modulus/S11.5.3_A1.js",
    "language/expressions/multiplication/S11.5.1_A1.js",
    "language/line-terminators/S7.3_A7_T3.js",
    "language/line-terminators/S7.3_A7_T5.js",
    "language/line-terminators/S7.3_A7_T4.js"
  ],
  "Range [0, 28) out of bounds for length 27" : [
    "language/eval-code/direct/var-env-func-strict-caller.js"
  ],
  "[InterpreterError] ast expected but got: #1498" : [
    "language/statementList/eval-block-with-statment-arrow-function-assignment-expr.js",
    "language/statementList/eval-block-with-statment-arrow-function-functionbody.js",
    "language/statementList/eval-block-with-statment-expr-arrow-function-boolean-literal.js"
  ]
}
```

This PR fixed the issue by correctly handling whitespace in the locationed parser.