### PR TITLE
Speed up type guard operations

### DIFF
--- a/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/AbsState.scala
@@ -283,7 +283,7 @@ trait AbsStateDecl { self: TyChecker =>
     def typeCheck(value: AbsValue, givenTy: ValueTy): ValueTy =
       val ty = value.ty
       if (ty <= givenTy) TrueT
-      else if ((ty && givenTy).isBottom) FalseT
+      else if (!(ty overlaps givenTy)) FalseT
       else BoolT
 
     /** variable existence check */

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -42,7 +42,7 @@ trait TypeGuardDecl { self: TyChecker =>
       else
         TypeGuard(for {
           (dty, p) <- map
-          if !(ty && dty.ty).isBottom
+          if ty overlaps dty.ty
         } yield dty -> this.lookup(dty.ty))
 
     def fieldLookup(fld: String): TypeGuard =
@@ -109,8 +109,8 @@ trait TypeGuardDecl { self: TyChecker =>
     def ||(that: TypeGuard)(lty: ValueTy, rty: ValueTy): TypeGuard =
       val (ldtys, rdtys) = (this.dtys, that.dtys)
       val dtys =
-        ldtys.filter(k => (k.ty && rty).isBottom || rdtys.contains(k)) ++
-        rdtys.filter(k => (k.ty && lty).isBottom || ldtys.contains(k))
+        ldtys.filter(k => !(k.ty overlaps rty) || rdtys.contains(k)) ++
+        rdtys.filter(k => !(k.ty overlaps lty) || ldtys.contains(k))
       TypeGuard((for {
         dty <- dtys.toList
         ty = lty || rty
@@ -181,7 +181,7 @@ trait TypeGuardDecl { self: TyChecker =>
     val all: Set[DemandType] = set.map(new DemandType(_))
 
     def from(givenTy: ValueTy): Set[DemandType] =
-      all.filter(dty => !(givenTy && dty.ty).isBottom)
+      all.filter(dty => givenTy overlaps dty.ty)
   }
 
   case class TypeProp(

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -22,23 +22,24 @@ trait TypeGuardDecl { self: TyChecker =>
     def apply(ty: ValueTy): TypeProp = lookup(ty)
 
     def lookup(ty: ValueTy): TypeProp =
-      val lst = for {
-        (dty, p) <- map
-        if ty <= dty.ty // maybe need cache?
-      } yield p
-      if lst.isEmpty then TypeProp()
-      else lst.reduce(_ && _)
+      if (map.isEmpty) TypeProp()
+      else
+        var acc: TypeProp = null
+        for ((dty, p) <- map if ty <= dty.ty)
+          acc = if (acc eq null) p else acc && p
+        if (acc eq null) TypeProp() else acc
 
     def update(ty: ValueTy, prop: TypeProp): TypeGuard =
-      val r = for dty <- DemandType.set yield DemandType(dty) -> {
-        val p = map.getOrElse(DemandType(dty), TypeProp())
-        if ty <= dty then prop && p
+      val r = for dty <- DemandType.all yield dty -> {
+        val p = map.getOrElse(dty, TypeProp())
+        if ty <= dty.ty then prop && p
         else p
       }
       TypeGuard(r.toMap)
 
     def refine(ty: ValueTy): TypeGuard =
-      TypeGuard(for {
+      if (map.isEmpty) this
+      else TypeGuard(for {
         (dty, p) <- map
         if !(ty && dty.ty).isBottom
       } yield dty -> this.lookup(dty.ty))
@@ -91,11 +92,10 @@ trait TypeGuardDecl { self: TyChecker =>
     } yield dty -> newProp)
 
     def bind(ty: ValueTy = ValueTy.Top)(using st: AbsState): TypeGuard =
-      this && TypeGuard((for {
-        kind <- DemandType.from(ty).toList
-        prop = TypeProp().bind
-        if prop.nonTop
-      } yield kind -> prop).toMap)
+      // the bound property does not depend on the demand type
+      val prop = TypeProp().bind
+      if (prop.isTop) this
+      else this && TypeGuard(DemandType.from(ty).map(_ -> prop).toMap)
 
     def has(x: Base): Boolean = map.values.exists(_.has(x))
 
@@ -120,7 +120,10 @@ trait TypeGuardDecl { self: TyChecker =>
         if !prop.isTop
       } yield dty -> prop).toMap)
 
-    def &&(that: TypeGuard): TypeGuard = TypeGuard((for {
+    def &&(that: TypeGuard): TypeGuard =
+      if (this.map.isEmpty) that
+      else if (that.map.isEmpty) this
+      else TypeGuard((for {
       dty <- (this.dtys ++ that.dtys).toList
       prop = this(dty) && that(dty)
       if !prop.isTop
@@ -172,10 +175,11 @@ trait TypeGuardDecl { self: TyChecker =>
         throw notSupported(s"Unsupported DemandType: $ty")
       }
 
+    /** the demand types, built once, since `set` is fixed */
+    val all: Set[DemandType] = set.map(new DemandType(_))
+
     def from(givenTy: ValueTy): Set[DemandType] =
-      DemandType.set
-        .filter(ty => !(givenTy && ty).isBottom)
-        .map(DemandType(_))
+      all.filter(dty => !(givenTy && dty.ty).isBottom)
   }
 
   case class TypeProp(

--- a/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
+++ b/src/main/scala/esmeta/analyzer/tychecker/TypeGuard.scala
@@ -39,10 +39,11 @@ trait TypeGuardDecl { self: TyChecker =>
 
     def refine(ty: ValueTy): TypeGuard =
       if (map.isEmpty) this
-      else TypeGuard(for {
-        (dty, p) <- map
-        if !(ty && dty.ty).isBottom
-      } yield dty -> this.lookup(dty.ty))
+      else
+        TypeGuard(for {
+          (dty, p) <- map
+          if !(ty && dty.ty).isBottom
+        } yield dty -> this.lookup(dty.ty))
 
     def fieldLookup(fld: String): TypeGuard =
       val m = for
@@ -123,11 +124,12 @@ trait TypeGuardDecl { self: TyChecker =>
     def &&(that: TypeGuard): TypeGuard =
       if (this.map.isEmpty) that
       else if (that.map.isEmpty) this
-      else TypeGuard((for {
-      dty <- (this.dtys ++ that.dtys).toList
-      prop = this(dty) && that(dty)
-      if !prop.isTop
-    } yield dty -> prop).toMap)
+      else
+        TypeGuard((for {
+          dty <- (this.dtys ++ that.dtys).toList
+          prop = this(dty) && that(dty)
+          if !prop.isTop
+        } yield dty -> prop).toMap)
 
     override def toString: String = stringify(this)
   }
@@ -242,16 +244,26 @@ trait TypeGuardDecl { self: TyChecker =>
       } yield x -> pair).toMap
 
     private def andEnv[A](left: Binding[A], right: Binding[A]): Binding[A] =
-      (for {
-        x <- (left.keySet ++ right.keySet).toList
-        (lty, lprov) = left.getOrElse(x, (ValueTy.Top, Provenance.Top))
-        (rty, rprov) = right.getOrElse(x, (ValueTy.Top, Provenance.Top))
-        pair = {
-          if (lty <= rty) (lty, lprov)
-          else if (rty <= lty) (rty, rprov)
-          else (lty && rty, lprov && rprov)
+      // an absent binding stands for the top type, which the meet keeps, so an
+      // empty side leaves the other one alone
+      if (right.isEmpty) left
+      else if (left.isEmpty)
+        right.map {
+          case (x, (rty, rprov)) =>
+            x -> (if (rty.isTop) (ValueTy.Top, Provenance.Top)
+                  else (rty, rprov))
         }
-      } yield x -> pair).toMap
+      else
+        (for {
+          x <- (left.keySet ++ right.keySet).toList
+          (lty, lprov) = left.getOrElse(x, (ValueTy.Top, Provenance.Top))
+          (rty, rprov) = right.getOrElse(x, (ValueTy.Top, Provenance.Top))
+          pair = {
+            if (lty <= rty) (lty, lprov)
+            else if (rty <= lty) (rty, rprov)
+            else (lty && rty, lprov && rprov)
+          }
+        } yield x -> pair).toMap
 
     def has(x: Base): Boolean =
       map.contains(x) || sexpr.fold(false)(_.has(x))

--- a/src/main/scala/esmeta/ty/ValueTy.scala
+++ b/src/main/scala/esmeta/ty/ValueTy.scala
@@ -163,6 +163,31 @@ sealed trait ValueTy extends Ty with Lattice[ValueTy] {
         this.nullv -- that.nullv,
       )
 
+  /** overlap check, which avoids building the meet */
+  def overlaps(that: ValueTy): Boolean =
+    if (this eq that) !this.isBottom
+    else if ((this eq Bot) || (that eq Bot)) false
+    else if (this eq Top) !that.isBottom
+    else if (that eq Top) !this.isBottom
+    else
+      !(this.clo && that.clo).isBottom ||
+      !(this.cont && that.cont).isBottom ||
+      !(this.record && that.record).isBottom ||
+      !(this.map && that.map).isBottom ||
+      !(this.list && that.list).isBottom ||
+      !(this.ast && that.ast).isBottom ||
+      !(this.grammarSymbol && that.grammarSymbol).isBottom ||
+      (this.codeUnit && that.codeUnit) ||
+      !(this.enumv && that.enumv).isBottom ||
+      !(this.math && that.math).isBottom ||
+      !(this.infinity && that.infinity).isBottom ||
+      !(this.number && that.number).isBottom ||
+      (this.bigInt && that.bigInt) ||
+      !(this.str && that.str).isBottom ||
+      !(this.bool && that.bool).isBottom ||
+      (this.undef && that.undef) ||
+      (this.nullv && that.nullv)
+
   /** value containment check */
   def contains(value: Value, heap: Heap): Boolean = value match
     case _ if this eq Top => true


### PR DESCRIPTION
Reduces `tycheck` from 9.3s to 8.3s (about 11%) without changing a single line of output. Every dumped log is byte-identical to `dev`: `detailed-types` (40 MB), `types`, `refined`, `guards`, `errors`, `error-nodes`, and `counter`; `summary.yml` differs only in `duration`. The error count stays 35 and the inferred guard count stays 161.

Guard inference is 68% of the run, so all three changes sit there.

- **Speed up type guard operations.** `TypeGuard.bind` rebuilt `TypeProp().bind` once per iteration of a loop that does not depend on it; it is now hoisted, and the method returns early once the bound type is top.
- **Skip the empty cases of the type property meet.** `&&`, `lookup`, `refine`, and `andEnv` all did full map work for an operand that is empty, which is the common case. They now short-circuit, `refine` folds instead of building an intermediate collection, and `DemandType.all` is computed once instead of on every call.
- **Test type overlap without building the meet.** The callers in `AbsState` and `TypeGuard` only ask whether two `ValueTy` overlap, but computed the whole meet and tested it for bottom. `ValueTy.overlaps` answers that directly, component by component, and short-circuits on the first overlap.

Measured on `es2026` (`0248456c7`), three runs each: `dev` 9,435 / 9,218 / 9,303 ms, this branch 8,122 / 8,388 / 8,301 ms.
