### PR TITLE
Fix: revert location info and correctly handle location for `eval`

### DIFF
--- a/src/main/scala/esmeta/parser/LAParsers.scala
+++ b/src/main/scala/esmeta/parser/LAParsers.scala
@@ -146,7 +146,18 @@ trait LAParsers extends Lexer {
   // location
   // handle whitespace in span info
   override def locationed[T <: Locational](p: => Parser[T]): Parser[T] =
-    new Parser[T] { def apply(in: Input) = p(Skip(in).next) }
+    new Parser[T] {
+      def apply(in: Input) = {
+        val trimmed = Skip(in).next
+        p(trimmed) match
+          case s @ Success(res, rest) =>
+            new Success(
+              res.setLoc(trimmed, rest),
+              rest,
+            )
+          case ns: NoSuccess => ns
+      }
+    }
   def locationed[T <: Locational](p: LAParser[T]): LAParser[T] = new LAParser(
     follow => locationed(p.parser(follow)),
     p.first,


### PR DESCRIPTION
Since there still exists a problem after merging https://github.com/es-meta/esmeta/pull/327 and https://github.com/es-meta/esmeta/pull/329, I fixed it in this PR.
I explicitly handled three different cases for location information:
* Use the already parsed AST for the parsing of the entire source code
* Parse strings at runtime (e.g., `eval` or `Function` constructor)
* Re-parse existing AST to support `covered-by` phrase in the specification.

I believe this PR has finally resolved the issue https://github.com/es-meta/esmeta/issues/326.