### PR TITLE
Support JSON productions

### DIFF
--- a/src/main/resources/manuals/grammars/ecma404.grammar
+++ b/src/main/resources/manuals/grammars/ecma404.grammar
@@ -1,0 +1,85 @@
+// JSON grammar from https://tc39.es/ecma404/
+
+JSONValue :
+  JSONObject
+  JSONArray
+  JSONNumber
+  JSONString
+  `true`
+  `false`
+  `null`
+
+JSONObject :
+  `{` `}`
+  `{` JSONMemberList `}`
+
+JSONMemberList :
+  JSONMember
+  JSONMemberList `,` JSONMember
+
+JSONMember :
+  JSONString `:` JSONValue
+
+JSONArray :
+  `[` `]`
+  `[` JSONElementList `]`
+
+JSONElementList :
+  JSONValue
+  JSONElementList `,` JSONValue
+
+JSONString :
+  `"` JSONStringCharacters? `"`
+
+// skipping |NonZeroDigit|, it is defined in ECMA-262.
+
+JSONNumber ::
+  `-`? JSONInteger JSONFraction? JSONExponent?
+
+JSONInteger ::
+  `0`
+  NonZeroDigit JSONDigits?
+
+JSONFraction ::
+  `.` JSONDigits
+
+JSONExponent ::
+  JSONExponentIndicator JSONSign? JSONDigits
+
+JSONExponentIndicator :: one of
+  `e` `E`
+
+JSONSign :: one of
+  `+` `-`
+
+JSONDigits ::
+  JSONDigit
+  JSONDigits JSONDigit
+
+JSONDigit :: one of
+  `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+
+JSONStringCharacters ::
+  JSONStringCharacter JSONStringCharacters?
+
+JSONStringCharacter ::
+  JSONSourceCharacter but not one of `"` or `\` or JSONControlCharacter
+  `\` JSONEscapeSequence
+
+JSONEscapeSequence ::
+  JSONEscapeCharacter
+  `u` JSONHexDigit JSONHexDigit JSONHexDigit JSONHexDigit
+
+JSONEscapeCharacter :: one of
+  `"` `\` `/` `b` `f` `n` `r` `t`
+
+JSONHexDigit :: one of
+  `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
+
+JSONSourceCharacter ::
+  > any Unicode code point
+
+// XXX originally `U+0000 through U+001F`, which cannot be written directly
+JSONControlCharacter :: one of
+  <U+0000> <U+0001> <U+0002> <U+0003> <U+0004> <U+0005> <U+0006> <U+0007> <U+0008> <U+0009> <U+000A> <U+000B> <U+000C> <U+000D> <U+000E> <U+000F>
+  <U+0010> <U+0011> <U+0012> <U+0013> <U+0014> <U+0015> <U+0016> <U+0017> <U+0018> <U+0019> <U+001A> <U+001B> <U+001C> <U+001D> <U+001E> <U+001F>

--- a/src/main/resources/result/spec-summary
+++ b/src/main/resources/result/spec-summary
@@ -1,9 +1,9 @@
 - version: 0248456c758431e4bb8e5d26333ff1865123c9cd (es2026)
 - grammar:
-  - productions: 378
-    - lexical: 164
+  - productions: 400
+    - lexical: 179
     - numeric string: 16
-    - syntactic: 198
+    - syntactic: 205
   - extended productions for web: 29
 - algorithms: 2909
   - complete: 2519 (86.59%)
@@ -11,8 +11,8 @@
 - algorithm steps: 22857
   - complete: 22101 (96.69%)
 - types: 8381
-  - known: 7485 (89.31%)
-  - yet: 209 (2.49%)
+  - known: 7486 (89.32%)
+  - yet: 208 (2.48%)
 - tables: 95
 - type model: 113
 - intrinsics: 102

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -8,6 +8,7 @@ import esmeta.spec.{*, given}
 import esmeta.spec.util.{Parsers => SpecParsers}
 import esmeta.ty.TyModel
 import esmeta.util.ManualInfo
+import esmeta.util.BaseUtils.{raise, warn}
 import esmeta.util.HtmlUtils.*
 import esmeta.util.SystemUtils.*
 import org.jsoup.nodes.*
@@ -240,7 +241,7 @@ class Extractor(
         rhs <- prod.rhsVec
         rhsName <- rhs.allNames
         syntax = lhsName + ":" + rhsName
-        (idx, subIdx) = idxMap(syntax)
+        (idx, subIdx) <- getSyntaxIdx(syntax, lhsName)
         target = SyntaxDirectedOperationHead.Target(lhsName, idx, subIdx)
       } yield generator(Some(target))
     } else {
@@ -248,6 +249,21 @@ class Extractor(
       List(generator(None))
     }
   }
+
+  private lazy val LhsNames: Set[String] =
+    (for (prod <- grammar.prods ++ grammar.prodsForWeb)
+      yield prod.lhs.name).toSet
+
+  private def getSyntaxIdx(
+    syntax: String,
+    lhsName: String,
+  ): List[(Int, Int)] = idxMap.get(syntax) match
+    case Some(pair) => List(pair)
+    // XXX ECMA-262 defines SDOs for productions of other specifications (e.g. ECMA-404)
+    case None if !LhsNames.contains(lhsName) =>
+      warn(s"ignore an SDO definition for production from external specification: $syntax")
+      Nil
+    case None => raise(s"unknown grammar production alternative: $syntax")
 
   // get concrete method heads
   private def extractConcMethodHead(

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -84,13 +84,18 @@ class Extractor(
 
   /** extracts a grammar */
   def extractGrammar: Grammar = {
-    val allProds = for {
+    val manualProds = for {
+      file <- ManualInfo.grammarFiles
+      prod <- parse[List[Production]](readFile(file).trim)
+    } yield (prod, false)
+    val specProds = for {
       elem <- document.getElems("emu-grammar[type=definition]:not([example])")
       content = elem.html.trim.unescapeHtml
       prods = parse[List[Production]](content)
       prod <- prods
       inAnnex = elem.isInAnnex
     } yield (prod, inAnnex)
+    val allProds = manualProds ++ specProds
     val prods =
       (for ((prod, inAnnex) <- allProds if !inAnnex) yield prod).sorted
     val prodsForWeb =

--- a/src/main/scala/esmeta/extractor/Extractor.scala
+++ b/src/main/scala/esmeta/extractor/Extractor.scala
@@ -261,7 +261,9 @@ class Extractor(
     case Some(pair) => List(pair)
     // XXX ECMA-262 defines SDOs for productions of other specifications (e.g. ECMA-404)
     case None if !LhsNames.contains(lhsName) =>
-      warn(s"ignore an SDO definition for production from external specification: $syntax")
+      warn(
+        s"ignore an SDO definition for production from external specification: $syntax",
+      )
       Nil
     case None => raise(s"unknown grammar production alternative: $syntax")
 

--- a/src/main/scala/esmeta/lang/util/Parser.scala
+++ b/src/main/scala/esmeta/lang/util/Parser.scala
@@ -1413,6 +1413,7 @@ trait Parsers extends IndentParsers {
     "*NaN*" ^^! NaNT |
     "integral Number" ^^^ NumberIntT |
     "property key" ^^^ (StrT || SymbolT) |
+    "property name" ^^^ StrT |
     "~" ~> "[-+a-zA-Z0-9]+".r <~ "~" ^^ { EnumT(_) }
   } <~ opt("s")
 

--- a/src/main/scala/esmeta/util/ManualInfo.scala
+++ b/src/main/scala/esmeta/util/ManualInfo.scala
@@ -20,6 +20,9 @@ object ManualInfo {
   /** manual algorithm files */
   lazy val algoFiles: List[String] = getFileNames(algoFilter)
 
+  /** manual grammar files */
+  lazy val grammarFiles: List[String] = getFileNames(grammarFilter)
+
   /** manual IR function files */
   lazy val funcFiles: List[String] = getFileNames(irFilter)
 

--- a/src/main/scala/esmeta/util/SystemUtils.scala
+++ b/src/main/scala/esmeta/util/SystemUtils.scala
@@ -37,6 +37,7 @@ object SystemUtils {
   /** extension filter */
   def extFilter(ext: String): String => Boolean = _.endsWith(s".$ext")
   lazy val algoFilter = extFilter("algo")
+  lazy val grammarFilter = extFilter("grammar")
   lazy val irFilter = extFilter("ir")
   lazy val cfgFilter = extFilter("cfg")
   lazy val jsFilter = extFilter("js")


### PR DESCRIPTION
This PR closes #350.

Regarding tc39/ecma262#3933, which removes the JSON-related definitions from ECMA-262 and instead refers to ECMA-404, moving these definitions outside ECMA-262 caused ESMeta to fail during SDO extraction due to unknown productions. (see `JSONEvaluation` at [spec preview](https://tc39.es/ecma262/pr/3933/#sec-jsonevaluation))

As a result, ESMeta fails as early as the extract phase, preventing subsequent phases such as tycheck from running:

[example](https://github.com/tc39/ecma262/actions/runs/31184269681/job/92884791510?pr=3933)
```
Run "${ESMETA_HOME}"/bin/esmeta tycheck -status -extract:log -tycheck:log -tycheck:ignore=esmeta-ignore.json
========================================
 extract phase
----------------------------------------
[ESMeta v0.7.3] Unexpected error occurred:
Error: Exception in thread "main" java.util.NoSuchElementException: key not found: JSONValue:null
	…
	at esmeta.extractor.Extractor.extractSdoHead$$anonfun$2(Extractor.scala:240)
```

This PR adds `ecma404.grammar` to resources, and supports type 'property name' as `StrT` ([spec](https://tc39.es/ecma262/#property-name)).


##### Note

After this change makes ESMeta handle the JSON productions, running tycheck on the branch of that [PR](https://github.com/tc39/ecma262/pull/3933) (by using `git -C ecma262 fetch origin pull/3933/merge && git -C ecma262 checkout FETCH_HEAD`) reports a type error in `IncrementModuleAsyncEvaluationCount`:

```
[ReturnTypeMismatch] Block[5865] return statement in IncrementModuleAsyncEvaluationCount (step 4, 5:12(235)-5:27(250))
- expected: Int[0+]
- actual  : Int
```

This seems to be a genuine type error rather than a false positive, **and unrelated to this PR**.
