### PR TITLE
Improve precision of math type intersection with sign types

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -10,7 +10,6 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
-  "INTRINSICS.Function.prototype.bind",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "TimeString",
   "TimeZoneString",

--- a/src/main/scala/esmeta/ty/MathTy.scala
+++ b/src/main/scala/esmeta/ty/MathTy.scala
@@ -68,7 +68,9 @@ sealed trait MathTy extends TyElem with Lattice[MathTy] {
       MathSetTy(set.filter(n => sign.contains(n.decimal)))
     case (MathSetTy(set), MathSignTy(sign)) =>
       MathSetTy(set.filter(n => sign.contains(n.decimal)))
-    case (l, r) => MathSignTy(l.toSign && r.toSign)
+    // comparison with integer domain
+    case (MathIntTy(int), MathSignTy(sign)) => MathIntTy(int && IntSignTy(sign))
+    case (MathSignTy(sign), MathIntTy(int)) => MathIntTy(IntSignTy(sign) && int)
 
   /** prune type */
   def --(that: => MathTy): MathTy = (this.canon, that.canon) match


### PR DESCRIPTION
While bumping ESMeta to 0.8.0 for [tc39/ecma262#3962](https://github.com/tc39/ecma262/pull/3962), the type check began failing on `Function.prototype.bind`.

The recent editorial restructuring of that algorithm moved the `ToIntegerOrInfinity` call *above* the ±∞ checks, so the `Else` branch now has to refine a mathematical value type — a path that was never exercised before.

`MathTy.&&` had no case for intersecting the integer domain with the sign domain, and fell through to:

```scala
case (l, r) => MathSignTy(l.toSign && r.toSign)
```

This widens the integer type into the sign domain, losing integrality. The following `-` and `max` then went to top, producing a spurious error at `SetFunctionLength`.

Intersect in the integer domain by lifting the sign type into `IntSignTy`:

```diff
-  case (l, r) => MathSignTy(l.toSign && r.toSign)
+  // comparison with integer domain
+  case (MathIntTy(int), MathSignTy(sign)) => MathIntTy(int && IntSignTy(sign))
+  case (MathSignTy(sign), MathIntTy(int)) => MathIntTy(IntSignTy(sign) && int)
```

`INTRINSICS.Function.prototype.bind` now type-checks, so it is removed from `manuals/tycheck-ignore.json`.
