### PR TITLE
recent <- CodePsy-2001:recent

### DIFF
--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -1,18 +1,18 @@
-- version: 84b38ad852ff426795fa29cebc06949027336c64 (es2025)
+- version: 0248456c758431e4bb8e5d26333ff1865123c9cd (es2026)
 - grammar:
   - productions: 378
     - lexical: 164
     - numeric string: 16
     - syntactic: 198
   - extended productions for web: 29
-- algorithms: 2867
-  - complete: 2500 (87.20%)
-  - equals: 2659 (92.75%)
-- algorithm steps: 22043
-  - complete: 21325 (96.74%)
-- types: 8260
-  - known: 7395 (89.53%)
-  - yet: 191 (2.31%)
-- tables: 99
+- algorithms: 2909
+  - complete: 2511 (86.32%)
+  - equals: 2701 (92.85%)
+- algorithm steps: 22850
+  - complete: 22087 (96.66%)
+- types: 8381
+  - known: 7590 (90.56%)
+  - yet: 104 (1.24%)
+- tables: 95
 - type model: 112
 - intrinsics: 101

--- a/src/main/scala/esmeta/Command.scala
+++ b/src/main/scala/esmeta/Command.scala
@@ -75,7 +75,7 @@ case object CmdExtract extends Command("extract", CmdBase >> Extract) {
   val help = "extracts specification model from ECMA-262 (spec.html)."
   val examples = List(
     "esmeta extract                           # extract current version.",
-    "esmeta extract -extract:target=es2025    # extract es2025 version.",
+    "esmeta extract -extract:target=es2026    # extract es2026 version.",
     "esmeta extract -extract:target=868fe7a   # extract 868fe7a hash version.",
   )
 }
@@ -85,7 +85,7 @@ case object CmdCompile extends Command("compile", CmdExtract >> Compile) {
   val help = "compiles a specification to an IR program."
   val examples = List(
     "esmeta compile                        # compile spec to IR program.",
-    "esmeta compile -extract:target=es2025 # compile es2025 spec to IR program",
+    "esmeta compile -extract:target=es2026 # compile es2026 spec to IR program",
   )
 }
 
@@ -94,7 +94,7 @@ case object CmdBuildCFG extends Command("build-cfg", CmdCompile >> BuildCFG) {
   val help = "builds a control-flow graph (CFG) from an IR program."
   val examples = List(
     "esmeta build-cfg                          # build CFG for spec.",
-    "esmeta build-cfg -extract:target=es2025   # build CFG for es2025 spec.",
+    "esmeta build-cfg -extract:target=es2026   # build CFG for es2026 spec.",
   )
 }
 
@@ -107,7 +107,7 @@ case object CmdTyCheck extends Command("tycheck", CmdBuildCFG >> TyCheck) {
   val examples = List(
     "esmeta tycheck                              # type check for spec.",
     "esmeta tycheck -tycheck:target='.*ToString' # type check with targets",
-    "esmeta tycheck -extract:target=es2025       # type check for es2025 spec.",
+    "esmeta tycheck -extract:target=es2026       # type check for es2026 spec.",
   )
 }
 
@@ -119,7 +119,7 @@ case object CmdParse extends Command("parse", CmdExtract >> Parse) {
   val help = "parses an ECMAScript file."
   val examples = List(
     "esmeta parse a.js                         # parse a.js file.",
-    "esmeta parse a.js -extract:target=es2025  # parse with es2025 spec.",
+    "esmeta parse a.js -extract:target=es2026  # parse with es2026 spec.",
     "esmeta parse a.js -parse:debug            # parse in the debugging mode.",
   )
   override val targetName = "<js>+"
@@ -130,7 +130,7 @@ case object CmdEval extends Command("eval", CmdBuildCFG >> Eval) {
   val help = "evaluates an ECMAScript file."
   val examples = List(
     "esmeta eval a.js                         # eval a.js file.",
-    "esmeta eval a.js -extract:target=es2025  # eval with es2025 spec.",
+    "esmeta eval a.js -extract:target=es2026  # eval with es2026 spec.",
     "esmeta eval a.js -eval:log               # eval in the logging mode.",
   )
   override val targetName = "<js>+"
@@ -219,7 +219,7 @@ case object CmdDumpVisualizer
 case object CmdYetCheck extends Command("yet-check", CmdBase >> YetCheck) {
   val help = "checks `yet-step` and `yet-type` in the specification."
   val examples = List(
-    "esmeta yet-check es2024 es2025  # check yet-steps/types between versions.",
+    "esmeta yet-check es2025 es2026  # check yet-steps/types between versions.",
   )
   override def showResult(res: (Int, Int)): Unit = {
     val (yetSteps, yetTypes) = res

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1296,10 +1296,7 @@ trait Parsers extends IndentParsers {
   }.named("lang.Type (single)")
 
   // types
-  lazy val langTy: P[Ty] =
-    ("either" ~> multi(valueTy, either = false)) |
-    multi(valueTy, either = false) |
-    specialTy
+  lazy val langTy: P[Ty] = multi(valueTy, either = false) | specialTy
   lazy val singleLangTy: P[Ty] = singleValueTy | specialTy
 
   // unknown types

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1310,7 +1310,6 @@ trait Parsers extends IndentParsers {
   lazy val singleValueTy: P[ValueTy] = singleCompTy | singlePureValueTy
 
   // completion record types
-  lazy val compTy: P[ValueTy] = multi(singleCompTy)
   lazy val singleCompTy: P[ValueTy] =
     "a Completion Record" ^^^ CompT |
     "a normal completion containing" ~> pureValueTy ^^ { NormalT(_) } |
@@ -1532,8 +1531,6 @@ trait Parsers extends IndentParsers {
     b ~ p ^^ { case b ~ p => new ~(b, List(p)) }
   private def isEither[T](p: Parser[T]): Parser[Boolean ~ List[T]] =
     either(isNeg, p)
-  private def hasEither[T](p: Parser[T]): Parser[Boolean ~ List[T]] =
-    either(hasNeg, p)
   private def isNeg: Parser[Boolean] =
     "is not" ^^^ true | "is" ^^^ false
   private def areNeg: Parser[Boolean] =
@@ -1552,9 +1549,6 @@ trait Parsers extends IndentParsers {
   // helper for creating expressions, conditions
   private def getRefExpr(r: Reference): Expression = ReferenceExpression(r)
   private def getExprCond(e: Expression): Condition = ExpressionCondition(e)
-
-  // literal for mathematical one
-  private val one = DecimalMathValueLiteral(1)
 
   // article
   private val indefArticle = "an " | "a "

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -32,7 +32,8 @@ trait Parsers extends IndentParsers {
   // user-defined directives
   lazy val directive: Parser[Directive] =
     lazy val name = "[-a-zA-Z0-9]+".r
-    ("[" ~> name <~ "=\"") ~ rep1sep(name, ",") <~ "\"]" ^^ {
+    ("[" ~> name <~ "=\"") ~ rep1sep(name, ",") <~ "\"" <~
+    opt(", normative-optional") <~ "]" ^^ {
       case x ~ vs => Directive(x, vs)
     }
 

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1296,7 +1296,10 @@ trait Parsers extends IndentParsers {
   }.named("lang.Type (single)")
 
   // types
-  lazy val langTy: P[Ty] = multi(valueTy, either = false) | specialTy
+  lazy val langTy: P[Ty] =
+    ("either" ~> multi(valueTy, either = false)) |
+    multi(valueTy, either = false) |
+    specialTy
   lazy val singleLangTy: P[Ty] = singleValueTy | specialTy
 
   // unknown types
@@ -1312,6 +1315,8 @@ trait Parsers extends IndentParsers {
   // completion record types
   lazy val singleCompTy: P[ValueTy] =
     "a Completion Record" ^^^ CompT |
+    "a normal completion containing one of ~suspended-start~, ~suspended-yield~, or ~completed~" ^^^
+    NormalT(EnumT("suspended-start", "suspended-yield", "completed")) |
     "a normal completion containing" ~> pureValueTy ^^ { NormalT(_) } |
     "a normal completion" ^^^ NormalT |
     "a throw completion" ^^^ AbruptT("throw") |
@@ -1360,7 +1365,7 @@ trait Parsers extends IndentParsers {
 
   // AST types
   lazy val astTy: P[ValueTy] =
-    val singleAstTy = opt(article) ~> nt <~ opt("Parse Node")
+    val singleAstTy = opt(article) ~> nt <~ opt("Parse Node" ~ opt("s"))
     opt(article) ~ "Parse Node" ~ opt("s") ^^^ AstT |
     rep1sep(singleAstTy, sep("or")) ^^ { ss => AstT(ss.toSet) }
 
@@ -1369,6 +1374,38 @@ trait Parsers extends IndentParsers {
 
   // simple types
   lazy val simpleTy: P[ValueTy] = opt(indefArticle) ~> {
+    "anything" ^^^ AnyT |
+    "<emu-not-ref>Unicode property name</emu-not-ref>" ^^^ StrT |
+    """\*"[^"]*"\*""".r ^^ { s => StrT(s.drop(2).dropRight(2)) } |
+    "`[^`]+`".r ^^ { s => StrT(s.drop(1).dropRight(1)) } |
+    "finite time value" ^^^ NumberT |
+    "time value" ^^^ NumberT |
+    "TypedArray element type" ^^^ EnumT(
+      "int8",
+      "uint8",
+      "uint8clamped",
+      "int16",
+      "uint16",
+      "int32",
+      "uint32",
+      "bigint64",
+      "biguint64",
+      "float32",
+      "float64",
+    ) |
+    "Unicode code point" ^^^ NonNegIntT |
+    "code point" ^^^ NonNegIntT |
+    "code unit" ^^^ CodeUnitT |
+    "character" ^^^ StrT |
+    "sequence of characters" ^^^ StrT |
+    "sequence of Unicode code points" ^^^ StrT |
+    "source text" ^^^ StrT |
+    "candidate execution" ^^^ RecordT("CandidateExecutionRecord") |
+    "read-modify-write modification function" ^^^ CloT |
+    "mathematical value" ^^^ MathT |
+    "Unicode property value" ^^^ StrT |
+    "nonterminal in one of the ECMAScript grammars" ^^^ AstT |
+    "Number, but not *NaN*" ^^^ (NumberT -- NaNT) |
     "Number" ^^^ NumberT |
     "BigInt" ^^^ BigIntT |
     "Boolean" ^^^ BoolT |
@@ -1379,20 +1416,6 @@ trait Parsers extends IndentParsers {
     "*true*" ^^^ TrueT |
     "integer" ^^^ IntT |
     "non-negative integer" ^^^ NonNegIntT |
-    // TODO See https://tc39.es/ecma262/2024/#sec-typedarray-objects
-    // "TypedArray element type" ^^^ EnumT(
-    //   "int8",
-    //   "uint8",
-    //   "uint8clamped",
-    //   "int16",
-    //   "uint16",
-    //   "int32",
-    //   "uint32",
-    //   "bigint64",
-    //   "biguint64",
-    //   "float32",
-    //   "float64",
-    // ) |
     "negative integer" ^^^ NegIntT |
     "non-positive integer" ^^^ NonPosIntT |
     "positive integer" ^^^ PosIntT |
@@ -1403,8 +1426,11 @@ trait Parsers extends IndentParsers {
     decimal ^^ { MathT(_) } |
     "+∞" ^^^ PosInfinityT |
     "-∞" ^^^ NegInfinityT |
+    "ECMAScript source text" ^^^ StrT |
     "ECMAScript language value" ^^^ ESValueT |
     "internal slot name" ^^^ StrT |
+    "nonterminal" ^^^ AstT |
+    "For-In Iterator" ^^^ RecordT("ForInIterator") |
     "Array" ^^^ ArrayT |
     "TypedArray" ^^^ TypedArrayT |
     opt("initialized") ~ "RegExp" ~ opt("instance") ^^^ RegExpT |
@@ -1412,6 +1438,7 @@ trait Parsers extends IndentParsers {
     "*NaN*" ^^! NaNT |
     "integral Number" ^^^ NumberIntT |
     "property key" ^^^ (StrT || SymbolT) |
+    "property name" ^^^ StrT |
     "~" ~> "[-+a-zA-Z0-9]+".r <~ "~" ^^ { EnumT(_) }
   } <~ opt("s")
 

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1173,6 +1173,7 @@ trait Parsers extends IndentParsers {
   } | {
     // InitializeHostDefinedRealm
     "the host requires use of an exotic object to serve as _realm_'s global object" |
+    "the host requires use of a specific object to serve as _realm_'s global object" |
     "the host requires that the `this` binding in _realm_'s global scope return an object other than the global object"
   } ^^! getExprCond(
     FalseLiteral(),

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1178,6 +1178,11 @@ trait Parsers extends IndentParsers {
   } ^^! getExprCond(
     FalseLiteral(),
   ) | {
+    // normative optional clauses for web hosts
+    "the host is a web browser or otherwise supports" ~> xrefId
+  } ^^! getExprCond(
+    FalseLiteral(),
+  ) | {
     // PropertyDefinitionEvaluation
     // NOTE if JSON.parse is supported, then the next line should be handled properly
     "this |PropertyDefinition| is contained within a |Script| that is being evaluated for ParseJSON (see step <emu-xref href=\"#step-json-parse-eval\"></emu-xref> of ParseJSON)"

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1384,23 +1384,9 @@ trait Parsers extends IndentParsers {
     "`[^`]+`".r ^^ { s => StrT(s.drop(1).dropRight(1)) } |
     "finite time value" ^^^ NumberT |
     "time value" ^^^ NumberT |
-    "TypedArray element type" ^^^ EnumT(
-      "int8",
-      "uint8",
-      "uint8clamped",
-      "int16",
-      "uint16",
-      "int32",
-      "uint32",
-      "bigint64",
-      "biguint64",
-      "float32",
-      "float64",
-    ) |
     "Unicode code point" ^^^ NonNegIntT |
     "code point" ^^^ NonNegIntT |
     "code unit" ^^^ CodeUnitT |
-    "character" ^^^ StrT |
     "sequence of characters" ^^^ StrT |
     "sequence of Unicode code points" ^^^ StrT |
     "source text" ^^^ StrT |
@@ -1408,7 +1394,6 @@ trait Parsers extends IndentParsers {
     "read-modify-write modification function" ^^^ CloT |
     "mathematical value" ^^^ MathT |
     "Unicode property value" ^^^ StrT |
-    "nonterminal in one of the ECMAScript grammars" ^^^ AstT |
     "Number, but not *NaN*" ^^^ (NumberT -- NaNT) |
     "Number" ^^^ NumberT |
     "BigInt" ^^^ BigIntT |
@@ -1420,6 +1405,20 @@ trait Parsers extends IndentParsers {
     "*true*" ^^^ TrueT |
     "integer" ^^^ IntT |
     "non-negative integer" ^^^ NonNegIntT |
+    // TODO See https://tc39.es/ecma262/2024/#sec-typedarray-objects
+    // "TypedArray element type" ^^^ EnumT(
+    //   "int8",
+    //   "uint8",
+    //   "uint8clamped",
+    //   "int16",
+    //   "uint16",
+    //   "int32",
+    //   "uint32",
+    //   "bigint64",
+    //   "biguint64",
+    //   "float32",
+    //   "float64",
+    // ) |
     "negative integer" ^^^ NegIntT |
     "non-positive integer" ^^^ NonPosIntT |
     "positive integer" ^^^ PosIntT |
@@ -1433,7 +1432,6 @@ trait Parsers extends IndentParsers {
     "ECMAScript source text" ^^^ StrT |
     "ECMAScript language value" ^^^ ESValueT |
     "internal slot name" ^^^ StrT |
-    "nonterminal" ^^^ AstT |
     "For-In Iterator" ^^^ RecordT("ForInIterator") |
     "Array" ^^^ ArrayT |
     "TypedArray" ^^^ TypedArrayT |

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -1047,6 +1047,10 @@ class Stringifier(detail: Boolean, location: Boolean) {
     if (!ty.grammarSymbol.isBottom)
       tys :+= "grammar symbol".withArticle(article)
 
+    // code units
+    if (ty.codeUnit)
+      tys :+= "code unit".withArticle(article)
+
     // lists
     ty.list match
       case ListTy.Top => tys :+= "a List"
@@ -1072,6 +1076,8 @@ class Stringifier(detail: Boolean, location: Boolean) {
     // numbers
     if (ty.number == NumberTy.Int)
       tys :+= "integral Number".withArticle(article)
+    else if (ty.number == (NumberTy.Top -- NumberTy.NaN))
+      tys :+= "Number, but not *NaN*".withArticle(article)
     else if (ty.number == NumberTy.NaN)
       tys :+= "NaN".withArticle(article)
     else if (!ty.number.isBottom) tys :+= "Number".withArticle(article)

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -471,25 +471,6 @@ class StringifyTinyTest extends LangTest {
       Type(FalseT) -> "*false*",
       Type(UndefT) -> "*undefined*",
       Type(NullT) -> "*null*",
-      Type(UnknownTy("any value except a Completion Record")) ->
-      "any value except a Completion Record",
-      Type(UnknownTy("a String of length 2")) -> "a String of length 2",
-      Type(UnknownTy("an ECMAScript language value, but not a Number")) ->
-      "an ECMAScript language value, but not a Number",
-      Type(UnknownTy("an Object that has a [[StringData]] internal slot")) ->
-      "an Object that has a [[StringData]] internal slot",
-      Type(
-        UnknownTy(
-          "a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values)",
-        ),
-      ) ->
-      "a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values)",
-      Type(
-        UnknownTy(
-          "an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification",
-        ),
-      ) ->
-      "an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification",
       Type(AstT) -> "a Parse Node",
       Type(AstT("Identifier")) -> "an |Identifier| Parse Node",
       Type(EnumT("unused")) -> "~unused~",

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -464,11 +464,32 @@ class StringifyTinyTest extends LangTest {
       Type(SymbolT) -> "a Symbol",
       Type(StrT) -> "a String",
       Type(ObjectT) -> "an Object",
+      Type(CodeUnitT) -> "a code unit",
       Type(ESValueT) -> "an ECMAScript language value",
+      Type(NumberT -- NaNT) -> "a Number, but not *NaN*",
       Type(TrueT) -> "*true*",
       Type(FalseT) -> "*false*",
       Type(UndefT) -> "*undefined*",
       Type(NullT) -> "*null*",
+      Type(UnknownTy("any value except a Completion Record")) ->
+      "any value except a Completion Record",
+      Type(UnknownTy("a String of length 2")) -> "a String of length 2",
+      Type(UnknownTy("an ECMAScript language value, but not a Number")) ->
+      "an ECMAScript language value, but not a Number",
+      Type(UnknownTy("an Object that has a [[StringData]] internal slot")) ->
+      "an Object that has a [[StringData]] internal slot",
+      Type(
+        UnknownTy(
+          "a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values)",
+        ),
+      ) ->
+      "a List of Records with fields [[Key]] (an ECMAScript language value) and [[Elements]] (a List of ECMAScript language values)",
+      Type(
+        UnknownTy(
+          "an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification",
+        ),
+      ) ->
+      "an Abstract Closure, a set of algorithm steps, or some other definition of a function's behaviour provided in this specification",
       Type(AstT) -> "a Parse Node",
       Type(AstT("Identifier")) -> "an |Identifier| Parse Node",
       Type(EnumT("unused")) -> "~unused~",


### PR DESCRIPTION
## Summary

- Added parsing support for ES2026 type prose.
  - `Number, but not *NaN*` → `NumberT -- NaNT`
  - `candidate execution` → `CandidateExecutionRecord`
  - `code unit` → `CodeUnitT`
  - `TypedArray element type` → TypedArray element enum
  - Added support for `ECMAScript source text`, `property name`, `For-In Iterator`, `Parse Nodes`, and related prose

- Added stringification for newly supported types.
  - `CodeUnitT` → `a code unit`
  - `NumberT -- NaNT` → `a Number, but not *NaN*`

- Kept unsupported prose as `UnknownTy(...)`.
  - `String of length 2`
  - `Object that has a [[StringData]] internal slot`
  - `ECMAScript language value, but not a Number`
  - `Records with fields ...`
  - broad `Abstract Closure ...`

- Added tests.
  - Parse/stringify round-trip tests for newly supported types
  - Checks that unsupported prose remains `UnknownTy`

- Verified with:
  - `sbt langStringifyTest langTypeTest extractorValidityTest formatCheck`

## Changes

- **chore: Update CLI examples to target `ES2026`**
- **refactor(parser): remove unused helpers**
- **feat(parser): parse ES2026 type prose**
