### PR TITLE
Migrate Occurrence Typing 

### DIFF
--- a/.completion
+++ b/.completion
@@ -17,7 +17,7 @@ _esmeta_completions() {
   extractOpt="-extract:target -extract:log -extract:eval -extract:repl -extract:strict -extract:allowed-yets"
   compileOpt="-compile:log -compile:log-with-loc -compile:opt"
   buildcfgOpt="-build-cfg:log -build-cfg:dot -build-cfg:pdf"
-  tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard"
+  tycheckOpt="-tycheck:target -tycheck:repl -tycheck:repl-continue -tycheck:ignore -tycheck:update-ignore -tycheck:log -tycheck:detail-log -tycheck:type-sens -tycheck:infer-guard -tycheck:effect"
   parseOpt="-parse:debug"
   evalOpt="-eval:timeout -eval:multiple -eval:tycheck -eval:log -eval:detail-log"
   webOpt="-web:host -web:port"

--- a/src/main/scala/esmeta/analyzer/Analyzer.scala
+++ b/src/main/scala/esmeta/analyzer/Analyzer.scala
@@ -48,6 +48,9 @@ abstract class Analyzer
   /** abstract values */
   type AbsValue <: AbsValueLike
 
+  /** effects */
+  type Effect <: EffectLike
+
   /** lookup for node points */
   def getResult(np: NodePoint[Node]): AbsState =
     npMap.getOrElse(np, AbsState.Bot)

--- a/src/main/scala/esmeta/analyzer/DomainLike.scala
+++ b/src/main/scala/esmeta/analyzer/DomainLike.scala
@@ -59,4 +59,12 @@ trait DomainLikeDecl { self: Analyzer =>
     def value: AbsValue
   }
   val AbsRet: DomainLike[AbsRet]
+
+  /** effects */
+  trait EffectLike extends DomainElemLike[Effect] { self: Effect =>
+
+    /** abstract domain */
+    def domain = Effect
+  }
+  val Effect: DomainLike[Effect]
 }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsRet.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsRet.scala
@@ -5,36 +5,38 @@ import esmeta.util.Appender.*
 /** abstract return values */
 trait AbsRetDecl { self: TyChecker =>
 
-  case class AbsRet(value: AbsValue) extends AbsRetLike {
+  case class AbsRet(value: AbsValue, effect: Effect) extends AbsRetLike {
     import AbsRet.*
 
     /** bottom check */
-    def isBottom: Boolean = value.isBottom
+    def isBottom: Boolean = value.isBottom && effect.isBottom
 
     /** partial order */
     def ⊑(that: AbsRet)(using AbsState): Boolean =
-      this.value ⊑ that.value
+      this.value ⊑ that.value && this.effect ⊑ that.effect
 
     /** not partial order */
     def !⊑(that: AbsRet)(using AbsState): Boolean = !(this ⊑ that)
 
     /** join operator */
     def ⊔(that: AbsRet)(using AbsState): AbsRet =
-      AbsRet(this.value ⊔ that.value)
+      AbsRet(this.value ⊔ that.value, this.effect ⊔ that.effect)
 
     /** meet operator */
     def ⊓(that: AbsRet)(using AbsState): AbsRet =
-      AbsRet(this.value ⊓ that.value)
+      AbsRet(this.value ⊓ that.value, this.effect ⊓ that.effect)
   }
   object AbsRet extends DomainLike[AbsRet] {
 
     /** top element */
-    lazy val Top: AbsRet = AbsRet(AbsValue.Top)
+    lazy val Top: AbsRet = AbsRet(AbsValue.Top, Effect.Top)
 
     /** bottom element */
-    lazy val Bot: AbsRet = AbsRet(AbsValue.Bot)
+    lazy val Bot: AbsRet = AbsRet(AbsValue.Bot, Effect.Bot)
 
     /** appender */
-    given rule: Rule[AbsRet] = (app, elem) => app >> elem.value
+    given effectRule: Rule[Set[String]] = iterableRule("(", ", ", ")")
+    given rule: Rule[AbsRet] = (app, elem) =>
+      app >> elem.value >> " " >> elem.effect
   }
 }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -249,7 +249,7 @@ trait AbsStateDecl { self: TyChecker =>
         val newV =
           if value.hasLocalBase(x) then value.weaken(Set(x), update = false)
           else value
-        this.copy(locals = locals + (x -> value))
+        this.copy(locals = locals + (x -> newV))
       case x: Global => this
 
     /** field update */

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -123,7 +123,7 @@ trait AbsStateDecl { self: TyChecker =>
 
     def get(sty: SymTy): AbsValue = AbsValue(sty)
 
-    def getTy(sty: SymTy): ValueTy = sty.ty
+    def getTy(sty: SymTy): ValueTy = sty.upper
 
     def getTy(base: Base): ValueTy = base match
       case l: Local => get(l).ty

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -107,7 +107,8 @@ trait AbsStateDecl { self: TyChecker =>
 
     /** weaken bases */
     def weaken(bases: Set[Base], update: Boolean): AbsState =
-      val newLocals = for { (x, v) <- locals } yield x -> v.weaken(bases, update)
+      val newLocals =
+        for { (x, v) <- locals } yield x -> v.weaken(bases, update)
       val newProp = if (update) prop.weaken(bases) else prop
       AbsState(reachable, newLocals, symEnv, newProp)
 
@@ -231,8 +232,8 @@ trait AbsStateDecl { self: TyChecker =>
 
     /** define variables */
     def define(x: Var, value: AbsValue): AbsState = x match
-        case x: Local  => this.update(x, value)
-        case x: Global => raise("do not support defining global variables")
+      case x: Local  => this.update(x, value)
+      case x: Global => raise("do not support defining global variables")
 
     /** identifier setter */
     def update(x: Var, value: AbsValue): AbsState = x match

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -118,7 +118,7 @@ trait AbsStateDecl { self: TyChecker =>
 
     /** weaken effect */
     def weaken(ef: Effect): AbsState =
-      if (ef.isBottom) this
+      if (!useEffect || ef.isBottom) this
       else
         val newLocals = for { (x, v) <- locals } yield x -> v.weaken(ef)
         val newSymEnv = for { (sym, ty) <- symEnv } yield sym -> ef(ty)
@@ -273,8 +273,10 @@ trait AbsStateDecl { self: TyChecker =>
           x -> v ⊔ v.fieldUpdate(fld, value)
         else x -> v)
         .updated(lx, this.get(lx).fieldUpdate(fld, value)) // strong update
-      val newEffect = effect.fieldUpdate(fld, value)
-      this.copy(locals = newLocals.toMap, effect = newEffect)
+      if (!useEffect) this.copy(locals = newLocals.toMap)
+      else
+        val newEffect = effect.fieldUpdate(fld, value)
+        this.copy(locals = newLocals.toMap, effect = newEffect)
     }
 
     /** type check */

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -17,6 +17,7 @@ trait AbsStateDecl { self: TyChecker =>
     locals: Map[Local, AbsValue],
     symEnv: Map[Sym, ValueTy],
     prop: TypeProp,
+    effect: Effect,
   ) extends AbsStateLike {
     import AbsState.*
 
@@ -33,8 +34,8 @@ trait AbsStateDecl { self: TyChecker =>
       case _ if this.isBottom => true
       case _ if that.isBottom => false
       case (
-            AbsState(_, llocals, lsymEnv, lprop),
-            AbsState(_, rlocals, rsymEnv, rprop),
+            AbsState(_, llocals, lsymEnv, lprop, leffect),
+            AbsState(_, rlocals, rsymEnv, rprop, reffect),
           ) =>
         llocals.forall { (x, lv) =>
           rlocals.get(x).fold(false) { rv =>
@@ -42,7 +43,8 @@ trait AbsStateDecl { self: TyChecker =>
           }
         } &&
         lsymEnv.forall { (sym, ty) => rsymEnv.get(sym).fold(false)(ty <= _) } &&
-        lprop <= rprop
+        lprop <= rprop &&
+        leffect ⊑ reffect
 
     /** not partial order */
     def !⊑(that: AbsState): Boolean = !(this ⊑ that)
@@ -72,7 +74,8 @@ trait AbsStateDecl { self: TyChecker =>
           ty = l.get(sym) || r.get(sym)
         } yield sym -> ty).toMap
         val newProp = l.prop || r.prop
-        AbsState(true, newLocals, newSymEnv, newProp)
+        val newEffect = l.effect ⊔ r.effect
+        AbsState(true, newLocals, newSymEnv, newProp, newEffect)
 
     /** get imprecise bases compared with another state */
     def getImprecBases(that: AbsState): Set[Base] =
@@ -103,14 +106,24 @@ trait AbsStateDecl { self: TyChecker =>
           ty = l.get(sym) ⊓ r.get(sym)
         } yield sym -> ty).toMap
         val newProp = l.prop && r.prop
-        AbsState(true, newLocals, newSymEnv, newProp)
+        val newEffect = l.effect ⊓ r.effect
+        AbsState(true, newLocals, newSymEnv, newProp, newEffect)
 
     /** weaken bases */
     def weaken(bases: Set[Base], update: Boolean): AbsState =
       val newLocals =
         for { (x, v) <- locals } yield x -> v.weaken(bases, update)
       val newProp = if (update) prop.weaken(bases) else prop
-      AbsState(reachable, newLocals, symEnv, newProp)
+      AbsState(reachable, newLocals, symEnv, newProp, effect)
+
+    /** weaken effect */
+    def weaken(ef: Effect): AbsState =
+      if (ef.isBottom) this
+      else
+        val newLocals = for { (x, v) <- locals } yield x -> v.weaken(ef)
+        val newSymEnv = for { (sym, ty) <- symEnv } yield sym -> ef(ty)
+        val newProp = prop.weaken(ef)
+        AbsState(reachable, newLocals, newSymEnv, newProp, ef)
 
     /** has imprecise elements */
     def hasImprec: Boolean = locals.values.exists(_.ty.isImprec)
@@ -260,7 +273,8 @@ trait AbsStateDecl { self: TyChecker =>
           x -> v ⊔ v.fieldUpdate(fld, value)
         else x -> v)
         .updated(lx, this.get(lx).fieldUpdate(fld, value)) // strong update
-      this.copy(locals = newLocals.toMap)
+      val newEffect = effect.fieldUpdate(fld, value)
+      this.copy(locals = newLocals.toMap, effect = newEffect)
     }
 
     /** type check */
@@ -330,11 +344,11 @@ trait AbsStateDecl { self: TyChecker =>
 
     /** bottom element */
     lazy val Bot: AbsState =
-      AbsState(false, Map(), Map(), TypeProp())
+      AbsState(false, Map(), Map(), TypeProp(), Effect())
 
     /** empty element */
     lazy val Empty: AbsState =
-      AbsState(true, Map(), Map(), TypeProp())
+      AbsState(true, Map(), Map(), TypeProp(), Effect())
 
     /** appender */
     given rule: Rule[AbsState] = mkRule(true)
@@ -343,13 +357,15 @@ trait AbsStateDecl { self: TyChecker =>
     private def mkRule(detail: Boolean): Rule[AbsState] = (app, elem) =>
       import SymTy.given
       if (!elem.isBottom) {
-        val AbsState(reachable, locals, symEnv, prop) = elem
+        val AbsState(reachable, locals, symEnv, prop, effect) = elem
         given localsRule: Rule[Map[Local, AbsValue]] = sortedMapRule(sep = ": ")
         given symEnvRule: Rule[Map[Sym, ValueTy]] = sortedMapRule(sep = ": ")
         given propRule: Rule[Map[Base, ValueTy]] = sortedMapRule(sep = " <: ")
         if (locals.nonEmpty) app >> locals
         if (symEnv.nonEmpty) app >> symEnv
         app >> prop
+        if (effect.nonEmpty) app >> effect
+        app
       } else app >> "⊥"
   }
 }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -1651,13 +1651,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       val (ref, givenTy) = pair
       ref match
         case v @ SVar(x) =>
-          val ty = v.ty
+          val ty = v.upper
           if (ty <= givenTy) None else Some(x -> givenTy)
         case v @ SSym(s) =>
           val ty = st.get(s)
           if (ty <= givenTy) None else Some(s -> givenTy)
         case SField(base, STy(x)) if x <= StrT && x.isSingle =>
-          val bty = base.ty
+          val bty = base.upper
           val field = x.str.getSingle match
             case One(elem) => elem
             case _         => return None

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -1465,7 +1465,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 case (EMath(0), _) =>
                   math = if (positive) MathTy.NegInt else MathTy.NonNegInt
                 case l =>
-              st.update(
+              st.strongUpdate(
                 x,
                 AbsValue(
                   ValueTy(
@@ -1485,7 +1485,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 case (EMath(0), _) =>
                   math = if (positive) MathTy.PosInt else MathTy.NonPosInt
                 case _ => rmath
-              lst.update(
+              lst.strongUpdate(
                 x,
                 AbsValue(
                   ValueTy(
@@ -1627,9 +1627,9 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         for {
           v <- get(_.get(x))
           given AbsState <- get
-          refinedV = if (v.ty <= ty.toValue) v else v ⊓ AbsValue(ty)
-          _ <- modify(_.update(x, refinedV))
-          _ <- notice(v, refinedV) // propagate type guard
+          refinedV = v.refine(ty)
+          _ <- modify(_.strongUpdate(x, refinedV))
+          _ <- modify(refine(v.guard(ty)))
         } yield ()
 
     def toBase(
@@ -1680,7 +1680,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         if (positive) lv ⊓ rv
         else if (rv.isSingle) lv -- rv
         else lv
-      _ <- modify(_.update(x, refinedV))
+      _ <- modify(_.strongUpdate(x, refinedV))
       _ <- notice(lv, refinedV)
     } yield ()
 
@@ -1711,7 +1711,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         record = lty.record.update(field, binding, refine = true),
       )
       refinedV = AbsValue(refinedTy)
-      _ <- modify(_.update(x, refinedV))
+      _ <- modify(_.strongUpdate(x, refinedV))
       _ <- notice(lv, refinedV)
     } yield ()
 
@@ -1739,7 +1739,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           val value = AbsValue(ValueTy.fromTypeOf(tname))
           if (positive) lv ⊓ value else lv -- value
         case _ => lv
-      _ <- modify(_.update(x, refinedV))
+      _ <- modify(_.strongUpdate(x, refinedV))
     } yield ()
 
     /** refine types with type checks */

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -276,7 +276,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           val v = AbsValue(retTy)
           v.lift
         }
-        if (useSyntacticKill) newRetV = newRetV.killMutable(using callerNp)
+        if (useSyntacticweaken) newRetV = newRetV.weakenMutable(using callerNp)
         for {
           nextNp <- getAfterCallNp(callerNp)
           newSt = callerSt.define(call.lhs, newRetV)
@@ -442,7 +442,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           given AbsState <- get
           tv <- transfer(expr)
           v =
-            if (useSyntacticKill) AbsValue(tv.ty)
+            if (useSyntacticweaken) AbsValue(tv.ty)
             else tv
           _ <- modify(_.update(x, v, refine = false))
         } yield ()
@@ -567,8 +567,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         guard <- if (inferTypeGuard) getTypeGuard(expr) else pure(TypeGuard())
         newV = if (inferTypeGuard) v.addGuard(guard) else v
       } yield
-        if (!useSyntacticKill) newV
-        else newV.killMutable)(st)
+        if (!useSyntacticweaken) newV
+        else newV.weakenMutable)(st)
       // No propagation if the result of the expression is bottom
       if (v.isBottom) (v, AbsState.Bot) else (v, newSt)
     }
@@ -1358,8 +1358,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         case (v, i) => i -> v
       }.toMap
       val newV = instantiate(call, value, map)
-      if (inferTypeGuard && useSyntacticKill)
-        newV.lift.killMutable(using callerNp)
+      if (inferTypeGuard && useSyntacticweaken)
+        newV.lift.weakenMutable(using callerNp)
       else if (inferTypeGuard) newV.lift
       else newV
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -171,7 +171,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
 
     /** transfer function for return points */
     def apply(rp: ReturnPoint): Unit = if (!canUseReturnTy(rp.func)) {
-      var AbsRet(value) = getResult(rp)
+      var AbsRet(value, effect) = getResult(rp)
       for {
         callerNps <- retEdges.get(rp)
         callerNp <- callerNps
@@ -180,7 +180,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         given callerSt: AbsState = callInfo(callerNp)
         val retTy = rp.func.retTy.ty.toValue
         val newV = instantiate(value, callerNp) ⊓ AbsValue(retTy)
-        val nextSt = callerSt.update(callerNp.node.lhs, newV)
+        val nextSt = callerSt.weaken(effect).update(callerNp.node.lhs, newV)
         analyzer += nextNp -> nextSt
       }
     }
@@ -400,7 +400,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
     /** propagate callee analysis result */
     def propagate(rp: ReturnPoint, callerNp: NodePoint[Call]): Unit = {
       if (!canUseReturnTy(rp.func)) {
-        val AbsRet(value) = getResult(rp)
+        val AbsRet(value, effect) = getResult(rp)
         (for {
           nextNp <- getAfterCallNp(callerNp)
           callerSt = callInfo(callerNp)
@@ -409,6 +409,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           newV = instantiate(value, callerNp) ⊓ AbsValue(retTy)
           if !newV.isBottom
         } yield analyzer += nextNp -> callerSt
+          .weaken(effect)
           .define(callerNp.node.lhs, newV))
           .getOrElse {
             if (!getResult(rp).isBottom) worklist += rp
@@ -447,15 +448,14 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           _ <- modify(_.update(x, v))
         } yield ()
       case IAssign(Field(x: Var, EStr(f)), expr) =>
-        for {
-          v <- transfer(expr)
-          given AbsState <- get
-          ty <- get(_.get(x).ty)
-          record = ty.record.update(f, v.ty, refine = false)
-          _ <- modify(
-            _.update(x, AbsValue(ty.copied(record = record))),
-          )
-        } yield ()
+        x match
+          case x: Local =>
+            for {
+              v <- transfer(expr)
+              given AbsState <- get
+              _ <- modify(_.update(x, f, v))
+            } yield ()
+          case _ => st => st /* do not support global variables */
       case IAssign(ref, expr)  => st => st /* TODO */
       case IExpand(base, expr) => st => st /* TODO */
       case IDelete(base, expr) => st => st /* TODO */
@@ -479,7 +479,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         for {
           v <- transfer(expr)
           st <- get
-          _ <- doReturn(inst, st, v)
+          ef <- get(_.effect)
+          _ <- doReturn(inst, st, v, ef)
           _ <- put(AbsState.Bot)
         } yield ()
       case IAssert(expr: EYet) =>
@@ -522,6 +523,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       irReturn: Return,
       givenSt: AbsState,
       v: AbsValue,
+      effect: Effect,
     )(using np: NodePoint[Node]): Unit =
       val NodePoint(func, node, view) = np
       val irp = InternalReturnPoint(func, node, irReturn)
@@ -542,13 +544,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               addError(ReturnTypeMismatch(irp, givenTy))
             AbsValue(STy(givenTy && expectedTy), givenV.guard)
 
-      val newRet = AbsRet(newV)
+      val newRet = AbsRet(newV, effect)
       if (!newV.isBottom)
-        val oldRet @ AbsRet(oldV) = getResult(rp)
+        val oldRet @ AbsRet(oldV, oldEffect) = getResult(rp)
         if (!oldRet.isBottom && useRepl) Repl.merged = true
         if (newRet !⊑ oldRet) {
           val v = (oldV ⊔ newV)
-          rpMap += rp -> AbsRet(v)
+          rpMap += rp -> AbsRet(v, oldEffect ⊔ effect)
           worklist += rp
         }
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -180,7 +180,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         given callerSt: AbsState = callInfo(callerNp)
         val retTy = rp.func.retTy.ty.toValue
         val newV = instantiate(value, callerNp) ⊓ AbsValue(retTy)
-        val nextSt = callerSt.weaken(effect).update(callerNp.node.lhs, newV)
+        val weakenedSt = if (useEffect) callerSt.weaken(effect) else callerSt
+        val nextSt = weakenedSt.update(callerNp.node.lhs, newV)
         analyzer += nextNp -> nextSt
       }
     }
@@ -408,9 +409,9 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           retTy = rp.func.retTy.ty.toValue
           newV = instantiate(value, callerNp) ⊓ AbsValue(retTy)
           if !newV.isBottom
-        } yield analyzer += nextNp -> callerSt
-          .weaken(effect)
-          .define(callerNp.node.lhs, newV))
+        } yield
+          val weakenedSt = if (useEffect) callerSt.weaken(effect) else callerSt
+          analyzer += nextNp -> weakenedSt.define(callerNp.node.lhs, newV))
           .getOrElse {
             if (!getResult(rp).isBottom) worklist += rp
           }
@@ -480,7 +481,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           v <- transfer(expr)
           st <- get
           ef <- get(_.effect)
-          _ <- doReturn(inst, st, v, ef)
+          _ <- doReturn(inst, st, v, if (useEffect) ef else Effect.Bot)
           _ <- put(AbsState.Bot)
         } yield ()
       case IAssert(expr: EYet) =>

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -274,7 +274,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           newV = instantiate(v, callerNp)
         } yield newV).getOrElse {
           val v = AbsValue(retTy)
-          v.lift
+          v.bind
         }
         if (useSyntacticweaken) newRetV = newRetV.weakenMutable(using callerNp)
         for {
@@ -565,7 +565,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
         v <- basicTransfer(expr, forArg)
         given AbsState <- get
         guard <- if (inferTypeGuard) inferGuard(expr) else pure(TypeGuard())
-        newV = if (inferTypeGuard) v.addGuard(guard) else v
+        newV = if (inferTypeGuard) v.addGuard(guard).bind else v
       } yield
         if (!useSyntacticweaken) newV
         else newV.weakenMutable)(st)
@@ -806,9 +806,6 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       import DemandType.*
       given Node = np.node
       expr match {
-        case EBool(bool) =>
-          val dty = if (bool) DemandType(TrueT) else DemandType(FalseT)
-          get(st => TypeGuard(Map(dty -> TypeProp().lift(using st))))
         case ERecord(tname @ "CompletionRecord", fields) =>
           for {
             pairs <- join(fields.map {
@@ -819,7 +816,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
             })
             v <- id(_.allocRecord(tname, pairs))
             given AbsState <- get
-          } yield v.lift.guard
+          } yield v.guard
         case EBinary(BOp.Lt, l, r) =>
           for {
             lv <- transfer(l)
@@ -893,13 +890,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               aux(lty, rty, true, true).map { thenTy =>
                 if (lty != thenTy && !thenTy.isBottom)
                   toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                    lmap += DemandType(TrueT) -> TypeProp(pair).lift
+                    lmap += DemandType(TrueT) -> TypeProp(pair)
                   }
               }
               aux(lty, rty, false, true).map { elseTy =>
                 if (lty != elseTy && !elseTy.isBottom)
                   toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                    lmap += DemandType(FalseT) -> TypeProp(pair).lift
+                    lmap += DemandType(FalseT) -> TypeProp(pair)
                   }
               }
             }
@@ -908,13 +905,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               aux(rty, lty, true, false).map { thenTy =>
                 if (rty != thenTy && !thenTy.isBottom)
                   toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                    rmap += DemandType(TrueT) -> TypeProp(pair).lift
+                    rmap += DemandType(TrueT) -> TypeProp(pair)
                   }
               }
               aux(rty, lty, false, false).map { elseTy =>
                 if (rty != elseTy && !elseTy.isBottom)
                   toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                    rmap += DemandType(FalseT) -> TypeProp(pair).lift
+                    rmap += DemandType(FalseT) -> TypeProp(pair)
                   }
               }
             }
@@ -926,7 +923,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 lguard(dty) &&
                 rguard(dty)
               }
-              newProp = prop.lift
+              newProp = prop
               if newProp.nonTop
             } yield dty -> newProp).toMap
             TypeGuard(guard)
@@ -947,12 +944,12 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               if (thenTy.isBottom) bools -= true
               else
                 toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                  guard += DemandType(TrueT) -> TypeProp(pair).lift
+                  guard += DemandType(TrueT) -> TypeProp(pair)
                 }
               if (elseTy.isBottom) bools -= false
               else
                 toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                  guard += DemandType(FalseT) -> TypeProp(pair).lift
+                  guard += DemandType(FalseT) -> TypeProp(pair)
                 }
             }
             TypeGuard(guard)
@@ -973,13 +970,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 if (thenTy.isBottom) bools -= true
                 else
                   toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                    guard += DemandType(TrueT) -> TypeProp(pair).lift
+                    guard += DemandType(TrueT) -> TypeProp(pair)
                   }
               if (lty != elseTy)
                 if (elseTy.isBottom) bools -= false
                 else
                   toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                    guard += DemandType(FalseT) -> TypeProp(pair).lift
+                    guard += DemandType(FalseT) -> TypeProp(pair)
                   }
             }
             TypeGuard(guard)
@@ -1004,13 +1001,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 if (thenTy.isBottom) bools -= true
                 else
                   toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                    guard += DemandType(TrueT) -> TypeProp(pair).lift
+                    guard += DemandType(TrueT) -> TypeProp(pair)
                   }
               if (lty != elseTy)
                 if (elseTy.isBottom) bools -= false
                 else
                   toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                    guard += DemandType(FalseT) -> TypeProp(pair).lift
+                    guard += DemandType(FalseT) -> TypeProp(pair)
                   }
             }
             TypeGuard(guard)
@@ -1066,13 +1063,13 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 if (thenTy.isBottom) bools -= true
                 else
                   toBase(ref -> thenTy, np, Some(true)).map { pair =>
-                    guard += DemandType(TrueT) -> TypeProp(pair).lift
+                    guard += DemandType(TrueT) -> TypeProp(pair)
                   }
               if (lty != elseTy)
                 if (elseTy.isBottom) bools -= false
                 else
                   toBase(ref -> elseTy, np, Some(false)).map { pair =>
-                    guard += DemandType(FalseT) -> TypeProp(pair).lift
+                    guard += DemandType(FalseT) -> TypeProp(pair)
                   }
             }
             TypeGuard(guard)
@@ -1087,8 +1084,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
             lf = guard(DemandType(FalseT))
           } yield {
             var guard: Map[DemandType, TypeProp] = Map()
-            guard += DemandType(TrueT) -> lf.lift
-            guard += DemandType(FalseT) -> lt.lift
+            guard += DemandType(TrueT) -> lf
+            guard += DemandType(FalseT) -> lt
             TypeGuard(guard)
           }
         case EBinary(BOp.Or, l, r) =>
@@ -1111,14 +1108,14 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               rt = rv.guard(DemandType(TrueT))
             } yield if (hasT) lt || rt else rt)(refinedSt)
             if (thenProp.nonTop)
-              guard += DemandType(TrueT) -> thenProp.lift
+              guard += DemandType(TrueT) -> thenProp
             val (elseProp, _) = (for {
               rv <- transfer(r)
               rf = rv.guard(DemandType(FalseT))
               hasF = lty.bool.contains(false)
             } yield lf && rf)(refinedSt)
             if (elseProp.nonTop)
-              guard += DemandType(FalseT) -> elseProp.lift
+              guard += DemandType(FalseT) -> elseProp
             TypeGuard(guard)
           }
         case EBinary(BOp.And, l, r) =>
@@ -1141,25 +1138,15 @@ trait AbsTransferDecl { analyzer: TyChecker =>
               rt = rv.guard(DemandType(TrueT))
             } yield lt && rt)(refinedSt)
             if (thenProp.nonTop)
-              guard += DemandType(TrueT) -> thenProp.lift
+              guard += DemandType(TrueT) -> thenProp
             val (elseProp, _) = (for {
               rv <- transfer(r)
               rf = rv.guard(DemandType(FalseT))
             } yield if (hasF) lf || rf else rf)(refinedSt)
             if (elseProp.nonTop)
-              guard += DemandType(FalseT) -> elseProp.lift
+              guard += DemandType(FalseT) -> elseProp
             TypeGuard(guard)
           }
-        case EEnum(name) =>
-          if DemandType.set.contains(EnumT(name)) then
-            get(st => {
-              TypeGuard(
-                Map(
-                  DemandType(EnumT(name)) -> TypeProp().lift(using st),
-                ),
-              )
-            })
-          else TypeGuard.Empty
         case _ => TypeGuard.Empty
       }
     }
@@ -1353,8 +1340,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
       }.toMap
       val newV = instantiate(call, value, map)
       if (inferTypeGuard && useSyntacticweaken)
-        newV.lift.weakenMutable(using callerNp)
-      else if (inferTypeGuard) newV.lift
+        newV.bind.weakenMutable(using callerNp)
+      else if (inferTypeGuard) newV.bind
       else newV
 
     /** instantiation of abstract values */
@@ -1611,7 +1598,7 @@ trait AbsTransferDecl { analyzer: TyChecker =>
                 case None    => pure(())
             } yield ()
         })
-        _ <- modify(st => st.copy(prop = prop.lift(using st)))
+        _ <- modify(st => st.copy(prop = prop.bind(using st)))
       } yield ()
 
     /** refine references using types */

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsTransfer.scala
@@ -411,7 +411,8 @@ trait AbsTransferDecl { analyzer: TyChecker =>
           if !newV.isBottom
         } yield
           val weakenedSt = if (useEffect) callerSt.weaken(effect) else callerSt
-          analyzer += nextNp -> weakenedSt.define(callerNp.node.lhs, newV))
+          analyzer += nextNp -> weakenedSt.define(callerNp.node.lhs, newV)
+        )
           .getOrElse {
             if (!getResult(rp).isBottom) worklist += rp
           }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -51,7 +51,7 @@ trait AbsValueDecl { self: TyChecker =>
 
     /** add type guard */
     def addGuard(guard: TypeGuard)(using AbsState): AbsValue =
-      this.copy(guard = (this.guard && guard).filter(this.ty))
+      this.copy(guard = this.guard && guard)
 
     /** weaken bases */
     def weaken(bases: Set[Base], update: Boolean)(using AbsState): AbsValue =

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -88,8 +88,8 @@ trait AbsValueDecl { self: TyChecker =>
     /** check whether it has a type guard */
     def hasTypeGuard(entrySt: AbsState): Boolean =
       import SymTy.*, SymExpr.*
-      guard.map.exists { (kind, constr) =>
-        constr.map.exists {
+      guard.map.exists { (kind, prop) =>
+        prop.map.exists {
           case (x: Sym, (ty, _)) => !(entrySt.getTy(SERef(SSym(x))) <= ty)
           case _                 => false
         }

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -53,12 +53,12 @@ trait AbsValueDecl { self: TyChecker =>
     def addGuard(guard: TypeGuard)(using AbsState): AbsValue =
       this.copy(guard = (this.guard && guard).filter(this.ty))
 
-    /** kill bases */
-    def kill(bases: Set[Base], update: Boolean)(using AbsState): AbsValue =
+    /** weaken bases */
+    def weaken(bases: Set[Base], update: Boolean)(using AbsState): AbsValue =
       val ty = this.symty.bases.exists(bases.contains) match
         case true  => STy(this.ty)
         case false => this.symty
-      val guard = if (update) this.guard.kill(bases) else this.guard
+      val guard = if (update) this.guard.weaken(bases) else this.guard
       AbsValue(ty, guard)
 
     /** remove non-parameter local variables */
@@ -70,7 +70,7 @@ trait AbsValueDecl { self: TyChecker =>
       given AbsState = givenSt
       if (isTypeGuardCandidate(func)) {
         val xs = givenSt.getImprecBases(entrySt)
-        this.kill(xs, update = false)
+        this.weaken(xs, update = false)
       } else AbsValue(this.ty)
 
     /** get symbols */
@@ -95,8 +95,8 @@ trait AbsValueDecl { self: TyChecker =>
         }
       }
 
-    def killMutable(using np: NodePoint[_], st: AbsState) =
-      this.copy(guard = this.guard.kill(np.func.mutableLocals))
+    def weakenMutable(using np: NodePoint[_], st: AbsState) =
+      this.copy(guard = this.guard.weaken(np.func.mutableLocals))
 
     def isSymbolic: Boolean = symty.isSymbolic
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -61,12 +61,14 @@ trait AbsValueDecl { self: TyChecker =>
       val guard = if (update) this.guard.weaken(bases) else this.guard
       AbsValue(ty, guard)
 
-    def refine(ty: ValueTy)(using st: AbsState): AbsValue = 
+    def refine(ty: ValueTy)(using st: AbsState): AbsValue =
       AbsValue(symty.refine(ty), guard.refine(ty))
 
-    def fieldUpdate(fld: String, value: AbsValue)(using AbsState): AbsValue = 
+    def fieldUpdate(fld: String, value: AbsValue)(using AbsState): AbsValue =
       val (tty, vty) = (symty.upper, value.symty.upper)
-      val newSymTy = STy(tty.copied(record = tty.record.update(fld, vty, refine = false)))
+      val newSymTy = STy(
+        tty.copied(record = tty.record.update(fld, vty, refine = false)),
+      )
       val newGuard = guard.fieldUpdate(fld, vty)
       AbsValue(newSymTy, newGuard)
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -61,6 +61,15 @@ trait AbsValueDecl { self: TyChecker =>
       val guard = if (update) this.guard.weaken(bases) else this.guard
       AbsValue(ty, guard)
 
+    def refine(ty: ValueTy)(using st: AbsState): AbsValue = 
+      AbsValue(symty.refine(ty), guard.refine(ty))
+
+    def fieldUpdate(fld: String, value: AbsValue)(using AbsState): AbsValue = 
+      val (tty, vty) = (symty.upper, value.symty.upper)
+      val newSymTy = STy(tty.copied(record = tty.record.update(fld, vty, refine = false)))
+      val newGuard = guard.fieldUpdate(fld, vty)
+      AbsValue(newSymTy, newGuard)
+
     /** remove non-parameter local variables */
     def forReturn(
       givenSt: AbsState,

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -25,7 +25,7 @@ trait AbsValueDecl { self: TyChecker =>
     def isBottom: Boolean = symty.isBottom
 
     /** upper type */
-    def ty(using st: AbsState): ValueTy = symty.ty
+    def ty(using st: AbsState): ValueTy = symty.upper
 
     /** single check */
     def isSingle(using st: AbsState): Boolean = symty.isSingle && guard.isEmpty

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -61,6 +61,11 @@ trait AbsValueDecl { self: TyChecker =>
       val guard = if (update) this.guard.weaken(bases) else this.guard
       AbsValue(ty, guard)
 
+    def weaken(effect: Effect)(using AbsState): AbsValue =
+      val sty = this.symty.weaken(effect)
+      val guard = this.guard.weaken(effect)
+      AbsValue(sty, guard)
+
     def refine(ty: ValueTy)(using st: AbsState): AbsValue =
       AbsValue(symty.refine(ty), guard.refine(ty))
 

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -90,8 +90,8 @@ trait AbsValueDecl { self: TyChecker =>
       val inGuard = guard.bases
       inSymty ++ inGuard
 
-    def lift(using st: AbsState): AbsValue =
-      AbsValue(symty, guard.lift(this.ty))
+    def bind(using st: AbsState): AbsValue =
+      AbsValue(symty, guard.bind(this.ty))
 
     /** check whether it has a local variable as a base */
     def hasLocalBase(x: Local): Boolean = bases.exists(_ == x)

--- a/src/main/scala/esmeta/analyzer/tychecker/Effect.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/Effect.scala
@@ -81,4 +81,3 @@ trait EffectDecl { self: TyChecker =>
     given rule: Rule[Effect] = (app, elem) => app >> elem.map
   }
 }
-

--- a/src/main/scala/esmeta/analyzer/tychecker/Effect.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/Effect.scala
@@ -1,0 +1,84 @@
+package esmeta.analyzer.tychecker
+
+import esmeta.util.Appender.*
+import esmeta.ty.*
+import esmeta.util.*
+
+/** abstract return values */
+trait EffectDecl { self: TyChecker =>
+
+  case class Effect(map: Map[String, Set[String]] = Map()) extends EffectLike {
+    import Effect.*
+
+    /** bottom check */
+    def isBottom: Boolean = map.isEmpty
+
+    /** partial order */
+    def ⊑(that: Effect)(using AbsState): Boolean =
+      this.map.forall {
+        case (k, v) => (that.map.contains(k) && v.subsetOf(that.map(k)))
+      }
+
+    /** not partial order */
+    def !⊑(that: Effect)(using AbsState): Boolean = !(this ⊑ that)
+
+    /** join operator */
+    def ⊔(that: Effect)(using AbsState): Effect =
+      Effect(
+        (for {
+          k <- this.map.keySet ++ that.map.keySet
+        } yield k -> (this.map.getOrElse(k, Set.empty) ++ that.map
+          .getOrElse(k, Set.empty))).toMap,
+      )
+
+    /** meet operator */
+    def ⊓(that: Effect)(using AbsState): Effect =
+      Effect(
+        (for {
+          k <- this.map.keySet intersect that.map.keySet
+        } yield k -> (this.map.getOrElse(k, Set.empty) intersect that.map
+          .getOrElse(k, Set.empty))).toMap,
+      )
+
+    def fieldUpdate(fld: String, value: AbsValue)(using AbsState): Effect =
+      Effect({
+        value.ty.record.bases match
+          case Inf => Map()
+          case Fin(set) =>
+            val baseTys = set.map(ManualInfo.tyModel.baseOf(_))
+            baseTys.map { baseTy => baseTy -> Set(fld) }.toMap
+      }) ⊔ this
+
+    def +(baseTy: String, field: Set[String]) = Effect(map + (baseTy -> field))
+
+    def nonEmpty: Boolean = map.nonEmpty
+
+    private def apply(rec: RecordTy): RecordTy = rec match
+      case RecordTy.Top => rec // unsound here
+      case RecordTy.Elem(rmap) => {
+        RecordTy(rmap.map((nty, fm) => {
+          val base = ManualInfo.tyModel.baseOf(nty)
+          val kfield = map.getOrElse(base, Set.empty)
+          nty -> fm.weaken(kfield)
+        }))
+      }
+    def apply(ty: ValueTy): ValueTy =
+      ty.copied(record = apply(ty.record))
+  }
+  object Effect extends DomainLike[Effect] {
+
+    /** top element */
+    lazy val Top: Effect = exploded("Top of an Effect")
+
+    /** bottom element */
+    lazy val Bot: Effect = Effect(Map.empty)
+
+    lazy val Empty: Effect = Effect()
+
+    /** appender */
+    private given Rule[Set[String]] = iterableRule("(", ", ", ")")
+    private given Rule[Map[String, Set[String]]] = sortedMapRule(sep = " -> ")
+    given rule: Rule[Effect] = (app, elem) => app >> elem.map
+  }
+}
+

--- a/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
@@ -31,17 +31,17 @@ trait SymTyDecl { self: TyChecker =>
       case SNormal(symty) => symty.isBottom
       case _              => false
 
-    def isSingle(using st: AbsState): Boolean = this.ty.getSingle match
+    def isSingle(using st: AbsState): Boolean = this.upper.getSingle match
       case One(_) => true
       case _      => false
 
     /* Evaluation of the Symbolic type */
-    def ty(using st: AbsState): ValueTy = this match
+    def upper(using st: AbsState): ValueTy = this match
       case STy(ty)             => ty
       case SVar(x)             => st.get(x).ty
       case SSym(sym)           => st.get(sym)
-      case SField(base, field) => st.get(base.ty, field.ty)
-      case SNormal(symty)      => NormalT(symty.ty)
+      case SField(base, field) => st.get(base.upper, field.upper)
+      case SNormal(symty)      => NormalT(symty.upper)
 
     def has(base: Base): Boolean = this match
       case STy(ty)        => false
@@ -87,7 +87,7 @@ trait SymTyDecl { self: TyChecker =>
     def ⊑(that: SymTy)(lst: AbsState, rst: AbsState): Boolean =
       (this, that) match
         case (STy(lty), STy(rty))           => lty ⊑ rty
-        case (l, STy(rty))                  => l.ty(using lst) ⊑ rty
+        case (l, STy(rty))                  => l.upper(using lst) ⊑ rty
         case (l, r) if l.isBottom || l == r => true
         case _                              => false
 
@@ -103,7 +103,7 @@ trait SymTyDecl { self: TyChecker =>
       (this, that) match
         case (l, r) if l.isBottom || l == r => r
         case (l, r) if r.isBottom           => l
-        case (l, r) => STy(l.ty(using lst) || r.ty(using rst))
+        case (l, r) => STy(l.upper(using lst) || r.upper(using rst))
 
     /** meet operator in same state */
     def ⊓(that: SymTy)(using st: AbsState): SymTy =
@@ -114,7 +114,7 @@ trait SymTyDecl { self: TyChecker =>
       (this, that) match
         case (l, r) if l.isBottom || r.isBottom => SymTy.Bot
         case (l, r) if l == r                   => l
-        case (l, r) => STy(l.ty(using lst) && r.ty(using rst))
+        case (l, r) => STy(l.upper(using lst) && r.upper(using rst))
 
     /** prune operator in same state */
     def --(that: SymTy)(using st: AbsState): SymTy =
@@ -124,7 +124,11 @@ trait SymTyDecl { self: TyChecker =>
     def --(that: SymTy)(lst: AbsState, rst: AbsState): SymTy =
       (this, that) match
         case (l, r) if r.isBottom => l
-        case (l, r)               => STy(l.ty(using lst) -- r.ty(using rst))
+        case (l, r)               => STy(l.upper(using lst) -- r.upper(using rst))
+
+    def refine(ty: ValueTy)(using st: AbsState): SymTy =
+      if (this ⊑ STy(ty)) this
+      else STy(this.upper ⊓ ty)
 
     def getString = s"${this}"
   }

--- a/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
@@ -124,7 +124,7 @@ trait SymTyDecl { self: TyChecker =>
     def --(that: SymTy)(lst: AbsState, rst: AbsState): SymTy =
       (this, that) match
         case (l, r) if r.isBottom => l
-        case (l, r)               => STy(l.upper(using lst) -- r.upper(using rst))
+        case (l, r) => STy(l.upper(using lst) -- r.upper(using rst))
 
     def refine(ty: ValueTy)(using st: AbsState): SymTy =
       if (this ⊑ STy(ty)) this

--- a/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
@@ -57,12 +57,12 @@ trait SymTyDecl { self: TyChecker =>
       case SField(base, field) => base.bases ++ field.bases
       case SNormal(symty)      => symty.bases
 
-    def kill(bases: Set[Base], update: Boolean): Option[SymTy] = this match
-      case t: SymRef      => killRef(t, bases, update)
+    def weaken(bases: Set[Base], update: Boolean): Option[SymTy] = this match
+      case t: SymRef      => weakenRef(t, bases, update)
       case STy(ty)        => Some(STy(ty))
-      case SNormal(symty) => symty.kill(bases, update).map(SNormal(_))
+      case SNormal(symty) => symty.weaken(bases, update).map(SNormal(_))
 
-    def killRef(
+    def weakenRef(
       ref: SymRef,
       bases: Set[Base],
       update: Boolean,
@@ -71,8 +71,8 @@ trait SymTyDecl { self: TyChecker =>
       case SSym(sym) => if (bases contains sym) None else Some(SSym(sym))
       case SField(b, f) =>
         for {
-          b <- killRef(b, bases, update)
-          f <- f.kill(bases, update)
+          b <- weakenRef(b, bases, update)
+          f <- f.weaken(bases, update)
         } yield SField(b, f)
 
     def isSymbolic: Boolean = this match

--- a/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/SymTy.scala
@@ -62,6 +62,17 @@ trait SymTyDecl { self: TyChecker =>
       case STy(ty)        => Some(STy(ty))
       case SNormal(symty) => symty.weaken(bases, update).map(SNormal(_))
 
+    def weaken(effect: Effect)(using st: AbsState): SymTy =
+      this match
+        case STy(ty)   => STy(effect(ty))
+        case SVar(x)   => SVar(x) // killed by abstract environment
+        case SSym(sym) => SSym(sym) // killed by symbolic environment
+        case SField(b, f) => // maybe unsound
+          val weakenedb = b.weaken(effect)
+          val weakenedf = f.weaken(effect)
+          SField(weakenedb.asInstanceOf[SymRef], weakenedf)
+        case SNormal(symty) => SNormal(symty.weaken(effect)) // sound by spec
+
     def weakenRef(
       ref: SymRef,
       bases: Set[Base],

--- a/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
@@ -383,7 +383,7 @@ class TyChecker(
       if value.hasTypeGuard(entrySt)
       guard = TypeGuard(for {
         (dty, pred) <- value.guard.map
-        newPred = TypeConstr(for {
+        newPred = TypeProp(for {
           pair <- pred.map
           (x, (ty, prov)) = pair
           if !(entrySt.getTy(x) <= ty)
@@ -433,8 +433,8 @@ class TyChecker(
         if (useSyntacticKill) (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
         else (x -> AbsValue(SSym(sym)), sym -> value.ty)
       }).unzip
-      AbsState(true, newLocals.toMap, symEnv.toMap, TypeConstr())
-    } else AbsState(true, locals.toMap, Map(), TypeConstr())
+      AbsState(true, newLocals.toMap, symEnv.toMap, TypeProp())
+    } else AbsState(true, locals.toMap, Map(), TypeProp())
 
   /** get initial abstract states in each node point */
   private def getInitNpMap(

--- a/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
@@ -430,7 +430,8 @@ class TyChecker(
       val (newLocals, symEnv) = (for {
         ((x, value), sym) <- idxLocals
       } yield {
-        if (useSyntacticweaken) (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
+        if (useSyntacticweaken)
+          (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
         else (x -> AbsValue(SSym(sym)), sym -> value.ty)
       }).unzip
       AbsState(true, newLocals.toMap, symEnv.toMap, TypeProp())

--- a/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
@@ -18,7 +18,7 @@ class TyChecker(
   val inferTypeGuard: Boolean = true,
   val useBooleanGuard: Boolean = false,
   val useProvenance: Boolean = false,
-  val useSyntacticKill: Boolean = false,
+  val useSyntacticweaken: Boolean = false,
   val noRefine: Boolean = false,
   val typeSens: Boolean = false,
   val config: TyChecker.Config = TyChecker.Config(),
@@ -107,7 +107,7 @@ class TyChecker(
             "typeSens" -> typeSens,
             "inferTypeGuard" -> inferTypeGuard,
             "useProvenance" -> useProvenance,
-            "useSyntacticKill" -> useSyntacticKill,
+            "useSyntacticweaken" -> useSyntacticweaken,
           ),
           "duration" -> f"${time}%,d ms",
           "error" -> errors.size,
@@ -307,7 +307,7 @@ class TyChecker(
             silent = silent,
           )
         }
-        if (useSyntacticKill) {
+        if (useSyntacticweaken) {
           dumpFile(
             name = "mutated locals",
             data = cfg.funcs
@@ -430,7 +430,7 @@ class TyChecker(
       val (newLocals, symEnv) = (for {
         ((x, value), sym) <- idxLocals
       } yield {
-        if (useSyntacticKill) (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
+        if (useSyntacticweaken) (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
         else (x -> AbsValue(SSym(sym)), sym -> value.ty)
       }).unzip
       AbsState(true, newLocals.toMap, symEnv.toMap, TypeProp())

--- a/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
@@ -35,7 +35,8 @@ class TyChecker(
   with AbsRetDecl
   with AbsTransferDecl
   with TypeGuardDecl
-  with ViewDecl {
+  with ViewDecl
+  with EffectDecl {
 
   val tyStringifier = TyElem.getStringifier(false, false)
   import tyStringifier.given
@@ -379,7 +380,7 @@ class TyChecker(
     for {
       func <- cfg.funcs
       entrySt = getResult(NodePoint(func, func.entry, emptyView))
-      AbsRet(value) = getResult(ReturnPoint(func, emptyView))
+      AbsRet(value, _) = getResult(ReturnPoint(func, emptyView))
       if value.hasTypeGuard(entrySt)
       guard = TypeGuard(for {
         (dty, pred) <- value.guard.map
@@ -434,8 +435,8 @@ class TyChecker(
           (x -> AbsValue(STy(value.ty)), sym -> ValueTy.Bot)
         else (x -> AbsValue(SSym(sym)), sym -> value.ty)
       }).unzip
-      AbsState(true, newLocals.toMap, symEnv.toMap, TypeProp())
-    } else AbsState(true, locals.toMap, Map(), TypeProp())
+      AbsState(true, newLocals.toMap, symEnv.toMap, TypeProp(), Effect())
+    } else AbsState(true, locals.toMap, Map(), TypeProp(), Effect())
 
   /** get initial abstract states in each node point */
   private def getInitNpMap(

--- a/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TyChecker.scala
@@ -19,6 +19,7 @@ class TyChecker(
   val useBooleanGuard: Boolean = false,
   val useProvenance: Boolean = false,
   val useSyntacticweaken: Boolean = false,
+  val useEffect: Boolean = false,
   val noRefine: Boolean = false,
   val typeSens: Boolean = false,
   val config: TyChecker.Config = TyChecker.Config(),

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -84,10 +84,10 @@ trait TypeGuardDecl { self: TyChecker =>
       if newProp.nonTop
     } yield dty -> newProp)
 
-    def lift(ty: ValueTy = ValueTy.Top)(using st: AbsState): TypeGuard =
+    def bind(ty: ValueTy = ValueTy.Top)(using st: AbsState): TypeGuard =
       this && TypeGuard((for {
         kind <- DemandType.from(ty).toList
-        prop = TypeProp().lift
+        prop = TypeProp().bind
         if prop.nonTop
       } yield kind -> prop).toMap)
 
@@ -286,7 +286,7 @@ trait TypeGuardDecl { self: TyChecker =>
       )).maxOption
         .getOrElse(0)
 
-    def lift(using st: AbsState): TypeProp =
+    def bind(using st: AbsState): TypeProp =
       this && st.prop
 
     override def toString: String = (new Appender >> this).toString

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -78,6 +78,12 @@ trait TypeGuardDecl { self: TyChecker =>
       if newProp.nonTop
     } yield dty -> newProp)
 
+    def weaken(effect: Effect): TypeGuard = TypeGuard(for {
+      (dty, prop) <- map
+      newProp = prop.weaken(effect)
+      if newProp.nonTop
+    } yield dty -> newProp)
+
     def forReturn(symEnv: Map[Sym, ValueTy]): TypeGuard = TypeGuard(for {
       (dty, prop) <- map
       newProp = prop.forReturn(symEnv)
@@ -255,6 +261,14 @@ trait TypeGuardDecl { self: TyChecker =>
         localEnv = localEnv.filter { case (x, _) => !bases.contains(x) },
         symEnv = symEnv.filter { case (x, _) => !bases.contains(x) },
         sexpr = sexpr.fold(None)(_.weaken(bases)),
+      )
+
+    def weaken(effect: Effect): TypeProp =
+      TypeProp(
+        localEnv = localEnv.map {
+          case (x, (ty, prov)) => x -> (effect(ty), prov)
+        },
+        symEnv = symEnv.map { case (x, (ty, prov)) => x -> (effect(ty), prov) },
       )
 
     def forReturn(symEnv: Map[Sym, ValueTy]): TypeProp = TypeProp(

--- a/src/main/scala/esmeta/phase/TyCheck.scala
+++ b/src/main/scala/esmeta/phase/TyCheck.scala
@@ -24,6 +24,7 @@ case object TyCheck extends Phase[CFG, Unit] {
       targetPattern = config.target,
       inferTypeGuard = config.inferTypeGuard,
       typeSens = config.typeSens,
+      useEffect = config.effect,
       config = TyChecker.Config(),
       ignore = config.ignorePath.fold(Ignore())(Ignore.apply),
       log = config.log,
@@ -84,6 +85,11 @@ case object TyCheck extends Phase[CFG, Unit] {
       BoolOption(_.inferTypeGuard = _),
       "automatic inference of type guards (default: true).",
     ),
+    (
+      "effect",
+      BoolOption(_.effect = _),
+      "enable effect system (default: false).",
+    ),
   )
   case class Config(
     var target: Option[String] = None,
@@ -95,5 +101,6 @@ case object TyCheck extends Phase[CFG, Unit] {
     var detail: Boolean = false,
     var typeSens: Boolean = false,
     var inferTypeGuard: Boolean = true,
+    var effect: Boolean = false,
   )
 }

--- a/src/main/scala/esmeta/ty/FieldMap.scala
+++ b/src/main/scala/esmeta/ty/FieldMap.scala
@@ -60,6 +60,10 @@ case class FieldMap(map: Map[String, Binding])
     val (field, binding) = pair
     FieldMap(map + (field -> binding))
 
+  /** field weaken */
+  def weaken(fields: Set[String]): FieldMap =
+    FieldMap(map.filterNot { case (f, _) => fields.contains(f) })
+
   /** fields */
   def fields: Set[String] = map.keySet
 


### PR DESCRIPTION
This PR introduces a refactored implementation of the occurrence typing method and effect system.
This includes renaming, restructuring the symbolic types, and refactoring type guard operators. 

The analysis time slightly increased (6.42s -> 8.01s), but it is still reasonable (imo).
With the effect system, it is guaranteed to be sound, but it is significantly heavier (15.38s). 
The effect system is off by default, and can be turned on by the `-tycheck:effect=true` option. 

Note that this PR makes six more type guards (145 -> 151). I'm not sure why the old implementation couldn't find those guards, but it seems the new guards are correct when manually inspected.

