### PR TITLE
Fix template intrinsic names in visualizer dump

### DIFF
--- a/src/main/scala/esmeta/dump/visualizer/DumpSecIdToFuncInfo.scala
+++ b/src/main/scala/esmeta/dump/visualizer/DumpSecIdToFuncInfo.scala
@@ -4,6 +4,7 @@ import esmeta.*
 import esmeta.cfg.*
 import esmeta.error.ESMetaError
 import esmeta.ir.{Type as IRType, Func as IrFunc, *}
+import esmeta.util.HtmlUtils.*
 import esmeta.util.SystemUtils.*
 import io.circe.*, io.circe.syntax.*
 import scala.collection.mutable.{ListBuffer, Map as MMap, Set as MSet}
@@ -25,6 +26,11 @@ object DumpSecIdToFuncInfo {
         if (func.isSDO && func.sdoInfo.isDefined)
           s"$sectionId|${extractSDO(func.sdoInfo.get, cfg)}"
         else sectionId
+      val visualName = algo.headElem.getText match
+        case templatePattern(name)
+            if cfg.intrinsics.templateMap.contains(name) =>
+          s"_${name}_"
+        case _ => convertFuncName(func)
 
       val prev = secIdToFuncInfo.get(secId)
       val curr = prev
@@ -32,10 +38,10 @@ object DumpSecIdToFuncInfo {
           case (prevId, prevName, fallbackIds) =>
             if (func.isClo || func.isCont) then
               (prevId, prevName, fallbackIds :+ func.id)
-            else (func.id, convertFuncName(func), fallbackIds :+ prevId)
+            else (func.id, visualName, fallbackIds :+ prevId)
         }
         .getOrElse(
-          (func.id, convertFuncName(func), Nil),
+          (func.id, visualName, Nil),
         )
 
       secIdToFuncInfo += (secId -> curr)
@@ -70,6 +76,8 @@ object DumpSecIdToFuncInfo {
           }
           buffer.mkString(" ")
     } else func.name
+
+  private val templatePattern = "_(\\w+)_.*".r
 
   def parseMethodName(func: Func): String =
     JsonParser.parseAll(JsonParser.methodName, func.name) match {

--- a/src/test/scala/esmeta/dump/visualizer/DumpSecIdToFuncInfoSmallTest.scala
+++ b/src/test/scala/esmeta/dump/visualizer/DumpSecIdToFuncInfoSmallTest.scala
@@ -1,0 +1,43 @@
+package esmeta.dump.visualizer
+
+import esmeta.*
+import esmeta.cfg.*
+import esmeta.util.SystemUtils.*
+import io.circe.*
+
+/** visualizer section-to-function mapping test */
+class DumpSecIdToFuncInfoSmallTest extends ESMetaTest {
+  val name: String = "dumpSecIdToFuncInfoTest"
+  def category: String = "dump"
+
+  private lazy val cfg = ESMetaTest.cfg
+  private lazy val result =
+    DumpSecIdToFuncInfo(cfg)
+    readJson[Map[String, (Int, String, List[Int])]](
+      s"$DUMP_VISUALIZER_LOG_DIR/secIdToFunc.json",
+    )
+
+  private def candidateIds(info: (Int, String, List[Int])): List[Int] =
+    info._1 :: info._3
+
+  private def checkTemplate(
+    sectionId: String,
+    templateName: String,
+  ): Unit =
+    val info = result(sectionId)
+    val ids = candidateIds(info)
+    val names = ids.map(cfg.funcMap(_).name.stripPrefix("INTRINSICS.")).toSet
+    val expected = cfg.intrinsics.getInstances(templateName).keySet
+    assert(info._2 == s"_${templateName}_")
+    assert(names == expected)
+    assert(ids.size == expected.size)
+
+  // registration
+  def init: Unit =
+    check("preserve generic names and all template instances") {
+      checkTemplate("sec-nativeerror", "NativeError")
+      checkTemplate("sec-typedarray", "TypedArray")
+    }
+
+  init
+}

--- a/tests/result/dump/DumpSecIdToFuncInfoSmallTest
+++ b/tests/result/dump/DumpSecIdToFuncInfoSmallTest
@@ -1,0 +1,1 @@
+dump.DumpSecIdToFuncInfoSmallTest: 1 / 1

--- a/tests/result/dump/DumpSecIdToFuncInfoSmallTest.json
+++ b/tests/result/dump/DumpSecIdToFuncInfoSmallTest.json
@@ -1,0 +1,3 @@
+{
+  "preserve generic names and all template instances" : true
+}


### PR DESCRIPTION
Fixes #336 

Template-based intrinsic expansion creates multiple concrete CFG functions that share a single specification section. `DumpSecIdToFuncInfo` previously used the name of the last processed concrete function as the section's display name.

As a result, the visualizer mapped the generic `_NativeError_` and `_TypedArray_` sections to the concrete names `SyntaxError` and `Int32Array`, respectively.

This PR:
- preserves the generic name when the algorithm heading corresponds to a registered intrinsic template
- adds a regression test covering `_NativeError_`, `_TypedArray_`, and all of their concrete template instances

With the updated visualizer dump, the CallStack displays `_NativeError_` instead of `SyntaxError`.

The existing function-ID mapping is left unchanged. Selecting or combining examples across the concrete CFG functions is a consumer-side concern and should be addressed separately in the visualizer client.
