### PR TITLE
Fix soundness of the type domains

### DIFF
--- a/src/main/resources/manuals/tycheck-ignore.json
+++ b/src/main/resources/manuals/tycheck-ignore.json
@@ -9,6 +9,7 @@
   "FunctionBody[0,0].EvaluateFunctionBody",
   "FunctionDeclarationInstantiation",
   "GetViewByteLength",
+  "LocalTime",
   "MakeFullYear",
   "Record[SourceTextModuleRecord].ExecuteModule",
   "TypedArrayLength"

--- a/src/main/scala/esmeta/ty/AstTy.scala
+++ b/src/main/scala/esmeta/ty/AstTy.scala
@@ -52,10 +52,10 @@ enum AstTy extends TyElem with Lattice[AstTy] {
     else if (this <= that) this
     else if (that <= this) that
     else
-      (this.names, that.names) match
-        case (Inf, _)           => that
-        case (_, Inf)           => this
-        case (Fin(ls), Fin(rs)) => Simple(ls intersect rs)
+      (this, that) match
+        case (_: Detail, _: Detail) => Bot
+        // a chain production has several types, so an AST can be in both
+        case _ => this
 
   /** prune type */
   def --(that: => AstTy): AstTy =

--- a/src/main/scala/esmeta/ty/IntTy.scala
+++ b/src/main/scala/esmeta/ty/IntTy.scala
@@ -65,9 +65,10 @@ sealed trait IntTy extends TyElem with Lattice[IntTy] {
     case (IntSignTy(lsign), IntSignTy(rsign)) => IntSignTy(lsign * rsign)
     case (l, r)                               => l.toSignTy * r.toSignTy
 
-  def /(that: => IntTy): IntTy = (this, that) match
-    case (l @ IntSetTy(_), r @ IntSetTy(_)) if single(l, r, _ / _) != Top =>
-      single(l, r, _ / _)
+  def /(that: => IntTy): IntTy = (this.canon, that.canon) match
+    case (l, r) if l.isBottom || r.isBottom => Bot
+    case (IntSetTy(lset), IntSetTy(rset)) =>
+      IntSetTy(for { l <- lset; r <- rset if r != 0 } yield l / r)
     case (IntSignTy(lsign), IntSignTy(rsign)) => IntSignTy(lsign / rsign)
     case (l, r)                               => l.toSignTy / r.toSignTy
 

--- a/src/main/scala/esmeta/ty/MapTy.scala
+++ b/src/main/scala/esmeta/ty/MapTy.scala
@@ -65,9 +65,12 @@ enum MapTy extends TyElem with Lattice[MapTy] {
   /** normalized type */
   def normalized: MapTy = this match
     case Elem(key, value) if key.isTop && value.isTop       => Top
-    case Elem(key, value) if key.isBottom || value.isBottom => Bot
+    case Elem(key, value) if key.isBottom || value.isBottom => Empty
     case _                                                  => this
 }
 object MapTy extends Parser.From(Parser.mapTy) {
   def apply(key: ValueTy, value: ValueTy): MapTy = Elem(key, value).normalized
+
+  /** the type of the empty map */
+  lazy val Empty: MapTy = Elem(ValueTy.Bot, ValueTy.Bot)
 }

--- a/src/main/scala/esmeta/ty/NumberTy.scala
+++ b/src/main/scala/esmeta/ty/NumberTy.scala
@@ -69,32 +69,83 @@ case class NumberTy(finite: FinNumberTy, inf: InfinityTy, nan: Boolean)
   def -(that: NumberTy): NumberTy = arith(that, _ - _, _ - _)
 
   /** multiplication */
-  def *(that: NumberTy): NumberTy = arith(that, _ * _, _ * _)
+  def *(that: NumberTy): NumberTy = arith(that, _ * _, _ * _, true)
 
-  /** division */
-  def /(that: NumberTy): NumberTy = arith(that, _ / _, _ / _)
+  /** the sign of the type, counting its infinities */
+  private def extSign: Sign =
+    finite.canon.toSign || Sign(inf.contains(false), false, inf.contains(true))
 
-  /** An operand that may be an infinity makes any infinity possible, and an
-    * indeterminate form such as `∞ - ∞` produces *NaN*.
-    *
-    * TODO this does not model an overflow of the finite part to an infinity.
+  /** division, which does not preserve integrality */
+  def /(that: NumberTy): NumberTy =
+    if (this.isBottom || that.isBottom) Bot
+    else
+      val l = this.finite.canon
+      val r = that.finite.canon
+      val lSign = l.toSign
+      val rSign = r.toSign
+      val lInf = !this.inf.isBottom
+      val rInf = !that.inf.isBottom
+      val resNaN =
+        this.nan || that.nan || (lInf && rInf) || (lSign.zero && rSign.zero)
+      // a nonzero integral divisor never makes the quotient larger
+      val mayOverflow = r match
+        case FinNumberIntTy(_) => rSign.zero
+        case _                 => !r.isBottom
+      val nonZeroDividend = lSign.neg || lSign.pos || lInf
+      val resInf =
+        // a zero divisor gives both infinities, since *+0* and *-0* are one sign
+        if (rSign.zero && nonZeroDividend) InfinityTy.Top
+        else if (lInf || (!l.isBottom && mayOverflow))
+          NumberTy.infOfSign(this.extSign / that.extSign)
+        else InfinityTy.Bot
+      // a dividend over an infinity, and a quotient that underflows, give zero
+      val quotient =
+        if (!l.isBottom && (rInf || !r.isBottom)) (lSign / rSign) || Sign.Zero
+        else lSign / rSign
+      NumberTy(FinNumberSignTy(quotient), resInf, resNaN)
+
+  /** An infinite operand makes an infinity possible, an indeterminate form such
+    * as `inf - inf` gives *NaN*, and two finite operands can still overflow.
     */
   private def arith(
     that: NumberTy,
     intOp: (IntTy, IntTy) => IntTy,
     signOp: (Sign, Sign) => Sign,
+    zeroTimesInf: Boolean = false,
   ): NumberTy =
     if (this.isBottom || that.isBottom) Bot
     else
-      val bothFinite = this.inf.isBottom && that.inf.isBottom
-      val resInf = if (bothFinite) InfinityTy.Bot else InfinityTy.Top
+      val lSign = this.finite.canon.toSign
+      val rSign = that.finite.canon.toSign
+      // an infinity survives a multiplication only against a nonzero factor
+      val fromInf =
+        if (!zeroTimesInf) !this.inf.isBottom || !that.inf.isBottom
+        else
+          (!this.inf.isBottom && (!that.inf.isBottom || rSign.neg || rSign.pos)) ||
+          (!that.inf.isBottom && (!this.inf.isBottom || lSign.neg || lSign.pos))
       val resNaN =
-        nan || that.nan || (!this.inf.isBottom && !that.inf.isBottom)
+        nan || that.nan || (!this.inf.isBottom && !that.inf.isBottom) ||
+        (zeroTimesInf && ((!this.inf.isBottom && rSign.zero) ||
+        (!that.inf.isBottom && lSign.zero)))
+      lazy val resInf = NumberTy.infOfSign(signOp(this.extSign, that.extSign))
+      def infOf(overflow: Boolean): InfinityTy =
+        if (fromInf || overflow) resInf else InfinityTy.Bot
       (this.finite.canon, that.finite.canon) match
-        case (FinNumberIntTy(l), FinNumberIntTy(r)) =>
-          NumberTy(FinNumberIntTy(intOp(l, r)), resInf, resNaN)
+        // a double represents an integer exactly only up to 2^53
+        case (FinNumberIntTy(l), FinNumberIntTy(r)) if exactInts(intOp(l, r)) =>
+          NumberTy(FinNumberIntTy(intOp(l, r)), infOf(false), resNaN)
         case (l, r) =>
-          NumberTy(FinNumberSignTy(signOp(l.toSign, r.toSign)), resInf, resNaN)
+          val bothFin = !l.isBottom && !r.isBottom
+          // a product of two finite values can underflow to a zero
+          val sign = signOp(l.toSign, r.toSign)
+          NumberTy(
+            FinNumberSignTy(
+              if (zeroTimesInf && bothFin) sign || Sign.Zero
+              else sign,
+            ),
+            infOf(bothFin),
+            resNaN,
+          )
 
   /** non-negative integral check */
   def isNonNegInt: Boolean = isInt && finite.toIntTy.isNonNeg
@@ -282,6 +333,17 @@ object FinNumberTy {
 }
 
 object NumberTy extends Parser.From(Parser.numberTy) {
+
+  def exactInts(ty: IntTy): Boolean = ty.canon match
+    case IntSetTy(set) => set.forall(_.abs <= maxExactInt)
+    case _             => false
+
+  def infOfSign(sign: Sign): InfinityTy = InfinityTy(
+    (if (sign.pos) Set(true) else Set()) ++ (if (sign.neg) Set(false)
+                                             else Set()),
+  )
+
+  lazy val maxExactInt: scala.math.BigInt = scala.math.BigInt(2).pow(53)
 
   /** Constants do not include NaN as default except Top. An infinity is a
     * Number, so a type described by a sign includes the infinity of that sign,

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -374,7 +374,7 @@ case object ValueTopTy extends ValueTy {
   def cont: BSet[Int] = Inf
   def record: RecordTy = RecordTy.Top
   def map: MapTy = MapTy.Top
-  def list: ListTy = ListTy.Bot // unsound but need to remove cycle
+  def list: ListTy = ListTy.Top
   def ast: AstTy = AstTy.Top
   def grammarSymbol: BSet[GrammarSymbol] = Inf
   def codeUnit: Boolean = true

--- a/src/test/scala/esmeta/analyzer/TransferSmallTest.scala
+++ b/src/test/scala/esmeta/analyzer/TransferSmallTest.scala
@@ -1,0 +1,112 @@
+package esmeta.analyzer
+
+import esmeta.interpreter.Interpreter
+import esmeta.ir.{UOp, COp}
+import esmeta.state.*
+import esmeta.ty.*
+
+/** transfer function test
+  *
+  * The lattice operations are covered by the `ty` tests; this checks that the
+  * unary transfer functions over-approximate what the interpreter computes.
+  */
+class TransferSmallTest extends AnalyzerTest {
+  val name: String = "analyzerTransferTest"
+
+  private val checker = AnalyzerTest.tychecker
+  import checker.{AbsValue, AbsState}
+  private given AbsState = AbsState.Empty
+
+  /** concrete witnesses, including the boundary values that the numeric domains
+    * have had bugs on
+    */
+  private val maths = List[BigDecimal](-3, -2.5, -1, -0.5, 0, 0.5, 1, 2.5, 3)
+    .map(Math(_))
+  private val numbers = List(
+    Double.NegativeInfinity,
+    -2.5,
+    -1.0,
+    -0.0,
+    0.0,
+    1.0,
+    2.5,
+    Double.PositiveInfinity,
+    Double.NaN,
+  ).map(Number(_))
+  private val values: List[Value] = maths ++ numbers ++ List(
+    Infinity(true),
+    Infinity(false),
+    BigInt(7),
+  )
+
+  /** the type of a single concrete value, so that a witness can be lifted into
+    * the abstract domain without going through the analyzer
+    */
+  private def tyOf(v: Value): ValueTy = v match
+    case m: Math     => MathT(m.decimal)
+    case n: Number   => NumberT(n)
+    case Infinity(p) => if (p) InfinityT(true) else InfinityT(false)
+    case BigInt(_)   => BigIntT
+    case _           => AnyT
+
+  private val tys: List[ValueTy] = List(
+    MathT,
+    ValueTy(math = MathTy.Int),
+    ValueTy(math = MathTy.Pos),
+    ValueTy(math = MathTy.Neg),
+    ValueTy(math = MathTy.NonNeg),
+    NumberT,
+    ValueTy(number = NumberTy.Int),
+    ValueTy(number = NumberTy.Pos),
+    ValueTy(number = NumberTy.Neg),
+    ValueTy(number = NumberTy.NaN),
+    ValueTy(number = NumberTy.Infinite),
+    InfinityT,
+    BigIntT,
+  ) ++ values.map(tyOf)
+
+  /** Check that an abstract unary operation holds every value the interpreter
+    * can produce from a value the operand holds.
+    */
+  private def checkUnary(
+    desc: String,
+    abs: AbsValue => AbsValue,
+    con: Value => Option[Value],
+  ): Unit =
+    val violations = for {
+      ty <- tys
+      res = abs(AbsValue(ty)).ty
+      v <- values if ty.contains(v, Heap())
+      w <- con(v)
+      if !res.contains(w, Heap())
+    } yield s"$v -> $w is missing from $desc($ty) = $res"
+    check(desc) {
+      if (violations.nonEmpty) {
+        println(s"[FAILED] $desc: ${violations.size} violation(s)")
+        violations.distinct.take(10).foreach(v => println(s"- $v"))
+        assert(violations.isEmpty)
+      }
+    }
+
+  private def opt(f: => Value): Option[Value] =
+    try Some(f)
+    catch case _: Throwable => None
+
+  // registration
+  def init: Unit = {
+    checkUnary("negation", -_, v => opt(Interpreter.eval(UOp.Neg, v)))
+    checkUnary("bitwise negation", ~_, v => opt(Interpreter.eval(UOp.BNot, v)))
+    checkUnary(
+      "absolute",
+      _.abs,
+      { case m: Math => Some(Interpreter.abs(m)); case _ => None },
+    )
+    checkUnary(
+      "floor",
+      _.floor,
+      { case m: Math => Some(Interpreter.floor(m)); case _ => None },
+    )
+  }
+
+  init
+}

--- a/src/test/scala/esmeta/ty/LatticeTinyTest.scala
+++ b/src/test/scala/esmeta/ty/LatticeTinyTest.scala
@@ -1,0 +1,383 @@
+package esmeta.ty
+
+import esmeta.cfg.*
+import esmeta.es.*
+import esmeta.ir.{Func => IRFunc, FuncKind => IRFuncKind, *}
+import esmeta.state.*
+import esmeta.util.*
+import scala.collection.mutable.{Map => MMap, LinkedHashMap => LMMap}
+
+/** lattice test for the non-numeric type domains
+  *
+  * The numeric domains are covered by `NumericTinyTest`; this covers the rest,
+  * where the concrete witnesses are objects on a heap rather than numbers.
+  */
+class LatticeTinyTest extends TyTest {
+  val name: String = "tyLatticeTest"
+
+  // ---------------------------------------------------------------------------
+  // concrete witnesses
+  // ---------------------------------------------------------------------------
+  private val F = false
+  private val T = true
+
+  private val func = Func(
+    0,
+    IRFunc(true, IRFuncKind.AbsOp, "f", Nil, UnknownType, INop()),
+    Block(0),
+  )
+
+  // lists, including the empty one, which belongs to every element type
+  private val nilAddr = NamedAddr("nil")
+  private val mathListAddr = NamedAddr("mathList")
+  private val strListAddr = NamedAddr("strList")
+  private val mixedListAddr = NamedAddr("mixedList")
+
+  // maps, including the empty one, which belongs to every key/value type
+  private val emptyMapAddr = NamedAddr("emptyMap")
+  private val numMapAddr = NamedAddr("numMap")
+  private val strMapAddr = NamedAddr("strMap")
+
+  // records
+  private val recordAddr = NamedAddr("record")
+  private val symbolAddr = NamedAddr("symbol")
+  private val normalAddr = NamedAddr("normal")
+  private val abruptAddr = NamedAddr("abrupt")
+  private val completionAddr = NamedAddr("completion")
+
+  private val heap: Heap = Heap(
+    MMap(
+      nilAddr -> ListObj(Vector()),
+      mathListAddr -> ListObj(Vector(Math(5))),
+      strListAddr -> ListObj(Vector(Str("a"))),
+      mixedListAddr -> ListObj(Vector(Math(5), Str("a"))),
+      emptyMapAddr -> MapObj(LMMap()),
+      numMapAddr -> MapObj(LMMap(Number(42) -> Undef)),
+      strMapAddr -> MapObj(LMMap(Str("k") -> Str("v"))),
+      recordAddr -> RecordObj("", MMap("P" -> Number(42))),
+      symbolAddr -> RecordObj("Symbol", MMap("Description" -> Str("desc"))),
+      normalAddr -> RecordObj(
+        "NormalCompletion",
+        MMap(
+          "Type" -> Enum("normal"),
+          "Value" -> Undef,
+          "Target" -> Enum("empty"),
+        ),
+      ),
+      abruptAddr -> RecordObj(
+        "AbruptCompletion",
+        MMap(
+          "Type" -> Enum("throw"),
+          "Value" -> Undef,
+          "Target" -> Enum("empty"),
+        ),
+      ),
+      completionAddr -> RecordObj(
+        "CompletionRecord",
+        MMap(
+          "Type" -> Enum("normal"),
+          "Value" -> Undef,
+          "Target" -> Enum("empty"),
+        ),
+      ),
+    ),
+  )
+
+  private def listObj(a: Addr): ListObj =
+    heap(a).asInstanceOf[ListObj]
+  private def mapObj(a: Addr): MapObj =
+    heap(a).asInstanceOf[MapObj]
+
+  private def recordObj(a: Addr): RecordObj =
+    heap(a).asInstanceOf[RecordObj]
+
+  private val recordAddrs =
+    List(recordAddr, symbolAddr, normalAddr, abruptAddr, completionAddr)
+
+  private val listAddrs =
+    List(nilAddr, mathListAddr, strListAddr, mixedListAddr)
+  private val mapAddrs = List(emptyMapAddr, numMapAddr, strMapAddr)
+
+  private val astA0 = Syntactic("A", List(F, T), 0, Vector.empty)
+  private val astA1 = Syntactic("A", List(F, T), 1, Vector.empty)
+  private val astB5 = Syntactic("B", List(F, T), 5, Vector(Some(astA0), None))
+  private val asts = List(astA0, astA1, astB5).map(AstValue(_))
+
+  private val strs = List("a", "b", "c")
+  private val bools = List(true, false)
+
+  // ---------------------------------------------------------------------------
+  // type universes, including the redundant encodings of top and bottom
+  // ---------------------------------------------------------------------------
+  private val listTys: List[ListTy] = List(
+    ListTy.Top,
+    ListTy.Bot,
+    ListTy.Nil,
+    ListTy.Elem(MathT),
+    ListTy.Elem(StrT),
+    ListTy.Elem(MathT || StrT),
+    // redundant encoding
+    ListTy.Elem(AnyT),
+  )
+
+  private val mapTys: List[MapTy] = List(
+    MapTy.Top,
+    MapTy.Bot,
+    MapTy.Empty,
+    MapTy(NumberT, UndefT),
+    MapTy(StrT, StrT),
+    MapTy(NumberT || StrT, UndefT || StrT),
+    // redundant encodings
+    MapTy.Elem(AnyT, AnyT),
+    MapTy(NumberT, BotT),
+  )
+
+  private val astTys: List[AstTy] = List(
+    AstTy.Top,
+    AstTy.Bot,
+    AstTy.Simple(Set("A")),
+    AstTy.Simple(Set("B")),
+    AstTy.Simple(Set("A", "B")),
+    AstTy.Detail("A", 0),
+    AstTy.Detail("A", 1),
+    AstTy.Detail("B", 5),
+  )
+
+  private val boolTys: List[BoolTy] = List(
+    BoolTy.Top,
+    BoolTy.Bot,
+    BoolTy(true),
+    BoolTy(false),
+  )
+
+  private val strTys: List[BSet[String]] = List(
+    Inf,
+    Fin[String](),
+    Fin("a"),
+    Fin("b"),
+    Fin("a", "b"),
+  )
+
+  private val cloTys: List[CloTy] = List(
+    CloTy.Top,
+    CloTy.Bot,
+    CloSetTy(Set("f")),
+    CloSetTy(Set("g")),
+    CloSetTy(Set("f", "g")),
+  )
+
+  private val cloNames = List("f", "g", "h")
+
+  /** real declarations from the type model, including a parent and two of its
+    * children, so that subtyping through `TyModel` is exercised
+    */
+  private val recordTys: List[RecordTy] = List(
+    RecordTy.Top,
+    RecordTy.Bot,
+    RecordTy("CompletionRecord"),
+    RecordTy("NormalCompletion"),
+    RecordTy("AbruptCompletion"),
+    RecordTy("Symbol"),
+    RecordTy(""),
+    // refined by a field
+    RecordTy("CompletionRecord", Map("Type" -> EnumT("normal"))),
+    RecordTy("CompletionRecord", Map("Type" -> EnumT("throw"))),
+    RecordTy("NormalCompletion", Map("Type" -> EnumT("normal"))),
+    RecordTy("Symbol", Map("Description" -> StrT)),
+    // a union of a parent and a child
+    RecordTy("NormalCompletion") || RecordTy("AbruptCompletion"),
+    RecordTy("CompletionRecord") || RecordTy("Symbol"),
+  )
+
+  /** one witness per `ValueTy` component, to check that the component-wise
+    * composition really is exact -- it is only sound if the components are
+    * pairwise disjoint sets of concrete values
+    */
+  private val values: List[Value] = List(
+    nilAddr,
+    mathListAddr,
+    emptyMapAddr,
+    numMapAddr,
+    recordAddr,
+    symbolAddr,
+    Clo(func, Map()),
+    Cont(func, Map(), Nil),
+    AstValue(astA0),
+    AstValue(astB5),
+    GrammarSymbol("A", List(T, F)),
+    Math(5),
+    Infinity(true),
+    Number(1.5),
+    BigInt(7),
+    Str("a"),
+    Bool(true),
+    CodeUnit('x'),
+    Enum("empty"),
+    Undef,
+    Null,
+  )
+
+  private val valueTys: List[ValueTy] = List(
+    AnyT,
+    BotT,
+    NumberT,
+    MathT,
+    StrT,
+    BoolT,
+    UndefT,
+    NullT,
+    BigIntT,
+    CodeUnitT,
+    EnumT("empty"),
+    ListT,
+    NilT,
+    MapT,
+    RecordT("CompletionRecord"),
+    AstT,
+    AstT("A"),
+    CloT,
+    ContT,
+    GrammarSymbolT,
+    InfinityT,
+    // unions across components
+    NumberT || StrT,
+    ListT(MathT) || RecordT("Symbol"),
+  )
+
+  // registration
+  def init: Unit = {
+    checkLaws("list lattice laws")(
+      Domain[ListTy, Addr](
+        listTys,
+        listAddrs,
+        (t, a) => t.contains(listObj(a), heap),
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        _.normalized,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("map lattice laws")(
+      Domain[MapTy, Addr](
+        mapTys,
+        mapAddrs,
+        (t, a) => t.contains(mapObj(a), heap),
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        _.normalized,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("ast lattice laws")(
+      Domain[AstTy, AstValue](
+        astTys,
+        asts,
+        _ contains _,
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        identity,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("bool lattice laws")(
+      Domain[BoolTy, Boolean](
+        boolTys,
+        bools,
+        _ contains _,
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        identity,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("bounded set lattice laws")(
+      Domain[BSet[String], String](
+        strTys,
+        strs,
+        _ contains _,
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        identity,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("record lattice laws")(
+      Domain[RecordTy, Addr](
+        recordTys,
+        recordAddrs,
+        (t, a) => t.contains(recordObj(a), heap),
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        _.normalized,
+        _.isBottom,
+      ),
+    )
+
+    checkLaws("value lattice laws")(
+      Domain[ValueTy, Value](
+        valueTys,
+        values,
+        (t, v) => t.contains(v, heap),
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        identity,
+        _.isBottom,
+      ),
+    )
+
+    checkEqual("every component of `Any` is top")(
+      AnyT.clo.isTop -> true,
+      AnyT.cont.isTop -> true,
+      AnyT.record.isTop -> true,
+      AnyT.map.isTop -> true,
+      AnyT.list.isTop -> true,
+      AnyT.ast.isTop -> true,
+      AnyT.grammarSymbol.isTop -> true,
+      AnyT.codeUnit -> true,
+      AnyT.enumv.isTop -> true,
+      AnyT.math.isTop -> true,
+      AnyT.infinity.isTop -> true,
+      AnyT.number.isTop -> true,
+      AnyT.bigInt -> true,
+      AnyT.str.isTop -> true,
+      AnyT.bool.isTop -> true,
+      AnyT.undef -> true,
+      AnyT.nullv -> true,
+    )
+
+    checkLaws("closure lattice laws")(
+      Domain[CloTy, String](
+        cloTys,
+        cloNames,
+        _ contains _,
+        _ <= _,
+        _ -- _,
+        _ || _,
+        _ && _,
+        identity,
+        _.isBottom,
+      ),
+    )
+  }
+
+  init
+}

--- a/src/test/scala/esmeta/ty/NumericTinyTest.scala
+++ b/src/test/scala/esmeta/ty/NumericTinyTest.scala
@@ -25,6 +25,9 @@ class NumericTinyTest extends TyTest {
     2.5,
     3.0,
     3.0e9, // beyond Int range
+    9007199254740992.0, // 2^53, the last exactly represented integer
+    Double.MinPositiveValue, // a product that underflows to a zero
+    Double.MaxValue, // a sum that overflows to an infinity
     Double.PositiveInfinity,
     Double.NaN,
   ).map(Number(_))
@@ -87,6 +90,9 @@ class NumericTinyTest extends TyTest {
     numSet(Double.PositiveInfinity, 0.0, -0.0),
     // non-integral and out-of-Int-range values
     numSet(2.5),
+    // the boundary of exact integer representation, and beyond it
+    NumberTy.int(intSet(BigInt(2).pow(53))),
+    numSet(Double.MaxValue),
     numSet(1.0, 2.5),
     numSet(Double.NaN, 2.5),
     numSet(3.0e9),
@@ -143,67 +149,6 @@ class NumericTinyTest extends TyTest {
     intSet(huge),
     intSet(-huge, huge),
   )
-
-  /** a domain to check the lattice laws of */
-  private case class Domain[T, V](
-    tys: List[T],
-    values: List[V],
-    contains: (T, V) => Boolean,
-    le: (T, T) => Boolean,
-    prune: (T, T) => T,
-    join: (T, T) => T,
-    meet: (T, T) => T,
-    canon: T => T,
-    isBottom: T => Boolean,
-  )
-
-  /** Check that each abstract operation over-approximates its concrete
-    * counterpart: no value that belongs in the result may be missing from it. A
-    * violation means the analyzer may drop a reachable value, which is exactly
-    * the class of bug these operations have had.
-    */
-  private def checkLaws[T, V](desc: String)(d: Domain[T, V]): Unit =
-    import d.*
-    def has(t: T, v: V) = contains(t, v)
-    val violations = (for {
-      l <- tys
-      // canon must not change the meaning of a type
-      v <- values
-      if has(l, v) != has(canon(l), v)
-    } yield s"canon changes membership of $v in $l") ++ (for {
-      l <- tys
-      r <- tys
-      v <- values
-      (op, ty, expected) <- List(
-        ("--", prune(l, r), has(l, v) && !has(r, v)),
-        ("||", join(l, r), has(l, v) || has(r, v)),
-        ("&&", meet(l, r), has(l, v) && has(r, v)),
-      )
-      if expected && !has(ty, v)
-    } yield s"$v is missing from ($l $op $r) = $ty") ++ (for {
-      l <- tys
-      r <- tys
-      // the order must agree with containment, and bound each result
-      msg <-
-        (if (le(l, r) && values.exists(v => has(l, v) && !has(r, v)))
-           List(s"$l <= $r but they differ on a concrete value")
-         else Nil) ++
-        (if (!le(l, join(l, r))) List(s"$l is not below ($l || $r)")
-         else Nil) ++
-        (if (!le(meet(l, r), l)) List(s"($l && $r) is not below $l")
-         else Nil) ++
-        (if (!le(prune(l, r), l)) List(s"($l -- $r) is not below $l") else Nil)
-    } yield msg) ++ (for {
-      l <- tys
-      if !isBottom(prune(l, l))
-    } yield s"($l -- $l) is not bottom")
-    check(desc) {
-      if (violations.nonEmpty) {
-        println(s"[FAILED] $desc: ${violations.size} violation(s)")
-        violations.distinct.take(10).foreach(v => println(s"- $v"))
-        assert(violations.isEmpty)
-      }
-    }
 
   /** Check that each arithmetic operation over-approximates the concrete one
     * that the interpreter performs.
@@ -297,6 +242,34 @@ class NumericTinyTest extends TyTest {
         v <- con(x.decimal, y.decimal)
         if !r.contains(Math(v))
       } yield s"$x $name $y = $v is missing from ($a $name $b) = $r")
+    val numberViolations = for {
+      (name, abs, con) <- List[
+        (String, (NumberTy, NumberTy) => NumberTy, (Double, Double) => Double),
+      ](
+        ("+", _ + _, _ + _),
+        ("-", _ - _, _ - _),
+        ("*", _ * _, _ * _),
+        ("/", _ / _, _ / _),
+      )
+      a <- numberTys
+      b <- numberTys
+      r = abs(a, b)
+      x <- numbers if a.contains(x)
+      y <- numbers if b.contains(y)
+      v = Number(con(x.double, y.double))
+      if !r.contains(v)
+    } yield s"$x $name $y = $v is missing from ($a $name $b) = $r"
+
+    check("number arithmetic laws") {
+      if (numberViolations.nonEmpty) {
+        println(
+          s"[FAILED] number arithmetic laws: ${numberViolations.size} violation(s)",
+        )
+        numberViolations.distinct.take(10).foreach(v => println(s"- $v"))
+        assert(numberViolations.isEmpty)
+      }
+    }
+
     check("arithmetic laws") {
       if (violations.nonEmpty) {
         println(s"[FAILED] arithmetic laws: ${violations.size} violation(s)")

--- a/src/test/scala/esmeta/ty/TyTest.scala
+++ b/src/test/scala/esmeta/ty/TyTest.scala
@@ -36,4 +36,65 @@ trait TyTest extends ESMetaTest {
     "q" -> Binding(BoolT, false),
     "r" -> Binding(UndefT, true),
   )
+
+  /** a domain to check the lattice laws of */
+  protected case class Domain[T, V](
+    tys: List[T],
+    values: List[V],
+    contains: (T, V) => Boolean,
+    le: (T, T) => Boolean,
+    prune: (T, T) => T,
+    join: (T, T) => T,
+    meet: (T, T) => T,
+    canon: T => T,
+    isBottom: T => Boolean,
+  )
+
+  /** Check that each abstract operation over-approximates its concrete
+    * counterpart: no value that belongs in the result may be missing from it. A
+    * violation means the analyzer may drop a reachable value, which is exactly
+    * the class of bug these operations have had.
+    */
+  protected def checkLaws[T, V](desc: String)(d: Domain[T, V]): Unit =
+    import d.*
+    def has(t: T, v: V) = contains(t, v)
+    val violations = (for {
+      l <- tys
+      // canon must not change the meaning of a type
+      v <- values
+      if has(l, v) != has(canon(l), v)
+    } yield s"canon changes membership of $v in $l") ++ (for {
+      l <- tys
+      r <- tys
+      v <- values
+      (op, ty, expected) <- List(
+        ("--", prune(l, r), has(l, v) && !has(r, v)),
+        ("||", join(l, r), has(l, v) || has(r, v)),
+        ("&&", meet(l, r), has(l, v) && has(r, v)),
+      )
+      if expected && !has(ty, v)
+    } yield s"$v is missing from ($l $op $r) = $ty") ++ (for {
+      l <- tys
+      r <- tys
+      // the order must agree with containment, and bound each result
+      msg <-
+        (if (le(l, r) && values.exists(v => has(l, v) && !has(r, v)))
+           List(s"$l <= $r but they differ on a concrete value")
+         else Nil) ++
+        (if (!le(l, join(l, r))) List(s"$l is not below ($l || $r)")
+         else Nil) ++
+        (if (!le(meet(l, r), l)) List(s"($l && $r) is not below $l")
+         else Nil) ++
+        (if (!le(prune(l, r), l)) List(s"($l -- $r) is not below $l") else Nil)
+    } yield msg) ++ (for {
+      l <- tys
+      if !isBottom(prune(l, l))
+    } yield s"($l -- $l) is not bottom")
+    check(desc) {
+      if (violations.nonEmpty) {
+        println(s"[FAILED] $desc: ${violations.size} violation(s)")
+        violations.distinct.take(10).foreach(v => println(s"- $v"))
+        assert(violations.isEmpty)
+      }
+    }
 }

--- a/tests/result/analyzer/TransferSmallTest
+++ b/tests/result/analyzer/TransferSmallTest
@@ -1,0 +1,1 @@
+analyzer.TransferSmallTest: 4 / 4

--- a/tests/result/analyzer/TransferSmallTest.json
+++ b/tests/result/analyzer/TransferSmallTest.json
@@ -1,0 +1,6 @@
+{
+  "absolute" : true,
+  "bitwise negation" : true,
+  "floor" : true,
+  "negation" : true
+}

--- a/tests/result/ty/LatticeTinyTest
+++ b/tests/result/ty/LatticeTinyTest
@@ -1,0 +1,1 @@
+ty.LatticeTinyTest: 9 / 9

--- a/tests/result/ty/LatticeTinyTest.json
+++ b/tests/result/ty/LatticeTinyTest.json
@@ -1,0 +1,11 @@
+{
+  "ast lattice laws" : true,
+  "bool lattice laws" : true,
+  "bounded set lattice laws" : true,
+  "closure lattice laws" : true,
+  "every component of `Any` is top" : true,
+  "list lattice laws" : true,
+  "map lattice laws" : true,
+  "record lattice laws" : true,
+  "value lattice laws" : true
+}

--- a/tests/result/ty/NumericTinyTest
+++ b/tests/result/ty/NumericTinyTest
@@ -1,1 +1,1 @@
-ty.NumericTinyTest: 14 / 14
+ty.NumericTinyTest: 15 / 15

--- a/tests/result/ty/NumericTinyTest.json
+++ b/tests/result/ty/NumericTinyTest.json
@@ -8,6 +8,7 @@
   "math lattice laws" : true,
   "membership of large integral numbers" : true,
   "modulo" : true,
+  "number arithmetic laws" : true,
   "number lattice laws" : true,
   "prune a set by a sign" : true,
   "prune by a finite set" : true,


### PR DESCRIPTION
Follow-up to #373, which verified only the numeric lattice. Extends the same law harness to every other domain and to `NumberTy` arithmetic, and fixes the eight defects it found.

| | before | after |
| --- | --- | --- |
| `Ast[DestructuringAssignmentTarget] && Ast[ObjectLiteral]` | `Bot`, so the branch looked unreachable | `Ast[DestructuringAssignmentTarget]` |
| `Map[Number -> Undefined] && Map[String -> String]` | `Bot`, dropping the empty map | `MapTy.Empty` |
| `Any -- Number` | every list gone | lists kept |
| `Number[Int[1]] / Number[Int[0]]` | `ArithmeticException: / by zero` | `Number[Int[0], -INF, +INF]` |
| `Number[Int[1]] / Number[Int[2]]` | `Number[Int[0]]` | `Number[NonNeg]` |
| `Number[Int[MAX]] + Number[Int[1]]` | `Number[Int[MAX + 1]]`, a value no double holds | `Number[Pos, +INF]` |
| `Number[MIN] * Number[MIN]` | never a zero | a zero, from the underflow |
| `Number[+INF] * Number[Int[0]]` | no *NaN* | `Number[NaN]` |

`Ast.types` holds every name of a chain production, so one AST belongs to `Ast[A]` and `Ast[B]` at once and intersecting the name sets drops it. Two distinct `Detail`s stay disjoint; the rest falls back to the left operand, an over-approximation of the intersection that is still below it. The branch runs 184 times during `tycheck`, every one of them the destructuring check.

A map belongs to `Elem` when every entry does, which is vacuous for a map with no entries, so a bottom component means the empty map. It is now `MapTy.Empty`, mirroring `ListTy.Nil`, and the order is unchanged because `apply` normalizes.

`ValueTopTy.list` was `ListTy.Bot`, marked "unsound but need to remove cycle". That comment dates to 94baec582, when it sat on all 17 components and `ListTy.Top` was a strict `val` reading `ValueTy.Top`. `ListTy.Top` is now a bare enum case, the other 16 components have long since moved, and every entry point was checked in a fresh JVM.

Division does not preserve integrality, so `NumberTy./` no longer delegates to `IntTy./`: it works in the sign domain, and a zero divisor gives an infinity or *NaN* rather than trapping. `IntTy./` drops a zero divisor the way `%` already did, which also leaves it without a caller.

A double represents an integer exactly only up to 2^53, so the integer domain now applies only while the result stays inside it and the sign domain takes over past that. A product or a quotient of two finite values can underflow to a zero, an infinity survives a multiplication only against a nonzero factor, and the sign of a resulting infinity follows the sign of the result. The last three defects surfaced only after the witnesses grew to include 2^53, `Double.MaxValue`, and the smallest subnormal.

Analyzed nodes rise from 33,009 to 33,067 on `es2026` and from 33,734 to 33,792 on `ecma262` `main`; the AST fix accounts for all of it, and the analysis time is unchanged. Modelling the overflow adds `LocalTime` to `tycheck-ignore.json`, since `Number[Int]` reaches 1.8e308 and the time-value bound that rules the overflow out needs #354.

`LatticeTinyTest` covers list, map, AST, bool, `BSet`, closure, record, and value, and needs no CFG. `TransferSmallTest` checks `unary_-`, `unary_~`, `abs`, and `floor` against the interpreter and found nothing; it builds a `TyChecker`, so it belongs to the small tier beside `TyCheckSmallTest`. `Domain` and `checkLaws` move to `TyTest` so both files share them. The tiny tier goes from 848 ms to 1.02 s.
