### PR TITLE
Trim README and rewrite the release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,473 +1,170 @@
 [![test](https://github.com/es-meta/esmeta/actions/workflows/ci.yml/badge.svg)](https://github.com/es-meta/esmeta/actions)
 [![license](https://badgen.net/github/license/es-meta/esmeta)](https://github.com/es-meta/esmeta/blob/main/LICENSE.md)
 [![release](https://badgen.net/github/release/es-meta/esmeta)](https://github.com/es-meta/esmeta/releases)
-[![prs](https://badgen.net/github/prs/es-meta/esmeta)](https://github.com/es-meta/esmeta/pulls)
-[![slack](https://badgen.net/badge/slack/esmeta/blue)](https://esmeta.slack.com/)
 [![site](https://badgen.net/badge/site/jekyll/blue)](https://es-meta.github.io/)
 [![doc](https://badgen.net/badge/doc/scaladoc/blue)](https://es-meta.github.io/esmeta)
 
 # ESMeta
-**ESMeta** is an **E**CMAScript **S**pecification **Meta**language. This
-framework extracts a mechanized specification from a given version of
-ECMAScript/JavaScript specification ([ECMA-262](https://tc39.es/ecma262/)) and
-automatically generates language-based tools.
 
-## Table of Contents
+**ESMeta** is an **E**CMAScript **S**pecification **Meta**language. It extracts a
+mechanized specification from a given version of ECMAScript/JavaScript
+specification ([ECMA-262](https://tc39.es/ecma262/)) and automatically generates
+language-based tools: a JavaScript interpreter, a double debugger, a conformance
+test synthesizer, and a specification type analyzer.
 
-  * [Installation Guide](#installation-guide)
-    + [Download ESMeta](#download-esmeta)
-    + [Environment Setting](#environment-setting)
-    + [Installation of ESMeta using `sbt`](#installation-of-esmeta-using--sbt-)
-  * [Basic Commands](#basic-commands)
-    + [Parsing and Executing ECMAScript files](#parsing-and-executing-ecmascript-files)
-    + [Executing Test262 tests](#executing-test262-tests)
-  * [Supported Features](#supported-features)
-    + [Specification Exemplified with ECMA Visualizer](#specification-exemplified-with-ecma-visualizer)
-    + [Interactive Execution with ECMAScript Double Debugger](#interactive-execution-with-ecmascript-double-debugger)
-    + [Conformance Test Synthesizer from ECMA-262](#conformance-test-synthesizer-from-ecma-262)
-    + [Type Analysis on ECMA-262](#type-analysis-on-ecma-262)
-    + ~~[Meta-Level Static Analyzer for ECMAScript](#meta-level-static-analyzer-for-ecmascript)~~ (temporarily removed)
-  * [Academic Achievement](#academic-achievement)
-    + [Publications](#publications)
-    + [PLDI 2022 Tutorial](#pldi-2022-tutorial)
-    + [Communications of the ACM (CACM)](#communications-of-the-acm-cacm)
+## Installation
 
-
-## Installation Guide
-
-We explain how to install ESMeta with the necessary environment settings from
-scratch. Our framework is developed in Scala, which works on JDK 17+. So before
-installation, please install [JDK
-17+](https://www.oracle.com/java/technologies/downloads/) and
-[sbt](https://www.scala-sbt.org/), an interactive build tool for Scala.
-
-
-### Download ESMeta
-```bash
-$ git clone https://github.com/es-meta/esmeta.git
-```
-
-### Environment Setting
-Insert the following commands to `~/.bashrc` (or `~/.zshrc`):
-```bash
-# for ESMeta
-export ESMETA_HOME="<path to ESMeta>" # IMPORTANT!!!
-export PATH="$ESMETA_HOME/bin:$PATH" # for executables `esmeta` and etc.
-source $ESMETA_HOME/.completion # for auto-completion
-```
-The `<path to ESMeta>` should be the absolute path of the ESMeta repository.
-
-
-### Installation of ESMeta using `sbt`
-
-Please type the following command to 1) update the git submodules, 2) generate
-binary file `bin/esmeta`, and 3) apply the `.completion` for auto-completion.
+ESMeta is written in Scala and requires
+[JDK 17+](https://www.oracle.com/java/technologies/downloads/) and
+[sbt](https://www.scala-sbt.org/).
 
 ```bash
-$ cd esmeta && git submodule update --init && sbt assembly && source .completion
+git clone https://github.com/es-meta/esmeta.git
 ```
 
-If you see the following message, ESMeta is successfully installed:
+Add the following to `~/.bashrc` (or `~/.zshrc`), where `<path to ESMeta>` is the
+absolute path of the cloned repository:
+
 ```bash
-$ esmeta
-# Welcome to ESMeta v0.8.1 - ECMAScript Specification Metalanguage.
-# Please type `esmeta help` to see the help message.
+export ESMETA_HOME="<path to ESMeta>"  # IMPORTANT!!!
+export PATH="$ESMETA_HOME/bin:$PATH"   # for the `esmeta` executable
+source $ESMETA_HOME/.completion        # for auto-completion
 ```
 
+Then update the git submodules and build the binary:
 
-## Basic Commands
-
-You can run this framework with the following command:
 ```bash
-$ esmeta <command> <option>* <filename>*
+cd esmeta && git submodule update --init && sbt assembly && source .completion
 ```
-It supports the following commands:
-- `help` shows help messages.
-- `extract` extracts specification model from ECMA-262 (`ecma262/spec.html`).
-- `compile` compiles a specification to an IR program.
-- `build-cfg` builds a control-flow graph (CFG) from an IR program.
-- `tycheck` performs a type analysis of ECMA-262.
-- `parse` parses an ECMAScript file.
-- `eval` evaluates an ECMAScript file.
-- `web` starts a web server for an ECMAScript double debugger.
-- `test262-test` tests Test262 tests with harness files (default: tests/test262).
-- `inject` injects assertions to check final state of an ECMAScript file.
-- `mutate` mutates an ECMAScript program.
-- `analyze` analyzes an ECMAScript file using meta-level static analysis. (temporarily removed)
-- `dump-debugger` dumps the resources required by the standalone debugger. (for internal use)
-- `dump-visualizer` dumps the resources required by the visualizer. (for internal use)
 
-and global options:
-- `-silent` does not show final results.
-- `-error` shows error stack traces.
-- `-status` exits with status.
-- `-time` displays the duration time.
-- `-test262dir={string}` sets the directory of Test262 (default: `$ESMETA_HOME/tests/test262`).
+Run `esmeta` to check the installation.
 
-If you want to see the detailed help messages and command-specific options,
-please use the `help` command:
+## Usage
+
 ```bash
-# show help messages for all commands
-$ esmeta help
-
-# show help messages for specific commands with more details
-$ esmeta help <command>
+esmeta <command> <option>* <filename>*
 ```
 
-Please use the `build-cfg` command to extract a mechanized specification as a
-control-flow graph from ECMA-262:
+| Command | Description |
+| --- | --- |
+| `extract` | extract a specification model from ECMA-262 (`ecma262/spec.html`) |
+| `compile` | compile a specification to an IR program |
+| `build-cfg` | build a control-flow graph (CFG) from an IR program |
+| `parse` / `eval` | parse or evaluate an ECMAScript file |
+| `tycheck` | perform a type analysis of ECMA-262 |
+| `test262-test` | run [Test262](https://github.com/tc39/test262) tests (default: `tests/test262`) |
+| `fuzz` | synthesize JavaScript programs using specification coverage |
+| `inject` | inject assertions to check the final state of an ECMAScript file |
+
+Use `esmeta help` or `esmeta help <command>` for the full list of commands,
+global options, and command-specific options.
+
+Use the `-extract:target` option with any git tag, branch name, or commit hash
+to target another version of ECMA-262:
+
 ```bash
-$ esmeta build-cfg
-# ========================================
-#  extract phase
-# ----------------------------------------
-# ========================================
-#  compile phase
-# ----------------------------------------
-# ========================================
-#  build-cfg phase
-# ----------------------------------------
-# 0: def <BUILTIN>:INTRINSICS.SyntaxError(...): Unknown {
-#   ...
-# }
-# 1: def <INTERNAL>:BuiltinFunctionObject.Construct(...): Normal[Object] | Abrupt[throw] {
-#   ...
-# }
-# ...
+esmeta build-cfg -extract:target=origin/main  # a branch (the latest draft)
+esmeta build-cfg -extract:target=es2026       # a tag
+esmeta build-cfg -extract:target=2c78e6f      # a commit
 ```
-The `build-cfg` command consists of three phases:
-  1. The `extract` phase extracts specification model (`esmeta.spec.Spec`) from
-     ECMA-262 (`spec.html`).
-  2. The `compile` phase compiles it into a program (`esmeta.ir.Program`) in
-     **IRES**, an **I**ntermediate **R**epresentations for **E**CMAScript
-     **S**pecification.
-  3. The `build-cfg` phase builds a control-flow graph (`esmeta.cfg.CFG`) for a
-     given IRES program.
 
-You can extract mechanized specifications from other versions of ECMA-262 with
-the `-extract:target` option. Please enter any git tag/branch names or commit
-hash as an input of the option:
+## Features
+
+### Mechanized Specification and Interpreter
+
+`esmeta build-cfg` runs the core pipeline:
+
+1. `extract` — build a specification model (`esmeta.spec.Spec`) from `ecma262/spec.html`
+2. `compile` — lower it into an IR program (`esmeta.ir.Program`)
+3. `build-cfg` — build a control-flow graph (`esmeta.cfg.CFG`) from that program
+
+That graph is an executable interpreter, so `parse` and `eval` run JavaScript
+directly against the specification — and every feature below is built on it.
+
 ```bash
-# extract a mechanized specification from the origin/main branch version of ECMA-262
-$ esmeta build-cfg -extract:target=origin/main
-
-# extract a mechanized specification from the 2c78e6f commit version of ECMA-262
-$ esmeta build-cfg -extract:target=2c78e6f
+echo 'let x; x ??= class {}; function* f() {}' > example.js
+esmeta parse example.js
+esmeta eval example.js
 ```
 
-### Parsing and Executing ECMAScript files
+### ECMA Visualizer and Double Debugger
 
-After extracting mechanized specifications from ECMA-262, you can parse or
-execute ECMAScript/JavaScript programs. For example, consider the following
-example JavaScript file:
-```js
-// example.js
-let x; x ??= class {}; function* f() {}
-```
-You can parse or execute it with `parse` and `eval` commands.
-```bash
-# parse example.js
-$ esmeta parse example.js
-
-# execute example.js
-$ esmeta eval example.js
-```
-
-### Executing Test262 tests
-
-ESMeta supports the execution of [Test262](https://github.com/tc39/test262)
-tests to check the conformance between Test262 and ECMA-262.
-```bash
-# run all the applicable Test262 tests
-$ esmeta test262-test
-# ...
-# ========================================
-#  test262-test phase
-# ----------------------------------------
-# - harness                       :    96 tests are removed
-# ...
-# ----------------------------------------
-# - total: 31,537 available tests
-#   - normal: 31,537 tests
-#   - error: 0 tests
-# ----------------------------------------
-# ...
-```
-If you want to execute specific Test262 files or directories, please list their
-paths as arguments:
-```bash
-# run Test262 tests in a given directory
-$ esmeta test262-test tests/test262/test/language/expressions/addition
-```
-
-
-## Supported Features
-
-ESMeta supports other features utilizing mechanized specifications, including 1) exemplify specification with ECMA Visualizer, 2)
-interactive execution of ECMAScript/JavaScript file with a double debugger, 3)
-conformance test synthesizer, 4) type analysis of ECMA-262, and 5) meta-level
-static analysis for ECMAScript/JavaScript files.  All of them utilize mechanized
-specifications from ECMA-262. Thus, ESMeta always extracts mechanized
-specifications as control-flow graphs before performing these features.
-
-### Specification Exemplified with ECMA Visualizer
+Two tools for exploring the mechanized specification interactively
+([FSE 2025 Demo](https://doi.org/10.1145/3696630.3728579)).
 
 > [!NOTE]
->
-> **A short [introduction video](https://youtu.be/4XMjJPNmuBM) for ECMA Visualizer and Double Debugger is available.**
+> A short [introduction video](https://youtu.be/4XMjJPNmuBM) for both tools is
+> available.
 
 <img width="1150" alt="ecma-visualizer" src="https://github.com/user-attachments/assets/733403f5-03cc-4465-a773-e57d46d35180" />
 
-[**ECMA Visualizer**](https://chromewebstore.google.com/detail/nlfpedidieegejndiikebcgclhggaocd) is a Chrome Extension that helps users understand specifications by displaying rich information alongside the ecma-262 web documentation, collected through pre-fuzzing/measurement using ESMeta. This allows users to see helpful examples directly within the ecma-262 web documents. It provides the following features:
+[**ECMA Visualizer**](https://chromewebstore.google.com/detail/nlfpedidieegejndiikebcgclhggaocd)
+is a Chrome extension that displays information collected by ESMeta alongside the
+ECMA-262 web documentation:
 
-- Viewing minimal JavaScript program that passes through specific algorithm steps or control flow branches (`ReturnIfAbrupt`, denoted as `?`) in the specification
-- Viewing conformance tests (from test262) that pass through selected steps
-- Filtering displayed JS code using callpath
-- One-click debugging capability to execute the displayed minimal JS code, resuming from the selected step
-
-### Interactive Execution with ECMAScript Double Debugger
-
-> [!NOTE]
->
-> **A short [introduction video](https://youtu.be/4XMjJPNmuBM) for ECMA Visualizer and Double Debugger is available.**
-
-**ECMAScript Double Debugger** extends the ECMAScript/JavaScript interpreter in
-ESMeta to help you understand how a JavaScript Program runs according to
-ECMA-262. Currently, it is in an **beta stage** and supports following features:
-
-- Step-by-step execution of ECMA-262 algorithms
-- Line-by-line execution of ECMAScript/JavaScript code
-- Breakpoints by abstract algorithm names in ECMA-262
-- Inspection of ECMA-262 internal states
-- Seeing JavaScript state from the refined ECMA-262 state
-- Step backward, or even trace back to the provenance of specification record
-
-You can access the standalone debugger for the latest official release of specification directly at [es-meta.github.io/playground/](https://es-meta.github.io/playground/). Using this link gives you immediate access without having to install ESMeta, Scala, or any other dependencies on your system.
-
-If needed, you can also set up and run the debugger locally with the following instructions:
-```bash
-# turn on server of the double debugger
-$ esmeta web
-
-# install and turn on the client-side application using NPM
-$ cd client && npm install && npm start
-```
+- Minimal JavaScript programs that reach a specific algorithm step or branch
+- Conformance tests (from Test262) that pass through selected steps
+- Filtering of displayed JS code by call path
+- One-click debugging that resumes from the selected step
 
 <img width="1150" alt="debugger" src="https://github.com/user-attachments/assets/6c5f29a3-6d8a-458d-a4ed-478bb00666d7">
 
-We will enhance it with the following features:
-- Add more debugger features:
-  - Record timestamps during execution for resume & suspend steps (especially for Generator).
-  - ...
-- Show the type of each variable using the type analysis result.
-- Live-edit of `ecma262/spec.html` in the specification viewer.
+The [**ECMAScript Double Debugger**](https://es-meta.github.io/playground/)
+extends the interpreter to show how a JavaScript program runs according to
+ECMA-262: step-by-step execution of ECMA-262 algorithms, line-by-line execution
+of JavaScript code, breakpoints by abstract algorithm name, inspection of
+internal states, and stepping backward to the provenance of a specification
+record.
 
-### Conformance Test Synthesizer from ECMA-262
+> [!TIP]
+> Try the Double Debugger right now at
+> **[es-meta.github.io/playground](https://es-meta.github.io/playground/)** — no
+> installation required.
 
-ESMeta supports the synthesis of JavaScript files as conformance tests. We
-introduced the main concept of the test synthesis in the [ICSE 2021
-paper](https://doi.org/10.1109/ICSE43902.2021.00015) with a tool named
-[JEST](https://github.com/kaist-plrg/jest), a **J**avaScript **E**ngines and
-**S**pecification **T**ester. The test synthesis technique consists of two
-parts: 1) _program synthesis_ of JavaScript programs using **specification
-coverage** and 2) _assertion injection_ based on the mechanized specification
-extract from ECMA-262.
+### Type Analysis
 
-#### Synthesis of JavaScript Programs
+`esmeta tycheck` infers unknown types in the specification by analyzing the
+extracted IR with condition-based type refinement
+([ASE 2021](https://doi.org/10.1109/ASE51524.2021.9678781)). Without an option it
+analyzes the version of ECMA-262 that the `ecma262` submodule points to; use
+`-extract:target` to check another one:
 
-If you want to synthesize JavaScript programs, please use the `fuzz` command:
 ```bash
-esmeta fuzz -fuzz:log
-```
-It basically uses the **node/branch coverage** in the mechanized specification
-to synthesize JavaScript programs. The `-fuzz:log` option dumps the synthesized
-JavaScript programs into the `logs/fuzz/fuzz-<date>` directory with the detailed
-information of the synthesis process:
-
-* `seed`: seed of the random number generator
-* `node-coverage.json`: node coverage information
-* `branch-coverage.json`: branch coverage information
-* `constructor.json`: constructor information
-* `mutation-stat.tsv`: statistics of mutation methods
-* `selector-stat.tsv`: statistics of selector methods
-* `summary.tsv`: summary of the synthesis process for each logging interval
-* `target-conds.json`: target conditions for the synthesis
-* `unreach-funcs`: unreachable functions
-* `version`: ESMeta version information
-
-In addition, you can use **feature-sensitive coverage**, which is introduced in
-the [PLDI 2023 paper](https://doi.org/10.1145/3591240), with the following
-options:
-
-* `-fuzz:k-fs=<int>`: the depth of features for feature-sensitive coverage
-* `-fuzz:cp`: use the call path for feature-sensitive coverage
-
-For example, you can synthesize JavaScript programs with the 2-FCPS coverage
-(2-feature-sensitive coverage with call path) as follows:
-```bash
-esmeta fuzz -fuzz:log -fuzz:k-fs=2 -fuzz:cp
+esmeta tycheck                            # the current submodule version
+esmeta tycheck -extract:target=origin/main
 ```
 
-#### Assertion Injection
+### Conformance Testing
 
-You can inject assertions into the synthesized JavaScript programs according to
-the mechanized specification. If you want to inject assertions, please use the
-`inject` command:
-```bash
-# inject assertions based on the semantics described in ECMA-262
-$ esmeta inject example.js
-# ...
-# ========================================
-#  inject phase
-# ----------------------------------------
-# // [EXIT] normal
-# let x; x ??= class {}; function* f() {}
-#
-# $algo.set(f, "GeneratorDeclaration[0,0].InstantiateGeneratorFunctionObject")
-# $assert.sameValue(Object.getPrototypeOf(f), GeneratorFunction.prototype);
-# $assert.sameValue(Object.isExtensible(f), true);
-# ...
-```
-It prints the assertion-injected JavaScript program without definitions of
-assertions. The comment `// [EXIT] normal` denotes that this program should
-normally terminate. From the fourth line, injected assertions represent the
-expected value stored in variables, objects, or even internal properties.
+`esmeta test262-test` runs the [Test262](https://github.com/tc39/test262)
+conformance suite against the mechanized specification to check that Test262 and
+ECMA-262 agree. Pass paths to restrict the run to specific files or directories:
 
-If you want to dump the assertion-injected code to a program, please use the
-`-inject:out` option. If you want to inject definitions of assertions as well,
-please use the `-inject:defs` option:
 ```bash
-$ esmeta inject example.js -silent -inject:defs -inject:out=test.js
-# - Dumped an assertion-injected ECMAScript program into test.js.
+esmeta test262-test tests/test262/test/language/expressions/addition
 ```
 
-
-### Type Analysis on ECMA-262
-
-ESMeta provides a type analysis on ECMA-262 to infer unknown types in the
-specification. We introduced its main concept in the [ASE 2021
-paper](https://doi.org/10.1109/ASE51524.2021.9678781) with a tool names
-[JSTAR](https://github.com/kaist-plrg/jstar), a **J**avaScript **S**pecification
-**T**ype **A**nalyzer using **R**efinement. It analyzes types of mechanized
-specification by performing type analysis of IRES. We utilized _condition-based
-type refinement_ to prune out infeasible types in each branch for enhanced
-analysis precision.
-
-If you want to perform a type analysis of
-[ES2022](https://262.ecma-international.org/13.0/) (or ES13), the latest
-official version of ECMA-262, please type the following command:
-```bash
-$ esmeta tycheck
-# ...
-# ========================================
-#  tycheck phase
-# ----------------------------------------
-# - 1806 functions are initial targets.
-# - 2372 functions are analyzed in 32493 iterations.
-```
-
-You can perform type analysis on other versions of ECMA-262 with the
-`-extract:target` option. Please enter any git tag/branch names or commit hash
-as an input of the option:
-```bash
-# analyze types for origin/main branch version of ECMA-262
-$ esmeta tycheck -extract:target=origin/main
-
-# analyze types for 2c78e6f commit version of ECMA-262
-$ esmeta tycheck -extract:target=2c78e6f
-```
-
-
-### ~~Meta-Level Static Analyzer for ECMAScript~~
+ESMeta can also synthesize new conformance tests. `esmeta fuzz` synthesizes
+JavaScript programs using node/branch coverage of the mechanized specification
+([ICSE 2021](https://doi.org/10.1109/ICSE43902.2021.00015)), or feature-sensitive
+coverage with `-fuzz:k-fs=<int>` and `-fuzz:cp`
+([PLDI 2023](https://doi.org/10.1145/3591240),
+[TOSEM 2026](https://doi.org/10.1145/3808231)). `esmeta inject` then injects
+assertions derived from the semantics described in ECMA-262, turning synthesized
+programs into conformance tests.
 
 > [!WARNING]
->
-> The meta-level static analyzer is temporarily removed from the current version
-> of ESMeta. We are working on the improvement of the meta-level static analyzer
-> for ECMAScript/JavaScript programs. We will re-introduce this feature in the
-> future version of ESMeta.
+> The meta-level static analyzer (`analyze` command,
+> [ESEC/FSE 2022](https://dl.acm.org/doi/10.1145/3540250.3549097)) is temporarily
+> removed and will be re-introduced in a future version.
 
-ESMeta also supports a meta-level static analyzer for ECMAScript/JavaScript
-programs based on mechanized specifications extracted from ECMA-262. A
-mechanized specification is an interpreter that can parse and execute JavaScript
-programs. We introduced a way to indirectly analyze an ECMAScript/JavaScript
-program by analyzing its interpreter with a restriction with the given program.
-We call it _meta-level static analysis_ and presented this technique at
-[ESEC/FSE 2022](https://dl.acm.org/doi/10.1145/3540250.3549097).
+## Publications
 
-If you want to analyze JavaScript program using a meta-level static analysis,
-please use the `analyze` command:
-```bash
-$ esmeta analyze example.js
-# ...
-# ========================================
-#  analyze phase
-# ----------------------------------------
-# - 108 functions are analyzed in 1688 iterations.
-```
-
-ESMeta supports an interactive Read–eval–print loop (REPL) for the analysis with
-the `-analyze:repl` option:
-```bash
-$ esmeta analyze example.js -analyze:repl
-# ========================================
-#  analyze phase
-# ----------------------------------------
-#
-# command list:
-# - help                     Show help message.
-# ...
-#
-# [1] RunJobs[42]:Call[339] -> {
-#   ...
-# }
-
-analyzer> continue
-# - Static analysis finished. (# iter: 1688)
-
-analyzer> print -expr @REALM.GlobalObject.SubMap.f.Value.SubMap.name.Value
-# "f"
-
-analyzer> exit
-```
-It showed that the property `name` of the global variable `f` points to a single
-string `"f"`.
-
-In the future version of ESMeta, we will add more kind documentation for this
-analyzer REPL.
-
-## Academic Achievement
-
-### Publications
-
-- **[FSE 2025 Demo] JSSpecVis: A JavaScript Language Specification Visualization Tool**
-  ([old repo](https://github.com/ku-plrg/js-spec-vis))
+- **[TOSEM 2026] [Selective Feature-Sensitive Coverage for Conformance Testing of Programming Languages](https://doi.org/10.1145/3808231)**
+- **[FSE 2025 Demo] [JSSpecVis: A JavaScript Language Specification Visualization Tool](https://doi.org/10.1145/3696630.3728579)**
 - **[PLDI 2023] [Feature-Sensitive Coverage for Conformance Testing of Programming Language Implementations](https://doi.org/10.1145/3591240)**
-  ([old repo](https://github.com/jestfs/jestfs))
 - **[ESEC/FSE 2022] [Automatically Deriving JavaScript Static Analyzers from Specifications using Meta-Level Static Analysis](https://doi.org/10.1145/3540250.3549097)**
-  ([old repo](https://github.com/kaist-plrg/jsaver))
 - **[ASE 2021] [JSTAR: JavaScript Specification Type Analyzer using Refinement](https://doi.org/10.1109/ASE51524.2021.9678781)**
-  ([old repo](https://github.com/kaist-plrg/jstar))
 - **[ICSE 2021] [JEST: N+1-version Differential Testing of Both JavaScript Engines](https://doi.org/10.1109/ICSE43902.2021.00015)**
-  ([old repo](https://github.com/kaist-plrg/jest))
 - **[ASE 2020] [JISET: JavaScript IR-based Semantics Extraction Toolchain](https://doi.org/10.1145/3324884.3416632)**
-  ([old repo](https://github.com/kaist-plrg/jiset))
-
-### PLDI 2022 Tutorial
-
-**Title**: **[Filling the gap between the JavaScript language specification and tools using the JISET family](https://pldi22.sigplan.org/details/pldi-2022-tutorials/1/Filling-the-gap-between-the-JavaScript-language-specification-and-tools-using-the-JIS)**
-- Presenters: [Jihyeok Park](https://park.jihyeok.site/), [Seungmin An](https://github.com/h2oche), and [Sukyoung Ryu](https://plrg.kaist.ac.kr/ryu)
-- [Session 1](https://plrg.korea.ac.kr/assets/data/slides/2022/pldi22-tutorial-1.pdf)
-- [Session 2-1](https://plrg.korea.ac.kr/assets/data/slides/2022/pldi22-tutorial-2.pdf)
-- [Session 2-2](https://plrg.korea.ac.kr/assets/data/slides/2022/pldi22-tutorial-3.pdf)
-
-### Communications of the ACM (CACM)
-
-- **Title**: **[JavaScript Language Design and Implementation in Tandem](https://cacm.acm.org/research/javascript-language-design-and-implementation-in-tandem/)**
-  - DOI: [10.1145/3624723](https://doi.org/10.1145/3624723)
-
-See the following video for more details:
-
-<p align="center"><img src="http://img.youtube.com/vi/JGxc-KIUnQY/maxresdefault.jpg" width="500"></p>
-
-- link: [https://youtu.be/JGxc-KIUnQY](https://youtu.be/JGxc-KIUnQY)
+- **[CACM]** [JavaScript Language Design and Implementation in Tandem](https://doi.org/10.1145/3624723) ([video](https://youtu.be/JGxc-KIUnQY))

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
 // ESMeta version
 // NOTE: please update VERSION together in top-level package.scala
-// NOTE: please update version info in the README.md file
+// NOTE: `scripts/release` updates this together with package.scala
 ThisBuild / version := "0.8.1"
 
 // Scala version

--- a/scripts/release
+++ b/scripts/release
@@ -1,223 +1,450 @@
 #!/bin/bash
-# ------------------------------------------------------------------------------
-# PLEASE CAREFULLY USE IT.
-# IT WILL AUTOMATICALLY COMMIT/PUSH AND EVEN PUBLISH DOC PAGES.
-# ------------------------------------------------------------------------------
+# ==============================================================================
+# ESMeta release driver
+#
+# Walks through steps 1-7 of the release process described in the wiki:
+#   https://github.com/es-meta/esmeta/wiki/How-to-Release
+# Every step explains itself and waits for your confirmation ([Y/n/q]).
+# Steps 8-11 need forks and pull requests, so they are printed as manual
+# instructions once step 7 finishes.
+#
+# If any step fails, the script stops WITHOUT rolling anything back, and tells
+# you what has been done and what is left to do by hand.
+#
+# NOTE ON ORDERING: the wiki lists "merge main with dev" (3) before "update the
+# version files" (5), but every released commit shows the opposite: the version
+# bump is committed on `dev` and `main` is then fast-forwarded onto it, so the
+# tip of `main` is always the "Update version" commit. This script follows the
+# actual history and labels each step with its wiki number.
+#
+# Usage: scripts/release <semver>          e.g. scripts/release 0.9.0
+# ==============================================================================
 
-# colors
+set -u
+
+# Never hand output to a pager: this script is a prompt-driven flow and a pager
+# would swallow the terminal while waiting for input.
+export GIT_PAGER=cat
+export PAGER=cat
+
+# ------------------------------------------------------------------------------
+# output helpers
+# ------------------------------------------------------------------------------
 RED='\033[0;31m'
-LRED='\033[1;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+BOLD='\033[1m'
+NC='\033[0m'
 
-# log file
+mkdir -p logs
 LOG=logs/release
-rm -f $LOG
+: >"$LOG"
 
-function log {
-  color=$CYAN
-  if ! [ -z $2 ]; then color=$2; fi
-  dateStr=`date '+%Y-%m-%d %H:%M:%S'`
-  echo -e -n "${color}[$dateStr]${NC} $1... " | tee -a $LOG
+say()  { echo -e "$1" | tee -a "$LOG"; }
+ok()   { say "${GREEN}✓${NC} $1"; }
+warn() { say "${YELLOW}!${NC} $1"; }
+err()  { say "${RED}✗${NC} $1"; }
+rule() { say "${CYAN}------------------------------------------------------------${NC}"; }
+
+# ------------------------------------------------------------------------------
+# step bookkeeping
+# ------------------------------------------------------------------------------
+declare -a COMPLETED=()
+declare -a SKIPPED=()
+STEP_NO=0
+STEP_TITLE=""
+STEP_WIKI=""
+TOTAL=7
+
+begin() { # begin <no> <wiki-no> <title>
+  STEP_NO="$1"; STEP_WIKI="$2"; STEP_TITLE="$3"
+  say ""
+  rule
+  say "${BOLD}[$STEP_NO/$TOTAL] $STEP_TITLE${NC}  ${CYAN}(wiki step $STEP_WIKI)${NC}"
+  rule
 }
 
-function msg {
-  color=$NC
-  if ! [ -z $2 ]; then color=$2; fi
-  echo -e "${color}$1${NC}" | tee -a $LOG
+finish() { COMPLETED+=("$STEP_NO. $STEP_TITLE"); ok "done"; }
+
+skip() { SKIPPED+=("$STEP_NO. $STEP_TITLE"); warn "skipped"; }
+
+# confirm: Enter or y -> run, n -> skip the step, q -> quit early
+confirm() {
+  if [ ! -t 0 ]; then
+    err "This script is interactive; run it from a terminal."
+    exit 1
+  fi
+  local ans
+  while true; do
+    printf "${CYAN}Proceed? [Y/n/q] ${NC}"
+    read -r ans
+    case "$ans" in
+      "" | y | Y) return 0 ;;
+      n | N) skip; return 1 ;;
+      q | Q) say ""; warn "Stopped at your request."; summary; manual_from "$STEP_NO"; exit 0 ;;
+      *) echo "Please answer y (or Enter), n, or q." ;;
+    esac
+  done
 }
 
-function pass {
-  msg "PASS" $GREEN
+summary() {
+  say ""
+  rule
+  say "${BOLD}What has been done${NC}"
+  rule
+  if [ ${#COMPLETED[@]} -eq 0 ]; then
+    say "  (nothing)"
+  else
+    for s in "${COMPLETED[@]}"; do say "  ${GREEN}✓${NC} $s"; done
+  fi
+  if [ ${#SKIPPED[@]} -gt 0 ]; then
+    say ""
+    say "${BOLD}Skipped${NC}"
+    for s in "${SKIPPED[@]}"; do say "  ${YELLOW}-${NC} $s"; done
+  fi
 }
 
-function fail {
-  msg "FAIL" $RED
-}
-
-function error {
-  fail && msg && msg "$1" $RED
-}
-
-function warn {
-  msg "$1" $LRED
-}
-
-function clean {
-  fail
-  (
-    git checkout -- . &&
-    git switch dev
-  ) >/dev/null 2>&1
+# abort <reason>: never rolls back; reports state and what is left
+abort() {
+  say ""
+  err "${BOLD}[$STEP_NO/$TOTAL] $STEP_TITLE failed.${NC}"
+  say "  Reason: $1"
+  summary
+  say ""
+  warn "Nothing was rolled back. The repository is left exactly as it is now,"
+  warn "so you can inspect it, fix the problem, and redo the remaining steps."
+  say "  Current branch : $(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  say "  Working tree   : $(git status --porcelain | wc -l | tr -d ' ') changed file(s)"
+  manual_from "$STEP_NO"
+  say ""
+  say "Full log: $LOG"
   exit 1
 }
 
-function help {
-  log "Usage: $0 <semver>"
-  log
-  log "We use Semantic Versioning 2.0 without pre-release names."
-  log "(Please see https://semver.org.)"
-  exit 1
+# run <description> <command...>
+run() {
+  local desc="$1"; shift
+  say "  \$ $*"
+  if ! "$@" >>"$LOG" 2>&1; then
+    abort "$desc failed. See $LOG for the output."
+  fi
 }
 
+# ------------------------------------------------------------------------------
+# manual instructions (used both on success and on failure)
+# ------------------------------------------------------------------------------
+manual_from() { # manual_from <first-step-still-to-do>
+  local from="$1"
+  say ""
+  rule
+  say "${BOLD}Remaining work${NC}"
+  rule
+  [ "$from" -le 1 ] && say "  1. Rebase \`dev\` onto \`main\`:  git switch dev && git rebase main"
+  [ "$from" -le 2 ] && say "  2. Check that CI is green: https://github.com/es-meta/esmeta/actions"
+  [ "$from" -le 3 ] && say "  3. Update .mailmap for new contributors, then commit it."
+  [ "$from" -le 4 ] && say "  4. Set the version to $VERSION in build.sbt and src/main/scala/esmeta/package.scala, run \`sbt release\` and \`sbt test\`, then commit."
+  [ "$from" -le 5 ] && say "  5. Merge into main:  git switch main && git merge --ff-only dev"
+  [ "$from" -le 6 ] && say "  6. Push and tag:  git push origin dev && git push origin main && git tag $TAG_NAME && git push origin $TAG_NAME"
+  [ "$from" -le 7 ] && say "  7. Publish the ScalaDoc:  sbt ghpagesPushSite"
+  manual_tail
+}
+
+manual_tail() {
+  say ""
+  rule
+  say "${BOLD}Steps 8-11 and the downstream CI updates are always manual${NC}"
+  rule
+  say ""
+  say "${BOLD} 8-10. Create the GitHub release${NC}"
+  say "    https://github.com/es-meta/esmeta/releases/new?tag=$TAG_NAME"
+  say "     8. Choose the new tag $TAG_NAME."
+  say "     9. Click \"Generate release notes\"."
+  say "    10. Append the contributor list:"
+  say ""
+  say "        ## Contributors"
+  say ""
+  say "        The following list is automatically generated by \`git shortlog -sn --no-merges $PREV_TAG..$TAG_NAME\`:"
+  say "        \`\`\`"
+  if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+    git --no-pager shortlog -sn --no-merges "$PREV_TAG..$TAG_NAME" 2>/dev/null |
+      sed 's/^/        /' | tee -a "$LOG"
+  else
+    say "        (run the command above once the tag $TAG_NAME exists)"
+  fi
+  say "        \`\`\`"
+  say ""
+  say "${BOLD}11. Update the website${NC}"
+  say "    Copy README.md into index.md of es-meta/es-meta.github.io."
+  say ""
+  say "${BOLD}Update CI in tc39/ecma262${NC}"
+  say "    In your fork, on a new branch:"
+  say "    - .github/workflows/esmeta-installer/action.yml"
+  say "        # $TAG_NAME"
+  say "        echo \"ESMETA_VERSION=$TAG_COMMIT\" >> \$GITHUB_ENV"
+  say "    - regenerate the ignore file:"
+  say "        esmeta tycheck -tycheck:log -tycheck:ignore=esmeta-ignore.json -tycheck:update-ignore"
+  say "    - commit, push, and open a pull request."
+  say ""
+  say "${BOLD}Update CI in tc39/test262${NC}"
+  say "    In your fork, on a new branch:"
+  say "    - .github/workflows/esmeta-test262.yml"
+  say "        git clone --branch $TAG_NAME --depth 1 https://github.com/es-meta/esmeta.git \"\${ESMETA_HOME}\""
+  say "    - commit, push, and open a pull request."
+}
+
+# ------------------------------------------------------------------------------
+# argument and pre-flight checks
+# ------------------------------------------------------------------------------
 if [ "$#" -ne 1 ]; then
-  help
+  echo "Usage: $0 <semver>"
+  echo ""
+  echo "We use Semantic Versioning 2.0 without pre-release names (https://semver.org)."
+  echo "Example: $0 0.9.0"
+  exit 1
 fi
 
-VERSION=$1
+VERSION="$1"
 TAG_NAME="v$VERSION"
-SEM_VER_PATTERN='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
-REGEX='^(0|[1-9]\d*)\.(0|[1-9]\d*).(0|[1-9]\d*)$'
+# NOTE: bash uses POSIX ERE, which has no \d. Use [0-9] so that versions with
+# multi-digit components (0.10.0) are accepted.
+SEM_VER='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+TAG_COMMIT="<commit of $TAG_NAME>"
 
-log "Checking version name"
-if ! [[ "$VERSION" =~ $REGEX ]]; then
-  error "Invalid version name: ${LRED}$VERSION"
+say "${BOLD}ESMeta release $TAG_NAME${NC}"
+say ""
+say "This walks through steps 1-7 of the release wiki, asking before each one."
+say "Answer Enter or y to run a step, n to skip it, q to stop."
+say ""
+
+rule
+say "${BOLD}[0/$TOTAL] Pre-flight checks${NC}"
+rule
+
+if ! [[ "$VERSION" =~ $SEM_VER ]]; then
+  err "Invalid version name: $VERSION"
   exit 1
 fi
-pass
+ok "version name $VERSION"
 
-log "Fetching git"
-git fetch >/dev/null 2>&1 && pass || clean
+for tool in git sbt java; do
+  command -v "$tool" >/dev/null 2>&1 || { err "\`$tool\` is not installed."; exit 1; }
+done
+ok "git, sbt, and java are available"
 
-log "Checking tag name"
-if git rev-parse $TAG_NAME >/dev/null 2>&1; then
-  error "Already existed tag/branch name: ${LRED}$TAG_NAME"
+[ -n "${ESMETA_HOME:-}" ] || { err "ESMETA_HOME is not set."; exit 1; }
+ok "ESMETA_HOME=$ESMETA_HOME"
+
+if ! git fetch --tags origin >/dev/null 2>&1; then
+  err "Failed to fetch from origin."
   exit 1
 fi
-pass
+ok "fetched origin"
 
-log "Checking git status"
+if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+  err "Tag or branch $TAG_NAME already exists."
+  exit 1
+fi
+ok "$TAG_NAME does not exist yet"
+
 git update-index --refresh >/dev/null 2>&1
-if ! git diff-index --quiet HEAD -- >/dev/null 2>&1; then
-  error "Please remove all staged (M/D) or untracked(??) files:"
-  warn
-  warn "`git status --porcelain=v1 >/dev/null 2>&1`"
-  warn
+if [ -n "$(git status --porcelain)" ]; then
+  err "The working tree is not clean. Please commit or stash these first:"
+  git status --short | sed 's/^/    /' | tee -a "$LOG"
   exit 1
 fi
-pass
+ok "working tree is clean"
 
-log "Updating \`dev\` branch"
-(
-  git switch dev &&
-  git pull origin dev
-) >/dev/null 2>&1 && pass || clean
-
-log "Checking \`dev\` branch"
-DEV_HASH=`git rev-parse dev`
-ORIGIN_DEV_HASH=`git rev-parse origin/dev`
-if [ "$DEV_HASH" != "$ORIGIN_DEV_HASH" ]; then
-  error "The \`dev\` branch is not same with \`origin/dev\`:"
-  warn
-  warn "- dev       : $DEV_HASH"
-  warn "- origin/dev: $ORIGIN_DEV_HASH"
-  warn
-  exit 1
+PREV_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo '')"
+if [ -n "$PREV_TAG" ]; then
+  ok "previous release: $PREV_TAG"
+else
+  PREV_TAG="<previous tag>"
+  warn "no previous tag found"
 fi
-pass
 
-log "Checking whether \`main\` is an ancestor of \`dev\`"
-if ! git merge-base --is-ancestor origin/main dev; then
-  error "Please rebase \`dev\` into \`main\`:"
-  warn
-  warn "    $ git rebase main" $LRED
-  warn
-  exit 1
+# ------------------------------------------------------------------------------
+# 1. (wiki 1) rebase dev onto main
+# ------------------------------------------------------------------------------
+begin 1 1 "Rebase \`dev\` onto \`main\`"
+say "The release is cut from \`dev\`, so \`main\` must be an ancestor of it."
+say "Switches to \`dev\`, pulls it, and rebases onto \`main\` if needed."
+if confirm; then
+  run "switching to dev" git switch dev
+  run "pulling dev" git pull --ff-only origin dev
+  run "pulling main" git fetch origin main:main
+  if git merge-base --is-ancestor main dev; then
+    ok "\`main\` is already an ancestor of \`dev\`; nothing to rebase"
+  else
+    warn "\`main\` is not an ancestor of \`dev\`; rebasing"
+    run "rebasing dev onto main" git rebase main
+  fi
+  finish
 fi
-pass
 
-log "Updating \`build.sbt\`"
-(
-  sed -i '' -r -e 's/version := "[^ ]+"/version := "'$VERSION'"/' build.sbt
-) >/dev/null 2>&1 && pass || clean
-
-log "Updating \`package.json\`"
-(
-  sed -i '' -r -e 's/VERSION = "[^ ]+"/VERSION = "'$VERSION'"/' src/main/scala/esmeta/package.scala &&
-  pass
-) >/dev/null 2>&1 && pass || clean
-
-log "Updating \`README.md\`"
-(
-  sed -i '' -r -e 's/ESMeta v[^ ]+/ESMeta '$TAG_NAME'/' README.md &&
-  pass
-) >/dev/null 2>&1 && pass || clean
-
-log "Updating binary file using \`sbt release\`"
-(
-  sbt release
-) >/dev/null 2>&1 && pass || clean
-
-log "Testing using \`sbt test\`"
-(
-  sbt test
-) >/dev/null 2>&1 && pass || clean
-
-log "Adding commit to \`dev\`"
-(
-  git add build.sbt src/main/scala/esmeta/package.scala README.md &&
-  git commit -m 'Updated version'
-) >/dev/null 2>&1 && pass || clean
-
-log "Checking \`main\` branch"
-(
-  git switch main &&
-  git pull origin main
-) >/dev/null 2>&1 || clean
-MAIN_HASH=`git rev-parse main`
-ORIGIN_MAIN_HASH=`git rev-parse origin/main`
-if [ "$MAIN_HASH" != "$ORIGIN_MAIN_HASH" ]; then
-  error "The \`main\` branch is not same with \`origin/main\`:"
-  warn
-  warn "- main       : $MAIN_HASH"
-  warn "- origin/main: $ORIGIN_MAIN_HASH"
-  warn
-  exit 1
+# ------------------------------------------------------------------------------
+# 2. (wiki 2) check CI
+# ------------------------------------------------------------------------------
+begin 2 2 "Check that the CI is green"
+say "All GitHub Actions runs for \`dev\` must pass before releasing."
+say "Also make sure \`esmeta test262-test\` passed on the full suite."
+if confirm; then
+  if command -v gh >/dev/null 2>&1; then
+    say ""
+    if ci_runs="$(gh run list --repo es-meta/esmeta --branch dev --limit 5 2>&1)"; then
+      say "$ci_runs"
+    else
+      warn "Could not query GitHub Actions; check the page manually."
+    fi
+    say ""
+  fi
+  say "  https://github.com/es-meta/esmeta/actions"
+  printf "${CYAN}Is everything green (including test262-test)? [Y/n] ${NC}"
+  read -r ci_ans
+  case "$ci_ans" in
+    "" | y | Y) finish ;;
+    *) abort "CI is not green yet. Fix the failures and start again." ;;
+  esac
 fi
-pass
 
-log "Merging \`main\` to \`dev\`"
-(
-  git switch main &&
-  git pull origin main &&
-  git merge dev
-) >/dev/null 2>&1 && pass || clean
-
-echo
-echo -n "Do you want to publish ESMeta $TAG_NAME to the remote server? (y/n) "
-read PUBLISH
-if [ "$PUBLISH" != "y" ] && [ "$PUBLISH" != "" ]; then
-  log "Rollback \`dev\` and \`main\` branches "
-  (
-    git switch main &&
-    git reset --hard origin/main &&
-    git switch dev &&
-    git reset --hard origin/dev
-  ) >/dev/null 2>&1 && pass || clean
-  exit 1
+# ------------------------------------------------------------------------------
+# 3. (wiki 4) update .mailmap
+# ------------------------------------------------------------------------------
+begin 3 4 "Update \`.mailmap\` for new contributors"
+say "Contributors since $PREV_TAG:"
+say ""
+git --no-pager shortlog -sne "$PREV_TAG..dev" 2>/dev/null | sed 's/^/    /' | tee -a "$LOG"
+say ""
+say "If any name or address above is missing from .mailmap, edit it now in"
+say "another terminal. This step commits .mailmap if you changed it."
+if confirm; then
+  if [ -n "$(git status --porcelain .mailmap)" ]; then
+    run "staging .mailmap" git add .mailmap
+    run "committing .mailmap" git commit -m "Update .mailmap"
+    ok ".mailmap committed"
+  else
+    ok ".mailmap unchanged; nothing to commit"
+  fi
+  finish
 fi
-msg
 
-log "Pushing \`dev\` to \`origin/dev\`"
-(
-  git switch dev &&
-  git push origin dev
-) >/dev/null 2>&1 && pass || clean
+# ------------------------------------------------------------------------------
+# 4. (wiki 5) bump the version, rebuild, test, and commit
+# ------------------------------------------------------------------------------
+begin 4 5 "Set the version to $VERSION, rebuild, and test"
+say "Updates:"
+say "  - build.sbt                          version := \"$VERSION\""
+say "  - src/main/scala/esmeta/package.scala VERSION = \"$VERSION\""
+say "Then runs \`sbt release\` (format, assembly, and .completion) and \`sbt test\`."
+say "\`sbt release\` regenerates .completion, which is tracked, so it is committed too."
+say "This takes several minutes."
+if confirm; then
+  if [ "$(uname)" = "Darwin" ]; then SED_INPLACE=(-i '') ; else SED_INPLACE=(-i) ; fi
 
-log "Pushing \`main\` to \`origin/main\`"
-(
-  git switch main &&
-  git push origin main
-) >/dev/null 2>&1 && pass || clean
+  run "updating build.sbt" \
+    sed "${SED_INPLACE[@]}" -E "s/version := \"[^\"]+\"/version := \"$VERSION\"/" build.sbt
+  grep -q "version := \"$VERSION\"" build.sbt || abort "build.sbt was not updated."
+  ok "build.sbt"
 
-log "Creating tag \`$TAG_NAME\`"
-(
-  git tag $TAG_NAME &&
-  git push --tag origin $TAG_NAME
-) >/dev/null 2>&1 && pass || clean
+  run "updating package.scala" \
+    sed "${SED_INPLACE[@]}" -E "s/VERSION = \"[^\"]+\"/VERSION = \"$VERSION\"/" \
+    src/main/scala/esmeta/package.scala
+  grep -q "VERSION = \"$VERSION\"" src/main/scala/esmeta/package.scala || \
+    abort "package.scala was not updated."
+  ok "package.scala"
 
-log "Updating \`gh-pages\`"
-(
-  sbt ghpagesPushSite
-) >/dev/null 2>&1 && pass || clean
+  # The README no longer prints a version string; update it only if it does.
+  if grep -q "ESMeta v[0-9]" README.md; then
+    run "updating README.md" \
+      sed "${SED_INPLACE[@]}" -E "s/ESMeta v[0-9][^ ]*/ESMeta $TAG_NAME/" README.md
+    ok "README.md"
+  else
+    ok "README.md carries no version string; left untouched"
+  fi
+
+  say "  running \`sbt release\` (this takes a while)..."
+  run "sbt release" sbt release
+  ok "sbt release"
+
+  say "  running \`sbt test\`..."
+  run "sbt test" sbt test
+  ok "sbt test"
+
+  say ""
+  say "Files to be committed:"
+  git status --short | sed 's/^/    /' | tee -a "$LOG"
+  say ""
+  printf "${CYAN}Commit these as \"Update version\"? [Y/n] ${NC}"
+  read -r commit_ans
+  case "$commit_ans" in
+    "" | y | Y)
+      run "staging the version bump" git add -A
+      run "committing the version bump" git commit -m "Update version"
+      finish
+      ;;
+    *) abort "You declined the commit. The files above are still modified." ;;
+  esac
+fi
+
+# ------------------------------------------------------------------------------
+# 5. (wiki 3) merge dev into main
+# ------------------------------------------------------------------------------
+begin 5 3 "Fast-forward \`main\` to \`dev\`"
+say "\`main\` always points at the \"Update version\" commit of the latest release,"
+say "so this must be a fast-forward. If it is not, \`dev\` was not rebased properly."
+if confirm; then
+  run "switching to main" git switch main
+  run "pulling main" git pull --ff-only origin main
+  if ! git merge --ff-only dev >>"$LOG" 2>&1; then
+    run "switching back to dev" git switch dev
+    abort "\`main\` cannot be fast-forwarded to \`dev\`. Rebase \`dev\` onto \`main\` and retry from step 1."
+  fi
+  ok "main is now at $(git rev-parse --short main)"
+  finish
+fi
+
+# ------------------------------------------------------------------------------
+# 6. (wiki 6) push and tag
+# ------------------------------------------------------------------------------
+begin 6 6 "Push \`dev\` and \`main\`, then create the tag $TAG_NAME"
+say "${YELLOW}This is the first step that changes the remote repository.${NC}"
+say "It pushes:"
+say "  dev  -> origin/dev   ($(git rev-parse --short dev))"
+say "  main -> origin/main  ($(git rev-parse --short main))"
+say "and creates the tag $TAG_NAME on \`main\`."
+if confirm; then
+  run "pushing dev" git push origin dev
+  ok "pushed dev"
+  run "pushing main" git push origin main
+  ok "pushed main"
+  run "creating the tag" git tag "$TAG_NAME" main
+  run "pushing the tag" git push origin "$TAG_NAME"
+  ok "pushed $TAG_NAME"
+  TAG_COMMIT="$(git rev-parse "$TAG_NAME")"
+  finish
+fi
+
+# ------------------------------------------------------------------------------
+# 7. (wiki 7) publish the ScalaDoc
+# ------------------------------------------------------------------------------
+begin 7 7 "Publish the ScalaDoc to gh-pages"
+say "Runs \`sbt ghpagesPushSite\`, which pushes to the gh-pages branch."
+if confirm; then
+  run "sbt ghpagesPushSite" sbt ghpagesPushSite
+  finish
+fi
+
+# ------------------------------------------------------------------------------
+# done
+# ------------------------------------------------------------------------------
+[ "$TAG_COMMIT" = "<commit of $TAG_NAME>" ] && \
+  TAG_COMMIT="$(git rev-parse "$TAG_NAME" 2>/dev/null || echo "<commit of $TAG_NAME>")"
+
+say ""
+rule
+say "${GREEN}${BOLD}Steps 1-7 finished for $TAG_NAME.${NC}"
+rule
+summary
+manual_tail
+say ""
+say "Full log: $LOG"


### PR DESCRIPTION
## README

473 → 170 lines. Drops the table of contents, the sample output dumps, the analyzer REPL walkthrough, the fuzz log listing, and the PLDI 2022 slides. Adds descriptions for the extract/compile/build-cfg pipeline and `test262-test`, links each feature to its paper, adds the TOSEM 2026 paper and the missing FSE 2025 Demo link, and removes the `$` prompt from code blocks so they can be copied as-is.

## `scripts/release`

Untouched since 2022 (#128) and covering only part of the release wiki. It now drives steps 1-7 interactively — each step explains itself and waits for `[Y/n/q]` — and prints steps 8-11 as manual instructions. On failure it leaves the repository alone and reports how far it got, instead of running `git checkout -- .`.

Fixes: the version regex rejected multi-digit components (`0.10.0`); the unclean-tree message was always empty; the regenerated `.completion` was never staged; the README `sed` step had become a no-op; `logs/` was assumed to exist; `sed -i ''` was BSD-only.

Publishing steps (`sbt release`, push, tag, `ghpagesPushSite`) were reviewed only — everything else was exercised in a throwaway clone.