### PR TITLE
Feat parse constants

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -10,5 +10,7 @@
   "GetViewByteLength",
   "INTRINSICS.Function.prototype.bind",
   "Record[SourceTextModuleRecord].ExecuteModule",
+  "TimeString",
+  "TimeZoneString",
   "TypedArrayLength"
 ]

--- a/src/main/resources/result/complete-funcs
+++ b/src/main/resources/result/complete-funcs
@@ -640,6 +640,7 @@ DEFAULT:AllPrivateIdentifiersValid
 DEFAULT:Contains
 DEFAULT:ContainsArguments
 DateFromTime
+Day
 DayFromYear
 DaysInYear
 DecimalBigIntegerLiteral[0,0].NumericValue
@@ -1164,6 +1165,7 @@ HostLoadImportedModule
 HostMakeJobCallback
 HostPromiseRejectionTracker
 HostResizeArrayBuffer
+HourFromTime
 INTRINSICS.AggregateError
 INTRINSICS.Array.from
 INTRINSICS.Array.fromAsync
@@ -1815,10 +1817,12 @@ MakeArgSetter:clo0
 MakeClassConstructor
 MakeConstructor
 MakeDataViewWithBufferWitnessRecord
+MakeDate
 MakeFullYear
 MakeMethod
 MakePrivateReference
 MakeSuperPropertyReference
+MakeTime
 MakeTypedArrayWithBufferWitnessRecord
 MemberExpression[0,0].IsDestructuring
 MemberExpression[1,0].AssignmentTargetType
@@ -1887,6 +1891,7 @@ MethodDefinition[5,0].MethodDefinitionEvaluation
 MethodDefinition[5,0].PrivateBoundIdentifiers
 MethodDefinition[5,0].PropName
 MethodDefinition[5,0].SpecialMethod
+MinFromTime
 ModuleBody[0,0].Evaluation
 ModuleExportName[0,0].ReferencedBindings
 ModuleExportName[1,0].ReferencedBindings
@@ -2322,6 +2327,7 @@ Script[0,0].ScriptIsStrict
 Script[0,0].VarDeclaredNames
 Script[0,0].VarScopedDeclarations
 Script[0,1].ScriptIsStrict
+SecFromTime
 SerializeJSONProperty
 Set
 SetDataHas
@@ -2517,6 +2523,7 @@ ThrowCompletion
 ThrowStatement[0,0].Evaluation
 TimeClip
 TimeString
+TimeWithinDay
 ToBigInt
 ToBigInt64
 ToBigUint64
@@ -2668,3 +2675,4 @@ __IS_ARRAY_INDEX__
 __NEW_ERROR_OBJ__
 __NEW_OBJ__
 __REMOVE_ELEM__
+msFromTime

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -6,13 +6,14 @@
     - syntactic: 205
   - extended productions for web: 29
 - algorithms: 2909
-  - complete: 2519 (86.59%)
-  - equals: 2693 (92.57%)
+  - complete: 2527 (86.87%)
+  - equals: 2692 (92.54%)
 - algorithm steps: 22857
-  - complete: 22101 (96.69%)
+  - complete: 22109 (96.73%)
 - types: 8381
   - known: 7486 (89.32%)
   - yet: 208 (2.48%)
+- constants: 7
 - tables: 95
 - type model: 113
 - intrinsics: 102

--- a/src/main/scala/esmeta/compiler/Compiler.scala
+++ b/src/main/scala/esmeta/compiler/Compiler.scala
@@ -855,6 +855,10 @@ class Compiler(
         case "π" => EGLOBAL_MATH_PI
         case _   => EYet(s"<mathematical constant: $name>")
       if (pre == 1) expr else EBinary(BOp.Mul, EMath(pre), expr)
+    case ConstantLiteral(name) =>
+      spec.constantMap.get(name) match
+        case Some(const) => compile(fb, const.value)
+        case None        => EYet(s"<constant: $name>")
     case NumberLiteral(n)       => ENumber(n)
     case BigIntLiteral(n)       => EBigInt(n)
     case TrueLiteral()          => EBool(true)

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -8,7 +8,7 @@ import esmeta.spec.{*, given}
 import esmeta.spec.util.{Parsers => SpecParsers}
 import esmeta.ty.TyModel
 import esmeta.util.ManualInfo
-import esmeta.util.BaseUtils.{raise, warn}
+import esmeta.util.BaseUtils.*
 import esmeta.util.HtmlUtils.*
 import esmeta.util.SystemUtils.*
 import org.jsoup.nodes.*
@@ -24,6 +24,16 @@ object Extractor:
 
   /** extracts a specification with a target version of ECMA-262 */
   def apply(targetOpt: Option[String] = None, eval: Boolean = false): Spec =
+    from(targetOpt, eval).result
+
+  /** extracts a specification with a target version of ECMA-262 */
+  def apply(target: String): Spec = apply(Some(target))
+
+  /** creates an extractor with a target version of ECMA-262 */
+  def from(
+    targetOpt: Option[String] = None,
+    eval: Boolean = false,
+  ): Extractor =
     val (version, document) = Spec.getVersionWith(targetOpt) {
       case version =>
         // if bugfix patch exists, apply it to spec.html
@@ -37,10 +47,7 @@ object Extractor:
         }
         document
     }
-    apply(document, Some(version), eval)
-
-  /** extracts a specification with a target version of ECMA-262 */
-  def apply(target: String): Spec = apply(Some(target))
+    new Extractor(document, Some(version), eval)
 
 /** extensible helper of specification extractor from ECMA-262 */
 class Extractor(
@@ -49,7 +56,8 @@ class Extractor(
   eval: Boolean = false,
 ) extends SpecParsers {
   lazy val parser: LangUtil.Parsers =
-    if (eval) LangUtil.ParserForEval else LangUtil.Parser
+    val parser = if (eval) LangUtil.ParserForEval else LangUtil.Parser
+    parser.withConstNames(constants.map(_.name).toSet)
 
   /** final result */
   lazy val result =
@@ -57,6 +65,7 @@ class Extractor(
       version = version,
       grammar = grammar,
       algorithms = algorithms,
+      constants = constants,
       tables = tables,
       tyModel = tyModel,
       intrinsics = intrinsics,
@@ -72,6 +81,9 @@ class Extractor(
 
   /** abstract algorithms in ECMA-262 */
   lazy val algorithms = extractAlgorithms
+
+  /** constants in ECMA-262 */
+  lazy val constants = extractConstants
 
   /** tables in ECMA-262 */
   lazy val tables = extractTables
@@ -187,6 +199,13 @@ class Extractor(
     }
     heads.map(_ -> parent)
   }
+
+  /** extracts constants defined by `emu-eqn` elements */
+  def extractConstants: List[Constant] = for {
+    elem <- document.getElems("emu-eqn[aoid]")
+    content = elem.html.unescapeHtml.split("\\s+").mkString(" ").trim
+    (name, value) <- optional(parseBy(constDef)(content))
+  } yield Constant(name, value)
 
   /** extracts tables */
   def extractTables: Map[String, Table] = (for {

--- a/src/main/scala/esmeta/lang/Expression.scala
+++ b/src/main/scala/esmeta/lang/Expression.scala
@@ -344,6 +344,9 @@ case class NumberLiteral(double: Double)
   with DoubleEquals
 case class BigIntLiteral(bigInt: BigInt) extends NumericLiteral
 
+/** references to constants defined by `emu-eqn` elements */
+case class ConstantLiteral(name: String) extends Literal
+
 // boolean literals
 sealed trait BooleanLiteral extends Literal
 case class TrueLiteral() extends BooleanLiteral

--- a/src/main/scala/esmeta/lang/util/CaseCollector.scala
+++ b/src/main/scala/esmeta/lang/util/CaseCollector.scala
@@ -290,6 +290,8 @@ class CaseCollector extends UnitWalker {
         s"{{ decimal }}"
       case MathConstantLiteral(pre, name) =>
         s"{{ const }}"
+      case ConstantLiteral(name) =>
+        s"{{ const }}"
       case NumberLiteral(n) =>
         s"{{ number }}"
       case BigIntLiteral(n) =>

--- a/src/main/scala/esmeta/lang/util/JsonProtocol.scala
+++ b/src/main/scala/esmeta/lang/util/JsonProtocol.scala
@@ -190,6 +190,8 @@ object JsonProtocol extends BasicJsonProtocol {
   given Encoder[ErrorObjectLiteral] = deriveEncoderWithType
   given Decoder[SymbolLiteral] = deriveDecoderWithType
   given Encoder[SymbolLiteral] = deriveEncoderWithType
+  given Decoder[NumericLiteral] = deriveDecoderWithType
+  given Encoder[NumericLiteral] = deriveEncoderWithType
   given Decoder[PositiveInfinityMathValueLiteral] = deriveDecoderWithType
   given Encoder[PositiveInfinityMathValueLiteral] = deriveEncoderWithType
   given Decoder[NegativeInfinityMathValueLiteral] = deriveDecoderWithType
@@ -202,6 +204,8 @@ object JsonProtocol extends BasicJsonProtocol {
   given Encoder[NumberLiteral] = deriveEncoderWithType
   given Decoder[BigIntLiteral] = deriveDecoderWithType
   given Encoder[BigIntLiteral] = deriveEncoderWithType
+  given Decoder[ConstantLiteral] = deriveDecoderWithType
+  given Encoder[ConstantLiteral] = deriveEncoderWithType
   given Decoder[TrueLiteral] = deriveDecoderWithType
   given Encoder[TrueLiteral] = deriveEncoderWithType
   given Decoder[FalseLiteral] = deriveDecoderWithType

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -14,6 +14,17 @@ trait Parsers extends IndentParsers {
   type P[T] = EPackratParser[T]
   type PL[T <: Locational] = LocationalParser[T]
 
+  /** names of constants defined by `emu-eqn` elements in ECMA-262 */
+  def constNames: Set[String] = Set()
+
+  /** the same parser but aware of the given names of constants */
+  def withConstNames(names: Set[String]): Parsers =
+    val forEval = eval
+    new Parsers {
+      override def constNames = names
+      override def eval = forEval
+    }
+
   // ---------------------------------------------------------------------------
   // metalanguage blocks
   // ---------------------------------------------------------------------------
@@ -610,6 +621,7 @@ trait Parsers extends IndentParsers {
     opt(int) ~ "π" ^^ {
       case p ~ n => MathConstantLiteral(p.getOrElse(1), n)
     } |
+    constLiteral |
     decimal ^^ { DecimalMathValueLiteral(_) } |
     "*+∞*<sub>𝔽</sub>" ^^! NumberLiteral(Double.PositiveInfinity) |
     "*-∞*<sub>𝔽</sub>" ^^! NumberLiteral(Double.NegativeInfinity) |
@@ -629,6 +641,12 @@ trait Parsers extends IndentParsers {
     "BigInt" ^^! BigIntTypeLiteral() |
     "Object" ^^! ObjectTypeLiteral()
   )
+
+  // constant literals (e.g., `msPerDay`)
+  lazy val constLiteral: PL[ConstantLiteral] =
+    word.filter(name => constNames.contains(name)) ^^ {
+      ConstantLiteral(_)
+    }
 
   // field literal
   lazy val fieldLiteral: PL[FieldLiteral] =

--- a/src/main/scala/esmeta/lang/util/Stringifier.scala
+++ b/src/main/scala/esmeta/lang/util/Stringifier.scala
@@ -595,6 +595,7 @@ class Stringifier(detail: Boolean, location: Boolean) {
       case MathConstantLiteral(pre, name) =>
         if (pre != 1) app >> pre
         app >> name
+      case ConstantLiteral(name) => app >> name
       case NumberLiteral(n) =>
         if (n.isNaN) app >> "*NaN*"
         else

--- a/src/main/scala/esmeta/phase/Extract.scala
+++ b/src/main/scala/esmeta/phase/Extract.scala
@@ -3,7 +3,6 @@ package esmeta.phase
 import esmeta.*
 import esmeta.extractor.Extractor
 import esmeta.lang.*
-import esmeta.lang.util.ParserForEval.{getParseCount, getCacheCount}
 import esmeta.spec.*
 import esmeta.util.*
 import esmeta.util.BaseUtils.*
@@ -22,12 +21,14 @@ case object Extract extends Phase[Unit, Spec] {
     cmdConfig: CommandConfig,
     config: Config,
   ): Spec = if (!config.repl) {
-    lazy val spec = Extractor(config.target, config.eval)
+    lazy val extractor = Extractor.from(config.target, config.eval)
+    lazy val spec = extractor.result
     if (config.strict && config.log) warnInvalidPath(config.allowedYets)
     if (config.eval)
       time("extracting specification", spec)
-      println(f"- # of actual parsing: $getParseCount%,d")
-      println(f"- # of using cached result: $getCacheCount%,d")
+      val parser = extractor.parser
+      println(f"- # of actual parsing: ${parser.getParseCount}%,d")
+      println(f"- # of using cached result: ${parser.getCacheCount}%,d")
     if (config.log) log(spec)
     if (config.strict) checkStrict(spec, config)
     spec
@@ -111,6 +112,12 @@ case object Extract extends Phase[Unit, Spec] {
     )
 
     dumpFile("grammar", spec.grammar, s"$EXTRACT_LOG_DIR/grammar")
+
+    dumpFile(
+      name = "constants",
+      data = spec.constants.mkString(LINE_SEP),
+      filename = s"$EXTRACT_LOG_DIR/constants",
+    )
 
     dumpDir(
       name = "algorithms",

--- a/src/main/scala/esmeta/spec/Constant.scala
+++ b/src/main/scala/esmeta/spec/Constant.scala
@@ -1,0 +1,6 @@
+package esmeta.spec
+
+import esmeta.lang.NumericLiteral
+
+/** constants defined by `emu-eqn` elements in ECMA-262 */
+case class Constant(name: String, value: NumericLiteral) extends SpecElem

--- a/src/main/scala/esmeta/spec/Spec.scala
+++ b/src/main/scala/esmeta/spec/Spec.scala
@@ -17,6 +17,7 @@ case class Spec(
   version: Option[Spec.Version] = None, // git version
   grammar: Grammar = Grammar(), // lexical/syntactic grammar productions
   algorithms: List[Algorithm] = Nil, // abstract algorithms for semantics
+  constants: List[Constant] = Nil, // constants defined by `emu-eqn` elements
   tables: Map[String, Table] = Map(), // tables
   tyModel: TyModel = TyModel(), // type models
   intrinsics: Intrinsics = Intrinsics(), // intrinsics
@@ -96,6 +97,10 @@ case class Spec(
   lazy val fnameMap: Map[String, Algorithm] =
     (for (algo <- algorithms) yield algo.head.fname -> algo).toMap
 
+  /** mapping from constant names to constants */
+  lazy val constantMap: Map[String, Constant] =
+    (for (const <- constants) yield const.name -> const).toMap
+
   /** get stats */
   lazy val stats: Stats = new Stats(this)
 
@@ -113,6 +118,7 @@ case class Spec(
     version == None &&
     grammar == Grammar() &&
     algorithms.isEmpty &&
+    constants.isEmpty &&
     tables.isEmpty &&
     tyModel == TyModel() &&
     intrinsics == Intrinsics()

--- a/src/main/scala/esmeta/spec/Summary.scala
+++ b/src/main/scala/esmeta/spec/Summary.scala
@@ -10,6 +10,7 @@ case class Summary(
   algos: AlgorithmSummary = AlgorithmSummary(), // abstract algorithms
   steps: StepSummary = StepSummary(), // abstract algorithms steps
   types: TypeSummary = TypeSummary(), // types
+  constants: Int = 0, // constants defined by `emu-eqn` elements
   tables: Int = 0, // tables
   tyModel: Int = 0, // type models
   intrinsics: Int = 0, // intrinsics
@@ -19,7 +20,8 @@ case class Summary(
 object Summary extends Parser.From[Summary](Parser.summary) {
   def apply(spec: Spec): Summary = if (!spec.isEmpty) {
     import ProductionKind.*
-    val Spec(version, grammar, algos, tables, tyModel, intrinsics) = spec
+    val Spec(version, grammar, algos, constants, tables, tyModel, intrinsics) =
+      spec
     val Grammar(prods, prodsForWeb) = grammar
     val prodsBy = prods.groupBy(_.kind)
     val completeAlgos = spec.completeAlgorithms.length
@@ -49,6 +51,7 @@ object Summary extends Parser.From[Summary](Parser.summary) {
         known = knownTypes,
         yet = yetTypes,
       ),
+      constants = constants.length,
       tables = tables.size,
       tyModel = tyModel.decls.size,
       intrinsics = intrinsics.models.length,

--- a/src/main/scala/esmeta/spec/util/JsonProtocol.scala
+++ b/src/main/scala/esmeta/spec/util/JsonProtocol.scala
@@ -27,6 +27,10 @@ object JsonProtocol extends BasicJsonProtocol {
   given Decoder[Table] = deriveDecoder
   given Encoder[Table] = deriveEncoder
 
+  // constants defined by `emu-eqn` elements
+  given Decoder[Constant] = deriveDecoder
+  given Encoder[Constant] = deriveEncoder
+
   // ---------------------------------------------------------------------------
   // Grammar
   // ---------------------------------------------------------------------------

--- a/src/main/scala/esmeta/spec/util/Parser.scala
+++ b/src/main/scala/esmeta/spec/util/Parser.scala
@@ -287,6 +287,33 @@ trait Parsers extends LangParsers {
   }.named("spec.BuiltinPath")
 
   // ---------------------------------------------------------------------------
+  // Constants
+  // ---------------------------------------------------------------------------
+  // definitions by `emu-eqn` elements, as a name with its value
+  lazy val constDef: Parser[(String, NumericLiteral)] =
+    (word <~ "=") ~ rep1sep(constForm, "=") ^? {
+      case name ~ forms if forms.exists(_.isDefined) =>
+        name -> forms.flatten.head
+    }
+
+  // forms of the value of a constant, as its value if written as a number
+  private lazy val constForm: Parser[Option[NumericLiteral]] =
+    constValue <~ guard("=" | EOL) ^^ { Some(_) } | "[^=]+".r ^^^ None
+
+  // values of constants written as numbers
+  private lazy val constValue: Parser[NumericLiteral] =
+    "*" ~> double <~ "*<sub>𝔽</sub>" ^^ { NumberLiteral(_) } |
+    constFactor ~ opt("×" ~> constFactor) ^^ {
+      case n ~ rest => DecimalMathValueLiteral(rest.foldLeft(n)(_ * _))
+    }
+
+  // factors in the values of constants (e.g., `10<sup>9</sup>`)
+  private lazy val constFactor: Parser[BigDecimal] =
+    decimal ~ opt("<sup>" ~> "[0-9]+".r <~ "</sup>") ^^ {
+      case n ~ exp => exp.foldLeft(n)((n, e) => n.pow(e.toInt))
+    }
+
+  // ---------------------------------------------------------------------------
   // Types
   // ---------------------------------------------------------------------------
   // optional metalanguage types with colon
@@ -327,11 +354,14 @@ trait Parsers extends LangParsers {
       (empty ~ "- known:" ~> int <~ ".*".r) ~
       (empty ~ "- yet:" ~> int <~ ".*".r)
     } ^^ { case t ~ k ~ y => TypeSummary(t, k, y) }
+    val constants = empty ~ "- constants:" ~> int
     val tables = empty ~ "- tables:" ~> int
     val tyModel = empty ~ "- type model:" ~> int <~ empty
     val intr = empty ~ "- intrinsics:" ~> int <~ empty
-    version ~ grammar ~ algos ~ steps ~ types ~ tables ~ tyModel ~ intr ^^ {
-      case v ~ g ~ a ~ s ~ ty ~ t ~ m ~ i => Summary(v, g, a, s, ty, t, m, i)
+    version ~ grammar ~ algos ~ steps ~ types ~
+    constants ~ tables ~ tyModel ~ intr ^^ {
+      case v ~ g ~ a ~ s ~ ty ~ c ~ t ~ m ~ i =>
+        Summary(v, g, a, s, ty, c, t, m, i)
     }
   }.named("spec.Summary")
 

--- a/src/main/scala/esmeta/spec/util/Stringifier.scala
+++ b/src/main/scala/esmeta/spec/util/Stringifier.scala
@@ -39,6 +39,7 @@ object Stringifier {
       case elem: Param          => paramRule(app, elem)
       case elem: ParamKind      => paramKindRule(app, elem)
       case elem: Table          => tableRule(app, elem)
+      case elem: Constant       => constantRule(app, elem)
 
   // for specifications
   given specRule: Rule[Spec] = (app, spec) =>
@@ -53,6 +54,7 @@ object Stringifier {
       algos,
       steps,
       types,
+      constants,
       tables,
       tyModel,
       intr,
@@ -72,6 +74,7 @@ object Stringifier {
     app :> "- types: " >> types.total
     app :> "  - known: " >> types.known >> " " >> types.completeRatio
     app :> "  - yet: " >> types.yet >> " " >> types.yetRatio
+    app :> "- constants: " >> constants
     app :> "- tables: " >> tables
     app :> "- type model: " >> tyModel
     app :> "- intrinsics: " >> intr
@@ -239,4 +242,8 @@ object Stringifier {
 
   // TODO: for tables
   given tableRule: Rule[Table] = (app, table) => ???
+
+  // for constants defined by `emu-eqn` elements
+  given constantRule: Rule[Constant] = (app, constant) =>
+    app >> constant.name >> " = " >> constant.value
 }

--- a/src/test/scala/esmeta/ESMetaTest.scala
+++ b/src/test/scala/esmeta/ESMetaTest.scala
@@ -128,6 +128,23 @@ trait ESMetaTest extends funsuite.AnyFunSuite with BeforeAndAfterAll {
         assert(stringified == string)
     })
 
+  // check parse only, for parsers that do not keep everything they parse
+  def checkParse[T](desc: String, parser: BasicParsers#From[T])(
+    cases: (String, T)*,
+  ): Unit =
+    check(desc)(cases.foreach {
+      case (string, obj) =>
+        val parsed = optional(parser.from(string))
+        if (parsed != Some(obj)) {
+          println(s"[FAILED] $desc (parsing)")
+          val parsedStr = parsed.fold("<parsing failed>")(origToString)
+          println(s"- raw string: $string")
+          println(s"- parsed  : ${parsedStr}")
+          println(s"- expected: ${origToString(obj)}")
+        }
+        assert(parsed == Some(obj))
+    })
+
   // check JSON encoder/decoder
   def checkJson[T](desc: String)(
     cases: (T, Json)*,

--- a/src/test/scala/esmeta/lang/LangTest.scala
+++ b/src/test/scala/esmeta/lang/LangTest.scala
@@ -356,6 +356,8 @@ object LangTest {
   lazy val mathVal = DecimalMathValueLiteral(BigDecimal("0.5"))
   lazy val mathPi = MathConstantLiteral(1, "π")
   lazy val mathPiWithPre = MathConstantLiteral(2, "π")
+  lazy val msPerDay = ConstantLiteral("msPerDay")
+  lazy val hoursPerDay = ConstantLiteral("HoursPerDay")
   lazy val posZero = NumberLiteral(+0.0)
   lazy val negZero = NumberLiteral(-0.0)
   lazy val posInf = NumberLiteral(Double.PositiveInfinity)
@@ -520,4 +522,15 @@ object LangTest {
 
   lazy val two = DecimalMathValueLiteral(BigDecimal(2))
   lazy val six = DecimalMathValueLiteral(BigDecimal(6))
+
+  // ---------------------------------------------------------------------------
+  // constants defined by `emu-eqn` elements
+  // ---------------------------------------------------------------------------
+  val ConstParser = esmeta.lang.util.Parser.withConstNames(
+    Set(
+      "HoursPerDay",
+      "msPerDay",
+    ),
+  )
+  object ConstExpression extends ConstParser.From(ConstParser.expr)
 }

--- a/src/test/scala/esmeta/lang/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/lang/StringifyTinyTest.scala
@@ -202,6 +202,18 @@ class StringifyTinyTest extends LangTest {
       convToMathExpr -> "ℝ(_x_)",
     )
     // -------------------------------------------------------------------------
+    // constants defined by `emu-eqn` elements
+    // -------------------------------------------------------------------------
+    checkParseAndStringify("ConstantLiteral", ConstExpression)(
+      msPerDay -> "msPerDay",
+      hoursPerDay -> "HoursPerDay",
+      BinaryExpression(
+        msPerDay,
+        BinaryExpressionOperator.Mul,
+        refExpr,
+      ) -> "msPerDay × _x_",
+    )
+    // -------------------------------------------------------------------------
     // algorithm mathematical operation expressions
     // -------------------------------------------------------------------------
     checkParseAndStringify("MathOpExpression", Expression)(

--- a/src/test/scala/esmeta/spec/SpecTest.scala
+++ b/src/test/scala/esmeta/spec/SpecTest.scala
@@ -3,6 +3,7 @@ package spec
 
 import esmeta.lang.*
 import esmeta.spec.*
+import esmeta.spec.util.Parser
 import esmeta.ty.*
 
 /** test for ECMAScript specification (ECMA-262) */
@@ -101,4 +102,18 @@ object SpecTest {
     List(Param("value", UnknownType)),
     UnknownType,
   )
+
+  // constants defined by `emu-eqn` elements
+  object ConstantDef
+    extends Parser.From(Parser.constDef ^^ {
+      case (name, value) => Constant(name, value)
+    })
+
+  /** a constant whose value is a mathematical value */
+  def mathConst(name: String, value: String): Constant =
+    Constant(name, DecimalMathValueLiteral(BigDecimal(value)))
+
+  /** a constant whose value is a Number */
+  def numberConst(name: String, value: Double): Constant =
+    Constant(name, NumberLiteral(value))
 }

--- a/src/test/scala/esmeta/spec/StringifyTinyTest.scala
+++ b/src/test/scala/esmeta/spec/StringifyTinyTest.scala
@@ -26,6 +26,7 @@ class StringifyTinyTest extends SpecTest {
         AlgorithmSummary(2623, 2258, 0),
         StepSummary(19061, 18307),
         TypeSummary(5908, 5469, 439),
+        7,
         89,
         58,
         101,
@@ -45,6 +46,7 @@ class StringifyTinyTest extends SpecTest {
          |- types: 5908
          |  - known: 5469 (92.57%)
          |  - yet: 439 (7.43%)
+         |- constants: 7
          |- tables: 89
          |- type model: 58
          |- intrinsics: 101""".stripMargin,
@@ -163,6 +165,18 @@ class StringifyTinyTest extends SpecTest {
       Getter(NormalAccess(Base("A"), "B")) -> "get:A.B",
       Setter(NormalAccess(Base("A"), "B")) -> "set:A.B",
       SymbolAccess(Base("A"), "B") -> "A[%Symbol.B%]",
+    )
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+    checkParse("Constant", ConstantDef)(
+      "HoursPerDay = 24" ->
+      mathConst("HoursPerDay", "24"),
+      "msPerDay = *86400000*<sub>𝔽</sub> = msPerHour × 𝔽(HoursPerDay)" ->
+      numberConst("msPerDay", 86400000),
+      "nsPerDay = 10<sup>6</sup> × ℝ(msPerDay) = 8.64 × 10<sup>13</sup>" ->
+      mathConst("nsPerDay", "8.64e13"),
     )
   }
 

--- a/tests/result/lang/StringifyTinyTest
+++ b/tests/result/lang/StringifyTinyTest
@@ -1,1 +1,1 @@
-lang.StringifyTinyTest: 13 / 13
+lang.StringifyTinyTest: 14 / 14

--- a/tests/result/lang/StringifyTinyTest.json
+++ b/tests/result/lang/StringifyTinyTest.json
@@ -4,6 +4,7 @@
   "CalcExpression" : true,
   "ClampExpression" : true,
   "Condition" : true,
+  "ConstantLiteral" : true,
   "Expression" : true,
   "Intrinsic" : true,
   "Literal" : true,

--- a/tests/result/spec/StringifyTinyTest
+++ b/tests/result/spec/StringifyTinyTest
@@ -1,1 +1,1 @@
-spec.StringifyTinyTest: 10 / 10
+spec.StringifyTinyTest: 11 / 11

--- a/tests/result/spec/StringifyTinyTest.json
+++ b/tests/result/spec/StringifyTinyTest.json
@@ -1,5 +1,6 @@
 {
   "BuiltinPath" : true,
+  "Constant" : true,
   "Grammar" : true,
   "Head" : true,
   "Lhs" : true,


### PR DESCRIPTION
Handles #349 

This PR adds support for [time-related constants](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-related-constants) in the spec parser, with a few small additional changes.

Specifically,
1. Add support for constant parsing by pre-scanning the spec (like tables). Constants defined by `emu-eqn` elements are collected before algorithms are parsed.
2. `InvokeExpression` is now a `CalcExpression`. An invocation can therefore appear as an operand of a calculation

For example, [TimeFromYear](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-timefromyear) can now be parsed:

```
1. Return msPerDay × DayFromYear(y).
```

As a result, 13 more algorithms are complete (2519 → 2532), most of them date and time related.