### PR TITLE
Improve precision of integer modulo and exponentiation types

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -4,14 +4,11 @@
   "BigIntBitwiseOp",
   "ClassStaticBlockBody[0,0].EvaluateClassStaticBlockBody",
   "CompareTypedArrayElements",
-  "DecimalEscape[0,1].CapturingGroupNumber",
   "DoWait",
   "EvaluateImportCall",
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
   "Record[SourceTextModuleRecord].ExecuteModule",
-  "TimeString",
-  "TimeZoneString",
   "TypedArrayLength"
 ]

--- a/src/main/resources/manuals/types
+++ b/src/main/resources/manuals/types
@@ -611,7 +611,7 @@ type AgentRecord {
   IsLockFree8: Boolean;
   CandidateExecution: Record[CandidateExecutionRecord];
   KeptAlive: List[Record[Object | Symbol]];
-  ModuleAsyncEvaluationCount: Int;
+  ModuleAsyncEvaluationCount: Int[0+];
 }
 
 // https://tc39.es/ecma262/#sec-candidate-executions
@@ -714,7 +714,6 @@ type CyclicModuleRecord extends ModuleRecord {
   abstract def ExecuteModule;
   Status: Enum[~evaluated~, ~evaluating-async~, ~evaluating~, ~linked~, ~linking~, ~new~, ~unlinked~];
   EvaluationError: Abrupt[throw] | Enum[~empty~];
-  DFSIndex: Enum[~empty~] | Int;
   DFSAncestorIndex: Enum[~empty~] | Int;
   RequestedModules: List[Record[ModuleRequestRecord]];
   LoadedModules: List[Record[LoadedModuleRequestRecord]];

--- a/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsValue.scala
@@ -462,6 +462,8 @@ trait AbsValueDecl { self: TyChecker =>
     /** TODO AST type names whose MV returns a non-negative integer */
     lazy val nonNegIntMVTyNames: Set[String] = Set(
       "CodePoint",
+      "DecimalDigit",
+      "DecimalDigits",
       "Hex4Digits",
       "HexEscapeSequence",
     ) ++ posIntMVTyNames

--- a/src/main/scala/esmeta/ty/IntTy.scala
+++ b/src/main/scala/esmeta/ty/IntTy.scala
@@ -74,20 +74,23 @@ sealed trait IntTy extends TyElem with Lattice[IntTy] {
         val r = rset.head
         l match
           case IntSetTy(lset) => IntSetTy(lset.map(l => l %% r))
-          case IntSignTy(lsign) =>
-            val zero = lsign.zero
-            if (r.abs > 8) Top
-            else if (r > 0) {
-              if (zero) IntSetTy((0 until r.toInt).toSet.map(BigInt(_)))
-              else IntSetTy((1 until r.toInt).toSet.map(BigInt(_)))
-            } else {
-              if (zero) IntSetTy((r.toInt + 1 to 0).toSet.map(BigInt(_)))
-              else IntSetTy((r.toInt + 1 until 0).toSet.map(BigInt(_)))
-            }
+          case IntSignTy(_) =>
+            if (r > 8) NonNeg
+            else if (r < -8) NonPos
+            else if (r > 0) IntSetTy((0 until r.toInt).toSet.map(BigInt(_)))
+            else IntSetTy((r.toInt + 1 to 0).toSet.map(BigInt(_)))
       case _ => Top
 
   def **(that: => IntTy): IntTy =
-    single(this, that, (l, r) => l.pow(r.toInt))
+    if (this.isBottom || that.isBottom) Bot
+    // a negative exponent does not yield an integer
+    else if (!that.toSign.isNonNeg) Top
+    else
+      single(this, that, (l, r) => l.pow(r.toInt)) match
+        case res if res != Top         => res
+        case _ if this.toSign.isPos    => Pos
+        case _ if this.toSign.isNonNeg => NonNeg
+        case _                         => Top
 
   def &(that: => IntTy): IntTy = single(this, that, _ & _)
 


### PR DESCRIPTION
Resolves 6 type errors: 38 → 32 on es2026, 39 → 32 on ecma262 `main`.

- `IntTy.%`: keep the sign instead of falling back to `Top` when the divisor is too large to enumerate as a set. Also drop an unsound refinement that excluded 0 from the result for a non-zero dividend (`Int[+] % 2` gave `Int[1]`, but
  `4 % 2 = 0`).
- `IntTy.**`: infer the sign when the operands are not singletons, and skip `BigInt.pow`, which throws on a negative exponent.
- Add `DecimalDigit`/`DecimalDigits` to `nonNegIntMVTyNames`.
- `manuals/types`: mark `AgentRecord.ModuleAsyncEvaluationCount` as non-negative, and remove `CyclicModuleRecord.DFSIndex`, a field that no longer exists in ECMA-262.

Fixed algorithms: `TimeString`, `TimeZoneString`, `DecimalEscape[0,1].CapturingGroupNumber`, and — on `main` only —
`IncrementModuleAsyncEvaluationCount`, whose declared return type was narrowed to a non-negative integer by tc39/ecma262#3826 while the Agent Record table still says "an integer".

This also narrows 21 inferred signatures with no widening anywhere, e.g. `ToUint8`/`ToUint16`/`ToUint32` now return `NumberInt[0+]`, and makes the negative-value correction branch of `Number::unsignedRightShift` provably dead.