### PR TITLE
Parse hashbang comments in Script and Module

### DIFF
--- a/src/main/resources/manuals/test262/supported-features.json
+++ b/src/main/resources/manuals/test262/supported-features.json
@@ -99,6 +99,7 @@
   "for-of",
   "generators",
   "globalThis",
+  "hashbang",
   "import.meta",
   "iterator-helpers",
   "iterator-sequencing",

--- a/src/main/scala/esmeta/parser/ESParser.scala
+++ b/src/main/scala/esmeta/parser/ESParser.scala
@@ -63,8 +63,22 @@ case class ESParser(
         if (name == "CoalesceExpressionHead") handleLR
         else getParser(prod)
       else (args: List[Boolean]) => nt(name, lexers(name, 0 /* TODO args */ ))
-    name -> parser
+    // `InputElementHashbangOrRegExp` is the goal symbol only for the first
+    // token of a Script or a Module; other goals must keep rejecting `#!`.
+    val goalParser =
+      if (name == "Script" || name == "Module")
+        (args: List[Boolean]) => hashbang ~> parser(args)
+      else parser
+    name -> goalParser
   }).toMap
+
+  /** optional `HashbangComment`, matched before `Skip` so that anything in
+    * front of `#!` fails
+    */
+  private lazy val hashbang: LAParser[String] = new LAParser(
+    _ => getLexer("HashbangComment", Nil) | success(""),
+    emptyFirst,
+  )
 
   /** recursively update the filename in the location information of the AST */
   def updateFilename(ast: Ast, name: String): Unit =

--- a/src/main/scala/esmeta/parser/ESParser.scala
+++ b/src/main/scala/esmeta/parser/ESParser.scala
@@ -76,7 +76,7 @@ case class ESParser(
     * front of `#!` fails
     */
   private lazy val hashbang: LAParser[String] = new LAParser(
-    _ => getLexer("HashbangComment", Nil) | success(""),
+    _ => opt(getLexer("HashbangComment", Nil)) ^^ { _.getOrElse("") },
     emptyFirst,
   )
 


### PR DESCRIPTION
`HashbangComment` is extracted as a lexical production but was never referenced, so any source starting with `#!` failed to parse. Given `hb.js`:

```js
#!/usr/bin/env node
var x = 1;
```

```bash
esmeta eval hb.js
```

| | `dev` | this PR |
| --- | --- | --- |
| `hb.js` above | `RuntimeException: No result when parsing failed` | evaluates, `x` is `1` |
| whitespace or a comment before `#!` | parse error | parse error |
| `Function('#!\n_')` | `SyntaxError` | `SyntaxError` |

Attached as an optional prefix to the `Script` and `Module` goals, where `InputElementHashbangOrRegExp` is the goal symbol, and matched before `Skip`. A dynamic function body is parsed under its own goal, so it still rejects `#!`.

test262: 28,305 -> 28,309 passing, no failures. `hashbang` is added to `supported-features.json`.

The other 25 tests in `language/comments/hashbang` are filtered as `negative` or `non-strict` and never run; 24 check out by hand. The exception, `escaped-hashbang.js` (`\u0023\u0021`), parses on `dev` too — that restriction is an early error (#371).
